### PR TITLE
Add summary metric type

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ var summary = new Client.summary('metric_name', 'metric_help');
 summary.observe(10);
 ```
 
+Utility to observe request durations
+```
+var end = summary.startTimer();
+xhrRequest(function(err, res) {
+	end(); // Observes the value to xhrRequests duration in seconds
+});
+```
 
 #### Labels
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See example folder for a sample usage. The library does not bundle any web frame
 
 #### Configuration
 
-All metric types has 2 mandatory parameters, name and help. 
+All metric types has 2 mandatory parameters, name and help.
 
 #### Counter
 
@@ -52,12 +52,12 @@ xhrRequest(function(err, res) {
 
 Histograms track sizes and frequency of events.  
 
-**Configuration**  
+**Configuration**
 
 The defaults buckets are intended to cover usual web/rpc requests, this can however be overriden.
 ```
 var Client = require('prom-client');
-new Client.histogram('metric_name', 'metric_help', { 
+new Client.histogram('metric_name', 'metric_help', {
 	buckets: [ 0.10, 5, 15, 50, 100, 500 ]
 });
 ```
@@ -78,7 +78,31 @@ xhrRequest(function(err, res) {
 });
 ```
 
-#### Labels 
+#### Summary
+
+Summaries calculate percentiles of observed values.
+
+**Configuration**
+
+The default percentiles are: 0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999. But they can be overriden like this:
+
+```
+var Client = require('prom-client');
+new Client.summary('metric_name', 'metric_help', {
+	percentiles: [ 0.01, 0.1, 0.9, 0.99 ]
+});
+```
+
+Usage example
+
+```
+var Client = require('prom-client');
+var summary = new Client.summary('metric_name', 'metric_help');
+summary.observe(10);
+```
+
+
+#### Labels
 
 All metrics take an array as 3rd parameter that should include all supported label keys. There are 2 ways to add values to the labels
 ```

--- a/index.js
+++ b/index.js
@@ -9,3 +9,4 @@ exports.counter = require('./lib/counter');
 exports.gauge = require('./lib/gauge');
 exports.register = require('./lib/register');
 exports.histogram = require('./lib/histogram');
+exports.summary = require('./lib/summary');

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -1,5 +1,5 @@
 /**
- * Histogram
+ * Summary
  */
 'use strict';
 
@@ -47,9 +47,9 @@ function Summary(name, help, labelsOrConf, conf) {
 }
 
 /**
- * Observe a value in histogram
+ * Observe a value
  * @param {object} labels - Object with labels where key is the label key and value is label value. Can only be one level deep
- * @param {float} value - Value to observe in the histogram
+ * @param {float} value - Value to observe
  * @returns {void}
  */
 Summary.prototype.observe = function(labels, value) {
@@ -109,7 +109,7 @@ function getSumForExport(value, summary) {
  * @param {object} labels - Object with labels where key is the label key and value is label value. Can only be one level deep
  * @returns {function} - Function to invoke when you want to stop the timer and observe the duration in seconds
  * @example
- * var end = histogram.startTimer();
+ * var end = summary.startTimer();
  * makeExpensiveXHRRequest(function(err, res) {
  *	end(); //Observe the duration of expensiveXHRRequest
  * });

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -1,0 +1,231 @@
+/**
+ * Histogram
+ */
+'use strict';
+
+var register = require('./register');
+var type = 'summary';
+var isNumber = require('./util').isNumber;
+var extend = require('util-extend');
+var getProperties = require('./util').getPropertiesFromObj;
+var getLabels = require('./util').getLabels;
+var createValue = require('./util');
+var validateLabels = require('./validation').validateLabel;
+var validateMetricName = require('./validation').validateMetricName;
+var validateLabelNames = require('./validation').validateLabelName;
+var objectHash = require('object-hash');
+var TDigest = require('tdigest').TDigest;
+
+/**
+ * Summary
+ * @param {string} name - Name of the metric
+ * @param {string} help - Help for the metric
+ * @param {object|array} labelsOrConf - Either array of label names or config object as a key-value object
+ * @param {object} conf - Configuration object
+ * @constructor
+ */
+function Summary(name, help, labelsOrConf, conf) {
+	var obj;
+	var labels = [];
+
+	if(Array.isArray(labelsOrConf)) {
+		obj = conf || {};
+		labels = labelsOrConf;
+	} else {
+		obj = labelsOrConf || {};
+	}
+
+	validateInput(name, help, labels);
+
+	this.name = name;
+	this.help = help;
+
+	this.percentiles = configurePercentiles(obj.percentiles);
+	this.hashMap = {};
+	this.labelNames = labels || [];
+	register.registerMetric(this);
+}
+
+/**
+ * Observe a value in histogram
+ * @param {object} labels - Object with labels where key is the label key and value is label value. Can only be one level deep
+ * @param {float} value - Value to observe in the histogram
+ * @returns {void}
+ */
+Summary.prototype.observe = function(labels, value) {
+	observe.call(this, labels || {})(value);
+};
+
+Summary.prototype.get = function() {
+	var summary = this;
+	var data = getProperties(summary.hashMap);
+	var values = [];
+	data.forEach(function(s) {
+		extractSummariesForExport(s, summary.percentiles).forEach(function(v) {
+				values.push(v);
+		});
+		values.push(getSumForExport(s, summary));
+		values.push(getCountForExport(s, summary));
+	});
+
+	return {
+		name: this.name,
+		help: this.help,
+		type: type,
+		values: values
+	};
+};
+
+function extractSummariesForExport(summaryOfLabels, percentiles) {
+	summaryOfLabels.td.compress();
+
+	return percentiles.map(function (percentile) {
+		return {
+			labels: extend({ quantile: percentile}, summaryOfLabels.labels),
+			value: summaryOfLabels.td.percentile(percentile)
+		};
+	});
+}
+
+function getCountForExport(value, summary) {
+	return {
+		metricName: summary.name + '_count',
+		labels: value.labels,
+		value: value.count
+	};
+}
+
+function getSumForExport(value, summary) {
+	return {
+		metricName: summary.name + '_sum',
+		labels: value.labels,
+		value: value.sum
+	};
+}
+
+
+/**
+ * Start a timer that could be used to logging durations
+ * @param {object} labels - Object with labels where key is the label key and value is label value. Can only be one level deep
+ * @returns {function} - Function to invoke when you want to stop the timer and observe the duration in seconds
+ * @example
+ * var end = histogram.startTimer();
+ * makeExpensiveXHRRequest(function(err, res) {
+ *	end(); //Observe the duration of expensiveXHRRequest
+ * });
+ */
+Summary.prototype.startTimer = function(labels) {
+	return startTimer.call(this, labels)();
+};
+
+Summary.prototype.labels = function() {
+	var labels = getLabels(this.labelNames, arguments);
+	return {
+		observe: observe.call(this, labels),
+		startTimer: startTimer.call(this, labels)
+	};
+};
+
+function startTimer(labels) {
+	var summary = this;
+	return function() {
+		var start = new Date();
+		return function() {
+			var end = new Date();
+			summary.observe(labels, (end - start) / 1000);
+		};
+	};
+}
+function validateInput(name, help, labels) {
+	if(!help) {
+		throw new Error('Missing mandatory help parameter');
+	}
+	if(!name) {
+		throw new Error('Missing mandatory name parameter');
+	}
+
+	if(!validateMetricName(name)) {
+		throw new Error('Invalid metric name');
+	}
+
+	if(!validateLabelNames(labels)) {
+		throw new Error('Invalid label name');
+	}
+
+	labels.forEach(function(label) {
+		if(label === 'quantile') {
+			throw new Error('quantile is a reserved label keyword');
+		}
+	});
+}
+
+function configurePercentiles(configuredPercentiles) {
+	var defaultPercentiles = [ 0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999 ];
+	return (configuredPercentiles || defaultPercentiles).sort(sortAscending);
+}
+
+function sortAscending(x, y) {
+	return x - y;
+}
+
+function createValuePair(labels, value, metricName) {
+	return {
+		labels: labels,
+		value: value,
+		metricName: metricName
+	};
+}
+
+function findBound(upperBounds, value) {
+	for(var i = 0; i < upperBounds.length; i++) {
+		var bound = upperBounds[i];
+		if(value <= bound) {
+			return bound;
+		}
+
+	}
+	return -1;
+}
+
+function observe(labels) {
+	var summary = this;
+	return function(value) {
+		var labelValuePair = convertLabelsAndValues(labels, value);
+
+		validateLabels(summary.labelNames, summary.labels);
+		if(!isNumber(labelValuePair.value)) {
+			throw new Error('Value is not a valid number', labelValuePair.value);
+		}
+
+		var hash = objectHash(labelValuePair.labels);
+		var summaryOfLabel = summary.hashMap[hash];
+		if(!summaryOfLabel) {
+			summaryOfLabel = {
+				labels: labelValuePair.labels,
+				td: new TDigest(),
+				count: 0,
+				sum: 0
+			};
+		}
+
+		summaryOfLabel.td.push(labelValuePair.value);
+		summaryOfLabel.count++;
+		summaryOfLabel.sum += labelValuePair.value;
+		summary.hashMap[hash] = summaryOfLabel;
+	};
+}
+
+function convertLabelsAndValues(labels, value) {
+	if(isNumber(labels)) {
+		return {
+			value: labels,
+			labels: {}
+		};
+	}
+	return {
+		labels: labels,
+		value: value
+	};
+}
+
+module.exports = Summary;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "object-hash": "^0.9.2",
-    "util-extend": "^1.0.1",
-    "tdigest": "^0.1.1"
+    "tdigest": "^0.1.1",
+    "util-extend": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prom-client",
-  "version": "3.0.4",
+  "version": "3.1.0",
   "description": "Client for prometheus",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "object-hash": "^0.9.2",
-    "util-extend": "^1.0.1"
+    "util-extend": "^1.0.1",
+    "tdigest": "^0.1.1"
   }
 }

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -1,0 +1,131 @@
+'use strict';
+
+describe('summary', function() {
+	var Summary = require('../index').summary;
+	var expect = require('chai').expect;
+	var instance;
+
+	beforeEach(function() {
+		instance = new Summary('summary_test', 'test');
+	});
+
+	it('should add a value to the summary', function() {
+		instance.observe(100);
+		expect(instance.get().values[0].labels.quantile).to.equal(0.01);
+		expect(instance.get().values[0].value).to.equal(100);
+		expect(instance.get().values[7].metricName).to.equal('summary_test_sum');
+		expect(instance.get().values[7].value).to.equal(100);
+		expect(instance.get().values[8].metricName).to.equal('summary_test_count');
+		expect(instance.get().values[8].value).to.equal(1);
+	});
+
+	it('should correctly calculate percentiles when more values are added to the summary', function() {
+		instance.observe(100);
+		instance.observe(100);
+		instance.observe(100);
+		instance.observe(50);
+		instance.observe(50);
+
+		expect(instance.get().values.length).to.equal(9);
+
+		expect(instance.get().values[0].labels.quantile).to.equal(0.01);
+		expect(instance.get().values[0].value).to.equal(50);
+
+		expect(instance.get().values[1].labels.quantile).to.equal(0.05);
+		expect(instance.get().values[1].value).to.equal(50);
+
+		expect(instance.get().values[2].labels.quantile).to.equal(0.5);
+		expect(instance.get().values[2].value).to.equal(80);
+
+		expect(instance.get().values[3].labels.quantile).to.equal(0.9);
+		expect(instance.get().values[3].value).to.equal(100);
+
+		expect(instance.get().values[4].labels.quantile).to.equal(0.95);
+		expect(instance.get().values[4].value).to.equal(100);
+
+		expect(instance.get().values[5].labels.quantile).to.equal(0.99);
+		expect(instance.get().values[5].value).to.equal(100);
+
+		expect(instance.get().values[6].labels.quantile).to.equal(0.999);
+		expect(instance.get().values[6].value).to.equal(100);
+
+		expect(instance.get().values[7].metricName).to.equal('summary_test_sum');
+		expect(instance.get().values[7].value).to.equal(400);
+
+		expect(instance.get().values[8].metricName).to.equal('summary_test_count');
+		expect(instance.get().values[8].value).to.equal(5);
+	});
+
+	it('should correctly use calculate other percentiles when configured', function() {
+		instance = new Summary('summary_test', 'test', { percentiles: [ 0.5, 0.9 ] });
+		instance.observe(100);
+		instance.observe(100);
+		instance.observe(100);
+		instance.observe(50);
+		instance.observe(50);
+
+		expect(instance.get().values.length).to.equal(4);
+
+		expect(instance.get().values[0].labels.quantile).to.equal(0.5);
+		expect(instance.get().values[0].value).to.equal(80);
+
+		expect(instance.get().values[1].labels.quantile).to.equal(0.9);
+		expect(instance.get().values[1].value).to.equal(100);
+
+		expect(instance.get().values[2].metricName).to.equal('summary_test_sum');
+		expect(instance.get().values[2].value).to.equal(400);
+
+		expect(instance.get().values[3].metricName).to.equal('summary_test_count');
+		expect(instance.get().values[3].value).to.equal(5);
+	});
+
+	describe('labels', function() {
+		beforeEach(function() {
+			instance = new Summary('summary_test', 'help', [ 'method', 'endpoint'], { percentiles: [ 0.9 ] });
+		});
+
+		it('should record and calculate the correct values per label', function() {
+			instance.labels('GET', '/test').observe(50);
+			instance.labels('POST', '/test').observe(100);
+
+			var values = instance.get().values;
+			expect(values).to.have.length(6);
+			expect(values[0].labels.method).to.equal('GET');
+			expect(values[0].labels.endpoint).to.equal('/test');
+			expect(values[0].labels.quantile).to.equal(0.9);
+			expect(values[0].value).to.equal(50);
+
+			expect(values[1].metricName).to.equal('summary_test_sum');
+			expect(values[1].labels.method).to.equal('GET');
+			expect(values[1].labels.endpoint).to.equal('/test');
+			expect(values[1].value).to.equal(50);
+
+			expect(values[2].metricName).to.equal('summary_test_count');
+			expect(values[2].labels.method).to.equal('GET');
+			expect(values[2].labels.endpoint).to.equal('/test');
+			expect(values[2].value).to.equal(1);
+
+			expect(values[3].labels.quantile).to.equal(0.9);
+			expect(values[3].labels.method).to.equal('POST');
+			expect(values[3].labels.endpoint).to.equal('/test');
+			expect(values[3].value).to.equal(100);
+
+			expect(values[4].metricName).to.equal('summary_test_sum');
+			expect(values[4].labels.method).to.equal('POST');
+			expect(values[4].labels.endpoint).to.equal('/test');
+			expect(values[4].value).to.equal(100);
+
+			expect(values[5].metricName).to.equal('summary_test_count');
+			expect(values[5].labels.method).to.equal('POST');
+			expect(values[5].labels.endpoint).to.equal('/test');
+			expect(values[5].value).to.equal(1);
+		});
+
+		it('should throw error if label lengths does not match', function() {
+			var fn = function() {
+				instance.labels('GET').observe();
+			};
+			expect(fn).to.throw(Error);
+		});
+	});
+});


### PR DESCRIPTION
I've added a summary metric type to report to Prometheus. Added a dependency to TDigest to calculate the percentiles. Also reports count and sum of each label.

Also includes tests for the summary metric type.