### PR TITLE
Add post-timer labels (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,18 @@ gauge.set({ method: 'GET', statusCode: '200' }, 100); // 1st version, Set value 
 gauge.labels('GET', '200').set(100); // 2nd version, Same as above
 ```
 
+It is also possible to use timers with labels, both before and after the timer is created:
+```js
+var end = startTimer({ method: 'GET' }); // Set method to GET, we don't know statusCode yet
+xhrRequest(function(err, res) {
+	if (err) {
+		end({ statusCode: '500' }); // Sets value to xhrRequest duration in seconds with statusCode 500
+	} else {
+		end({ statusCode: '200' }); // Sets value to xhrRequest duration in seconds with statusCode 200
+	}
+});
+```
+
 #### Pushgateway
 
 It is possible to push metrics via a [Pushgateway](https://github.com/prometheus/pushgateway). 

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -133,13 +133,13 @@ function setToCurrentTime(labels) {
 	};
 }
 
-function startTimer(labels) {
+function startTimer(startLabels) {
 	var gauge = this;
 	return function() {
 		var start = new Date();
-		return function() {
+		return function(endLabels) {
 			var end = new Date();
-			gauge.set(labels, (end - start) / 1000);
+			gauge.set(extend(startLabels || {}, endLabels), (end - start) / 1000);
 		};
 	};
 }

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -7,6 +7,7 @@ var register = require('./register');
 var type = 'gauge';
 
 var isNumber = require('./util').isNumber;
+var extend = require('util-extend');
 var createValue = require('./util').setValue;
 var getProperties = require('./util').getPropertiesFromObj;
 var getLabels = require('./util').getLabels;

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -107,13 +107,13 @@ Histogram.prototype.labels = function() {
 	};
 };
 
-function startTimer(labels) {
+function startTimer(startLabels) {
 	var histogram = this;
 	return function() {
 		var start = new Date();
-		return function() {
+		return function(endLabels) {
 			var end = new Date();
-			histogram.observe(labels, (end - start) / 1000);
+			histogram.observe(extend(startLabels || {}, endLabels), (end - start) / 1000);
 		};
 	};
 }

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -136,16 +136,17 @@ Summary.prototype.labels = function() {
 	};
 };
 
-function startTimer(labels) {
+function startTimer(startLabels) {
 	var summary = this;
 	return function() {
 		var start = new Date();
-		return function() {
+		return function(endLabels) {
 			var end = new Date();
-			summary.observe(labels, (end - start) / 1000);
+			summary.observe(extend(startLabels || {}, endLabels), (end - start) / 1000);
 		};
 	};
 }
+
 function validateInput(name, help, labels) {
 	if(!help) {
 		throw new Error('Missing mandatory help parameter');

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -103,7 +103,7 @@ describe('gauge', function() {
 			end({ 'success': 'SUCCESS' });
 			expectValue(1);
 			clock.restore();
-		})
+		});
 	});
 
 	function expectValue(val) {

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -87,6 +87,23 @@ describe('gauge', function() {
 			expectValue(1);
 			clock.restore();
 		});
+		it('should be able to start a timer and set labels afterwards', function(){
+			var clock = sinon.useFakeTimers();
+			var end = instance.startTimer();
+			clock.tick(1000);
+			end({ 'code': 200 });
+			expectValue(1);
+			clock.restore();
+		});
+		it('should allow labels before and after timers', function(){
+			instance = new Gauge('name', 'help', ['code', 'success']);
+			var clock = sinon.useFakeTimers();
+			var end = instance.startTimer({ 'code': 200 });
+			clock.tick(1000);
+			end({ 'success': 'SUCCESS' });
+			expectValue(1);
+			clock.restore();
+		})
 	});
 
 	function expectValue(val) {

--- a/test/histogramTest.js
+++ b/test/histogramTest.js
@@ -162,7 +162,7 @@ describe('histogram', function() {
 			expect(res1.value).to.equal(1);
 			expect(res2.value).to.equal(1);
 			clock.restore();
-		})
+		});
 	});
 
 	function getValueByName(name, values) {

--- a/test/histogramTest.js
+++ b/test/histogramTest.js
@@ -140,6 +140,29 @@ describe('histogram', function() {
 			expect(res.value).to.equal(1);
 			clock.restore();
 		});
+
+		it('should start a timer and set labels afterwards', function(){
+			var clock = sinon.useFakeTimers();
+			var end = instance.startTimer();
+			clock.tick(500);
+			end({ 'method': 'get' });
+			var res = getValueByLeAndLabel(0.5, 'method', 'get', instance.get().values);
+			expect(res.value).to.equal(1);
+			clock.restore();
+		});
+
+		it('should allow labels before and after timers', function(){
+			instance = new Histogram('histogram_labels', 'Histogram with labels fn', [ 'method', 'success' ]);
+			var clock = sinon.useFakeTimers();
+			var end = instance.startTimer({ 'method': 'get' });
+			clock.tick(500);
+			end({ 'success': 'SUCCESS' });
+			var res1 = getValueByLeAndLabel(0.5, 'method', 'get', instance.get().values);
+			var res2 = getValueByLeAndLabel(0.5, 'success', 'SUCCESS', instance.get().values);
+			expect(res1.value).to.equal(1);
+			expect(res2.value).to.equal(1);
+			clock.restore();
+		})
 	});
 
 	function getValueByName(name, values) {

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -3,6 +3,7 @@
 describe('summary', function() {
 	var Summary = require('../index').summary;
 	var expect = require('chai').expect;
+	var sinon = require('sinon');
 	var instance;
 
 	beforeEach(function() {
@@ -156,5 +157,80 @@ describe('summary', function() {
 			};
 			expect(fn).to.throw(Error);
 		});
+
+		it('should start a timer', function() {
+			var clock = sinon.useFakeTimers();
+			var end = instance.labels('GET', '/test').startTimer();
+			clock.tick(1000);
+			end();
+			var values = instance.get().values;
+			expect(values).to.have.length(3);
+			expect(values[0].labels.method).to.equal('GET');
+			expect(values[0].labels.endpoint).to.equal('/test');
+			expect(values[0].labels.quantile).to.equal(0.9);
+			expect(values[0].value).to.equal(1);
+
+			expect(values[1].metricName).to.equal('summary_test_sum');
+			expect(values[1].labels.method).to.equal('GET');
+			expect(values[1].labels.endpoint).to.equal('/test');
+			expect(values[1].value).to.equal(1);
+
+			expect(values[2].metricName).to.equal('summary_test_count');
+			expect(values[2].labels.method).to.equal('GET');
+			expect(values[2].labels.endpoint).to.equal('/test');
+			expect(values[2].value).to.equal(1);
+
+			clock.restore();
+		});
+
+		it('should start a timer and set labels afterwards', function(){
+			var clock = sinon.useFakeTimers();
+			var end = instance.startTimer();
+			clock.tick(1000);
+			end({ 'method': 'GET', 'endpoint': '/test' });
+			var values = instance.get().values;
+			expect(values).to.have.length(3);
+			expect(values[0].labels.method).to.equal('GET');
+			expect(values[0].labels.endpoint).to.equal('/test');
+			expect(values[0].labels.quantile).to.equal(0.9);
+			expect(values[0].value).to.equal(1);
+
+			expect(values[1].metricName).to.equal('summary_test_sum');
+			expect(values[1].labels.method).to.equal('GET');
+			expect(values[1].labels.endpoint).to.equal('/test');
+			expect(values[1].value).to.equal(1);
+
+			expect(values[2].metricName).to.equal('summary_test_count');
+			expect(values[2].labels.method).to.equal('GET');
+			expect(values[2].labels.endpoint).to.equal('/test');
+			expect(values[2].value).to.equal(1);
+
+			clock.restore();
+		});
+
+		it('should allow labels before and after timers', function(){
+			var clock = sinon.useFakeTimers();
+			var end = instance.startTimer({ 'method': 'GET' });
+			clock.tick(1000);
+			end({ 'endpoint': '/test' });
+			var values = instance.get().values;
+			expect(values).to.have.length(3);
+			expect(values[0].labels.method).to.equal('GET');
+			expect(values[0].labels.endpoint).to.equal('/test');
+			expect(values[0].labels.quantile).to.equal(0.9);
+			expect(values[0].value).to.equal(1);
+
+			expect(values[1].metricName).to.equal('summary_test_sum');
+			expect(values[1].labels.method).to.equal('GET');
+			expect(values[1].labels.endpoint).to.equal('/test');
+			expect(values[1].value).to.equal(1);
+
+			expect(values[2].metricName).to.equal('summary_test_count');
+			expect(values[2].labels.method).to.equal('GET');
+			expect(values[2].labels.endpoint).to.equal('/test');
+			expect(values[2].value).to.equal(1);
+
+			clock.restore();
+		})
 	});
 });

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -231,6 +231,6 @@ describe('summary', function() {
 			expect(values[2].value).to.equal(1);
 
 			clock.restore();
-		})
+		});
 	});
 });


### PR DESCRIPTION
One common use case I've run into while using Prometheus at Tinder is having a label for success/failure on a single metric, like the following:

```javascript
var promClient = require('prom-client');
var metric = promClient.metric('metric_name', 'metric_help', ['success_response']);

var timer = metric.startTimer();
someFunction((err, result) => {
  if (err) {
    timer({ success_response: 'ERROR' });
    console.log('uh-oh');
    // do error logic
  } else {
    timer({ success_response: 'SUCCESS' });
    console.log('yay!');
    // do success logic
  }
})
```

With the original code, it seemed like there wasn't a very clean way to handle this; the only way we had solved the problem before was by creating two timers (eg, a `successTimer` and an `errorTimer`) and only ever calling one of the timers later, but that seems both prone to error and not very memory-safe.

In addition, we might also want to do something with more than just 2 options, such as tracking average response times for every HTTP code we have in an application.  In this case, the multiple-timer approach is also not very scalable, since we'd have to add an additional timer for each new code we wanted to send.

This was the approach I came up with; let me know if there's a better way of handling these kinds of use cases.