### PR TITLE
Allow resetting histogram and summary metrics

### DIFF
--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -79,6 +79,10 @@ Histogram.prototype.get = function() {
 	};
 };
 
+Histogram.prototype.reset = function() {
+	reset.call(this);
+};
+
 /**
  * Start a timer that could be used to logging durations
  * @param {object} labels - Object with labels where key is the label key and value is label value. Can only be one level deep
@@ -240,6 +244,12 @@ function createBucketValues(bucket, histogram) {
 		var valuePair = createValuePair(lbls, acc, histogram.name + '_bucket');
 		return valuePair;
 	};
+}
+
+function reset() {
+	this.sum = 0;
+	this.count = 0;
+	this.hashMap = {};
 }
 
 module.exports = Histogram;

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -80,7 +80,9 @@ Histogram.prototype.get = function() {
 };
 
 Histogram.prototype.reset = function() {
-	reset.call(this);
+	this.sum = 0;
+	this.count = 0;
+	this.hashMap = {};
 };
 
 /**
@@ -244,12 +246,6 @@ function createBucketValues(bucket, histogram) {
 		var valuePair = createValuePair(lbls, acc, histogram.name + '_bucket');
 		return valuePair;
 	};
-}
-
-function reset() {
-	this.sum = 0;
-	this.count = 0;
-	this.hashMap = {};
 }
 
 module.exports = Histogram;

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -76,6 +76,15 @@ Summary.prototype.get = function() {
 	};
 };
 
+Summary.prototype.reset = function() {
+	var data = getProperties(this.hashMap);
+	data.forEach(function(s) {
+		s.td.reset();
+		s.count = 0;
+		s.sum = 0;
+	});
+};
+
 function extractSummariesForExport(summaryOfLabels, percentiles) {
 	summaryOfLabels.td.compress();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prom-client",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Client for prometheus",
   "main": "index.js",
   "directories": {

--- a/test/histogramTest.js
+++ b/test/histogramTest.js
@@ -99,6 +99,15 @@ describe('histogram', function() {
 		expect(count.value).to.equal(1);
 	});
 
+	it('should allow to be reset itself', function() {
+		instance.observe(0.5);
+		var valuePair = getValueByName('test_histogram_count', instance.get().values);
+		expect(valuePair.value).to.equal(1);
+		instance.reset();
+		var valuePair = getValueByName('test_histogram_count', instance.get().values);
+		expect(valuePair.value).to.equal(undefined);
+	});
+
 	describe('labels', function() {
 		beforeEach(function() {
 			instance = new Histogram('histogram_labels', 'Histogram with labels fn', [ 'method' ]);
@@ -129,7 +138,7 @@ describe('histogram', function() {
 	});
 
 	function getValueByName(name, values) {
-		return values.reduce(function(acc, val) {
+		return values.length > 0 && values.reduce(function(acc, val) {
 			if(val.metricName === name) {
 				acc = val;
 			}

--- a/test/pushgatewayTest.js
+++ b/test/pushgatewayTest.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe.only('pushgateway', function() {
+describe('pushgateway', function() {
 	var Pushgateway = require('../index').Pushgateway;
 	var nock = require('nock');
 	var expect = require('chai').expect;
@@ -86,5 +86,3 @@ describe.only('pushgateway', function() {
 			connection: 'close' });
 	}
 });
-
-

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -79,6 +79,30 @@ describe('summary', function() {
 		expect(instance.get().values[3].value).to.equal(5);
 	});
 
+	it('should allow to reset itself', function() {
+		instance = new Summary('summary_test', 'test', { percentiles: [ 0.5 ] });
+		instance.observe(100);
+		expect(instance.get().values[0].labels.quantile).to.equal(0.5);
+		expect(instance.get().values[0].value).to.equal(100);
+
+		expect(instance.get().values[1].metricName).to.equal('summary_test_sum');
+		expect(instance.get().values[1].value).to.equal(100);
+
+		expect(instance.get().values[2].metricName).to.equal('summary_test_count');
+		expect(instance.get().values[2].value).to.equal(1);
+
+		instance.reset();
+
+		expect(instance.get().values[0].labels.quantile).to.equal(0.5);
+		expect(instance.get().values[0].value).to.equal(undefined);
+
+		expect(instance.get().values[1].metricName).to.equal('summary_test_sum');
+		expect(instance.get().values[1].value).to.equal(0);
+
+		expect(instance.get().values[2].metricName).to.equal('summary_test_count');
+		expect(instance.get().values[2].value).to.equal(0);
+	});
+
 	describe('labels', function() {
 		beforeEach(function() {
 			instance = new Summary('summary_test', 'help', [ 'method', 'endpoint'], { percentiles: [ 0.9 ] });


### PR DESCRIPTION
Added function to reset the values on a histogram and summary metric. Also enabled all tests again, because only the push-gateway tests were executed.