### PR TITLE
Summary percentile values should be 0 instead of undefined after reset

### DIFF
--- a/lib/summary.js
+++ b/lib/summary.js
@@ -89,9 +89,10 @@ function extractSummariesForExport(summaryOfLabels, percentiles) {
 	summaryOfLabels.td.compress();
 
 	return percentiles.map(function (percentile) {
+		var percentileValue = summaryOfLabels.td.percentile(percentile);
 		return {
-			labels: extend({ quantile: percentile}, summaryOfLabels.labels),
-			value: summaryOfLabels.td.percentile(percentile)
+			labels: extend({ quantile: percentile }, summaryOfLabels.labels),
+			value: percentileValue ? percentileValue : 0
 		};
 	});
 }

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -94,7 +94,7 @@ describe('summary', function() {
 		instance.reset();
 
 		expect(instance.get().values[0].labels.quantile).to.equal(0.5);
-		expect(instance.get().values[0].value).to.equal(undefined);
+		expect(instance.get().values[0].value).to.equal(0);
 
 		expect(instance.get().values[1].metricName).to.equal('summary_test_sum');
 		expect(instance.get().values[1].value).to.equal(0);


### PR DESCRIPTION
Small bug-fix to prevent Prometheus scrapers to fail when a summary value is reset and it's percentiles have no value anymore.