### PR TITLE
Don't register two metrics with the same name

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -1,11 +1,10 @@
 'use strict';
 
-// var metrics = [];
-var metrics = {}
+var metrics = {};
 
 var getMetrics = function getMetrics() {
-	return metrics.reduce(function(acc, metric) {
-		var item = metric.get();
+	return Object.keys(metrics).reduce(function(acc, metricKey) {
+		var item = metrics[metricKey].get();
 		var name = escapeString(item.name);
 		var help = escapeString(item.help);
 		var help = ['#', 'HELP', name, help].join(' ');
@@ -42,20 +41,15 @@ function escapeLabelValue(str) {
 }
 
 var registerMetric = function registerMetric(metricFn) {
-	// metrics.push(metricFn);
-  metrics[metricFn.name] = metricFn
+  var name = metricFn.get().name;
+  metrics[name] = metricFn;
 };
 
 var clearMetrics = function clearMetrics() {
-	// metrics = [];
-  metrics = {}
+  metrics = {};
 };
 
 var getMetricsAsJSON = function getMetricsAsJSON() {
-  // return metrics.map(function(metric) {
-  //   return metric.get();
-  // });
-
   return Object.keys(metrics).map(function(metricName) {
     return metrics[metricName].get();
   });

--- a/lib/register.js
+++ b/lib/register.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var metrics = [];
+// var metrics = [];
+var metrics = {}
 
 var getMetrics = function getMetrics() {
 	return metrics.reduce(function(acc, metric) {
@@ -41,16 +42,22 @@ function escapeLabelValue(str) {
 }
 
 var registerMetric = function registerMetric(metricFn) {
-	metrics.push(metricFn);
+	// metrics.push(metricFn);
+  metrics[metricFn.name] = metricFn
 };
 
 var clearMetrics = function clearMetrics() {
-	metrics = [];
+	// metrics = [];
+  metrics = {}
 };
 
 var getMetricsAsJSON = function getMetricsAsJSON() {
-  return metrics.map(function(metric) {
-    return metric.get();
+  // return metrics.map(function(metric) {
+  //   return metric.get();
+  // });
+
+  return Object.keys(metrics).map(function(metricName) {
+    return metrics[metricName].get();
   });
 };
 

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -26,13 +26,23 @@ describe('register', function() {
 		});
 	});
 
-	it('should handle more than one metric', function() {
-		register.registerMetric(getMetric());
-		register.registerMetric(getMetric());
+  describe('should handle more than one metric', function() {
+    it('should handle more than one metric with different names', function() {
+      register.registerMetric(getMetric('one'));
+      register.registerMetric(getMetric('two'));
 
-		var actual = register.metrics().split('\n');
-		expect(actual).to.have.length(7);
-	});
+      var actual = register.metrics().split('\n');
+      expect(actual).to.have.length(7);
+    });
+
+    it('should not register a metric with the same name twice', function() {
+      register.registerMetric(getMetric('one'));
+      register.registerMetric(getMetric('one'));
+
+      var actual = register.metrics().split('\n');
+      expect(actual).to.have.length(4);
+    });
+  });
 
 	it('should handle a metric without labels', function() {
 		register.registerMetric({
@@ -126,11 +136,11 @@ describe('register', function() {
 
 	});
 
-	function getMetric() {
+	function getMetric(appendName) {
 		return {
 			get: function() {
 				return {
-					name: 'test_metric',
+					name: 'test_metric' + (appendName || ''),
 					type: 'counter',
 					help: 'A test metric',
 					values: [ {

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -116,18 +116,30 @@ describe('register', function() {
 			expect(output[0].values.length).to.equal(1);
 		});
 
+    it('with one metric added twice', function() {
+      register.registerMetric(getMetric());
+      register.registerMetric(getMetric());
+      var output = register.getMetricsAsJSON();
+
+      expect(output.length).to.equal(1);
+      expect(output[0].name).to.equal('test_metric');
+      expect(output[0].type).to.equal('counter');
+      expect(output[0].help).to.equal('A test metric');
+      expect(output[0].values.length).to.equal(1);
+    });
+
 		it('with multiple metrics', function() {
-			register.registerMetric(getMetric());
-			register.registerMetric(getMetric());
-			register.registerMetric(getMetric());
+			register.registerMetric(getMetric('one'));
+			register.registerMetric(getMetric('two'));
+			register.registerMetric(getMetric('three'));
 
 			var output = register.getMetricsAsJSON();
 
 			expect(output.length).to.equal(3);
 
-			expect(output[0].name).to.equal('test_metric');
-			expect(output[1].name).to.equal('test_metric');
-			expect(output[2].name).to.equal('test_metric');
+			expect(output[0].name).to.equal('test_metric_one');
+			expect(output[1].name).to.equal('test_metric_two');
+			expect(output[2].name).to.equal('test_metric_three');
 
 			expect(output[0].values.length).to.equal(1);
 			expect(output[1].values.length).to.equal(1);
@@ -140,7 +152,7 @@ describe('register', function() {
 		return {
 			get: function() {
 				return {
-					name: 'test_metric' + (appendName || ''),
+					name: 'test_metric' + (appendName ? '_' + appendName : ''),
 					type: 'counter',
 					help: 'A test metric',
 					values: [ {


### PR DESCRIPTION
Hi! I found myself using this library in perhaps a strange way, but I believe this solves the issue. Essentially, prom-client was registering a metric twice, which messes up the scraper. In general the solution is to not have multiple metrics with the same name, but I couldn't find a clean way around it.

In a shared lib, I registered a metric. _Another_ dependency used that same shared lib as a dependency. Both are listed in their respective `package.json` as a git repo url for various reasons. This has the side effect that npm does not dedupe the dependency. Essentially, then, the metric name was registered twice, which caused the prometheus scraper to report `text format parsing error in line #: second HELP line for metric name "<metric_name>"`.

This change prevents a metric from being registered twice. I am no prometheus expert, so I would appreciate input on why this might be a bad idea! My first thought is that users of prom-client might not expect this behavior and could accidentally mix metrics (though, I think using labels properly would avoid this, yes?) My second thought is that my use case is pathological and I should not change the lib to work around it (in which case, any suggestions? use and escape `__dirname` appended to the metric name and have prometheus aggregate across all metrics with my `metric_name` prefix?)

All the tests pass, but something tells me this might be a bigger change than I think and just should be a larger version hop, but I leave that up to you!