### PR TITLE
Enfore tabs as indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+; http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = tab
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[package.json]
+indent_size = 2
+indent_style = space
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,73 +1,92 @@
 {
   "env": {
-    "node": true
-  },
-  "globals": {
+	"node": true
   },
   "rules": {
-    "quotes": [
-      2,
-      "single"
-    ],
-    "eol-last": [
-      0
-    ],
-    "no-underscore-dangle": [
-      0
-    ],
-    "no-mixed-requires": [
-      0
-    ],
-    "key-spacing": [
-      0
-    ],
-    "new-cap": [
-      0
-    ],
-    "no-console": 2,
-		"no-debugger": 2,
-    "no-path-concat": 0,
-    "no-shadow": 1,
-    "semi": 2,
-    "no-array-constructor": 2,
-    "no-caller": 2,
-    "no-eval": 2,
-    "no-extend-native": 2,
-    "no-extra-bind": 2,
-    "no-with": 2,
-    "no-loop-func": 2,
-    "no-multi-str": 2,
-    "no-new-func": 2,
-    "no-new-object": 2,
-    "no-return-assign": 2,
-    "no-sequences": 2,
-    "no-shadow-restricted-names": 2,
-    "no-spaced-func": 2,
-    "no-trailing-spaces": 2,
-    "no-unused-expressions": 2,
-		"no-use-before-define": 0,
-		"no-new": 0,
-    "curly": 2,
-    "dot-notation": [2, { "allowKeywords": true }],
-    "eqeqeq": 2,
-    "new-parens": 2,
-    "semi-spacing": 2,
-    "space-infix-ops": 2,
-		"keyword-spacing": ["error", { "overrides": {
-			"for": {
-				"after": false
-			},
-			"if": {
-				"after": false
-			},
-			"else": {
-				"after": true,
-				"before": true
-			}
-		}}],
-    "space-unary-ops": 2,
-    "strict": [2, "global"],
-    "yoda": 2,
-		"valid-jsdoc": 2
+	"indent": [
+	  2,
+	  "tab"
+	],
+	"quotes": [
+	  2,
+	  "single"
+	],
+	"eol-last": [
+	  0
+	],
+	"no-underscore-dangle": [
+	  0
+	],
+	"no-mixed-requires": [
+	  0
+	],
+	"key-spacing": [
+	  0
+	],
+	"new-cap": [
+	  0
+	],
+	"no-console": 2,
+	"no-debugger": 2,
+	"no-path-concat": 0,
+	"no-shadow": 1,
+	"semi": 2,
+	"no-array-constructor": 2,
+	"no-caller": 2,
+	"no-eval": 2,
+	"no-extend-native": 2,
+	"no-extra-bind": 2,
+	"no-with": 2,
+	"no-loop-func": 2,
+	"no-multi-str": 2,
+	"no-new-func": 2,
+	"no-new-object": 2,
+	"no-return-assign": 2,
+	"no-sequences": 2,
+	"no-shadow-restricted-names": 2,
+	"no-spaced-func": 2,
+	"no-trailing-spaces": 2,
+	"no-unused-expressions": 2,
+	"no-use-before-define": 0,
+	"no-new": 0,
+	"curly": 2,
+	"dot-notation": [
+	  2,
+	  {
+		"allowKeywords": true
+	  }
+	],
+	"eqeqeq": 2,
+	"new-parens": 2,
+	"semi-spacing": 2,
+	"space-infix-ops": 2,
+	"keyword-spacing": [
+	  "error",
+	  {
+		"overrides": {
+		  "for": {
+			"after": false
+		  },
+		  "if": {
+			"after": false
+		  },
+		  "else": {
+			"after": true,
+			"before": true
+		  }
+		}
+	  }
+	],
+	"space-unary-ops": 2,
+	"space-before-function-paren": [
+	  2,
+	  "never"
+	],
+	"strict": [
+	  2,
+	  "global"
+	],
+	"yoda": 2,
+	"valid-jsdoc": 2
   }
 }

--- a/lib/defaultMetrics.js
+++ b/lib/defaultMetrics.js
@@ -11,46 +11,46 @@ var processRequests = require('./metrics/processRequests');
 var heapSizeAndUsed = require('./metrics/heapSizeAndUsed');
 
 var metrics = {
-    processCpuTotal: processCpuTotal,
-    processStartTime: processStartTime,
-    osMemoryHeap: osMemoryHeap,
-    processOpenFileDescriptors: processOpenFileDescriptors,
-    processMaxFileDescriptors: processMaxFileDescriptors,
-    eventLoopLag: eventLoopLag,
-    processHandles: processHandles,
-    processRequests: processRequests,
-		heapSizeAndUsed: heapSizeAndUsed
+	processCpuTotal: processCpuTotal,
+	processStartTime: processStartTime,
+	osMemoryHeap: osMemoryHeap,
+	processOpenFileDescriptors: processOpenFileDescriptors,
+	processMaxFileDescriptors: processMaxFileDescriptors,
+	eventLoopLag: eventLoopLag,
+	processHandles: processHandles,
+	processRequests: processRequests,
+	heapSizeAndUsed: heapSizeAndUsed
 };
 
 var existingInterval = null;
 
-module.exports = function startDefaultMetrics (disabledMetrics, interval) {
-    if(existingInterval !== null) {
-        clearInterval(existingInterval);
-    }
+module.exports = function startDefaultMetrics(disabledMetrics, interval) {
+	if(existingInterval !== null) {
+		clearInterval(existingInterval);
+	}
 
-    disabledMetrics = disabledMetrics || [];
-    interval = interval || 10000;
+	disabledMetrics = disabledMetrics || [];
+	interval = interval || 10000;
 
-    var metricsInUse = Object.keys(metrics)
-        .filter(function (metric) {
-            return disabledMetrics.indexOf(metric) < 0;
-        })
-        .map(function (metric) {
-            return metrics[metric]();
-        });
+	var metricsInUse = Object.keys(metrics)
+		.filter(function(metric) {
+			return disabledMetrics.indexOf(metric) < 0;
+		})
+		.map(function(metric) {
+			return metrics[metric]();
+		});
 
-    function updateAllMetrics () {
-        metricsInUse.forEach(function (metric) {
-            metric.call();
-        });
-    }
+	function updateAllMetrics() {
+		metricsInUse.forEach(function(metric) {
+			metric.call();
+		});
+	}
 
-    updateAllMetrics();
+	updateAllMetrics();
 
-    existingInterval = setInterval(updateAllMetrics, interval).unref();
+	existingInterval = setInterval(updateAllMetrics, interval).unref();
 
-    return existingInterval;
+	return existingInterval;
 };
 
 module.exports.metricsList = Object.keys(metrics);

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -69,7 +69,7 @@ Histogram.prototype.get = function() {
 	var data = getProperties(this.hashMap);
 	var values =
 		data.map(extractBucketValuesForExport(this))
-		.reduce(addSumAndCountForExport(this), []);
+			.reduce(addSumAndCountForExport(this), []);
 
 	return {
 		name: this.name,
@@ -230,7 +230,7 @@ function addSumAndCountForExport(histogram) {
 	return function(acc, d) {
 		acc = acc.concat(d.buckets);
 
-		var infLabel = extend({ le: '+Inf'}, d.data.labels);
+		var infLabel = extend({ le: '+Inf' }, d.data.labels);
 		acc.push(createValuePair(infLabel, d.data.count, histogram.name + '_bucket'));
 		acc.push(createValuePair(d.data.labels, d.data.sum, histogram.name + '_sum'));
 		acc.push(createValuePair(d.data.labels, d.data.count, histogram.name + '_count'));

--- a/lib/metrics/eventLoopLag.js
+++ b/lib/metrics/eventLoopLag.js
@@ -2,19 +2,19 @@
 
 var Gauge = require('../gauge');
 
-function reportEventloopLag(start, gauge){
-    var delta = process.hrtime(start);
-    var nanosec = delta[0] * 1e9 + delta[1];
-    var ms = nanosec / 1e6;
+function reportEventloopLag(start, gauge) {
+	var delta = process.hrtime(start);
+	var nanosec = delta[0] * 1e9 + delta[1];
+	var ms = nanosec / 1e6;
 
-    gauge.set(Math.round(ms));
+	gauge.set(Math.round(ms));
 }
 
 module.exports = function() {
-    var gauge = new Gauge('node_eventloop_lag_milliseconds', 'Lag of event loop in milliseconds.');
+	var gauge = new Gauge('node_eventloop_lag_milliseconds', 'Lag of event loop in milliseconds.');
 
-    return function() {
-        var start = process.hrtime();
-        setImmediate(reportEventloopLag, start, gauge);
-    };
+	return function() {
+		var start = process.hrtime();
+		setImmediate(reportEventloopLag, start, gauge);
+	};
 };

--- a/lib/metrics/heapSizeAndUsed.js
+++ b/lib/metrics/heapSizeAndUsed.js
@@ -2,19 +2,19 @@
 
 var Gauge = require('../gauge');
 module.exports = function() {
-    if(typeof process.memoryUsage !== 'function') {
-        return function () {
-        };
-    }
-
-		var heapSizeTotal = new Gauge('process_heap_size_node_bytes', 'Process heap size from node.js in bytes.');
-		var heapSizeUsed = new Gauge('process_heap_size_used_bytes', 'Process heap size used in bytes.');
-
+	if(typeof process.memoryUsage !== 'function') {
 		return function() {
-			var memUsage = process.memoryUsage();
-			heapSizeTotal.set(memUsage.heapTotal);
-			heapSizeUsed.set(memUsage.heapUsed);
-
-			return { total: heapSizeTotal, used: heapSizeUsed };
 		};
+	}
+
+	var heapSizeTotal = new Gauge('process_heap_size_node_bytes', 'Process heap size from node.js in bytes.');
+	var heapSizeUsed = new Gauge('process_heap_size_used_bytes', 'Process heap size used in bytes.');
+
+	return function() {
+		var memUsage = process.memoryUsage();
+		heapSizeTotal.set(memUsage.heapTotal);
+		heapSizeUsed.set(memUsage.heapUsed);
+
+		return { total: heapSizeTotal, used: heapSizeUsed };
+	};
 };

--- a/lib/metrics/osMemoryHeap.js
+++ b/lib/metrics/osMemoryHeap.js
@@ -2,17 +2,17 @@
 
 var Gauge = require('../gauge');
 var linuxVariant = require('./osMemoryHeapLinux');
-var notLinuxVariant = function () {
-    var residentMemGauge = new Gauge('process_resident_memory_bytes', 'Resident memory size in bytes.');
+var notLinuxVariant = function() {
+	var residentMemGauge = new Gauge('process_resident_memory_bytes', 'Resident memory size in bytes.');
 
-    return function () {
-        var memoryUsage = process.memoryUsage();
+	return function() {
+		var memoryUsage = process.memoryUsage();
 
-        // I don't think the other things returned from `process.memoryUsage()` is relevant to a standard export
-        residentMemGauge.set(null, memoryUsage.rss);
-    };
+		// I don't think the other things returned from `process.memoryUsage()` is relevant to a standard export
+		residentMemGauge.set(null, memoryUsage.rss);
+	};
 };
 
-module.exports = function () {
-    return process.platform === 'linux' ? linuxVariant() : notLinuxVariant();
+module.exports = function() {
+	return process.platform === 'linux' ? linuxVariant() : notLinuxVariant();
 };

--- a/lib/metrics/osMemoryHeapLinux.js
+++ b/lib/metrics/osMemoryHeapLinux.js
@@ -5,46 +5,46 @@ var fs = require('fs');
 
 var values = ['VmSize', 'VmRSS', 'VmData'];
 
-function structureOutput (input) {
-    var returnValue = {};
+function structureOutput(input) {
+	var returnValue = {};
 
-    input.split('\n')
-        .filter(function (s) {
-            return values.some(function (value) {
-                return s.indexOf(value) === 0;
-            });
-        })
-        .forEach(function (string) {
-            var split = string.split(':');
+	input.split('\n')
+		.filter(function(s) {
+			return values.some(function(value) {
+				return s.indexOf(value) === 0;
+			});
+		})
+		.forEach(function(string) {
+			var split = string.split(':');
 
-            // Get the value
-            var value = split[1].trim();
-            // Remove trailing ` kb`
-            value = value.substr(0, value.length - 3);
-            // Make it into a number in bytes bytes
-            value = Number(value) * 1000;
+			// Get the value
+			var value = split[1].trim();
+			// Remove trailing ` kb`
+			value = value.substr(0, value.length - 3);
+			// Make it into a number in bytes bytes
+			value = Number(value) * 1000;
 
-            returnValue[split[0]] = value;
-        });
+			returnValue[split[0]] = value;
+		});
 
-    return returnValue;
+	return returnValue;
 }
 
-module.exports = function () {
-    var residentMemGauge = new Gauge('process_resident_memory_bytes', 'Resident memory size in bytes.');
-    var virtualMemGauge = new Gauge('process_virtual_memory_bytes', 'Virtual memory size in bytes.');
-    var heapSizeMemGauge = new Gauge('process_heap_bytes', 'Process heap size in bytes.');
+module.exports = function() {
+	var residentMemGauge = new Gauge('process_resident_memory_bytes', 'Resident memory size in bytes.');
+	var virtualMemGauge = new Gauge('process_virtual_memory_bytes', 'Virtual memory size in bytes.');
+	var heapSizeMemGauge = new Gauge('process_heap_bytes', 'Process heap size in bytes.');
 
-    return function () {
-        fs.readFile('/proc/self/status', 'utf8', function (err, status) {
-            if(err) {
-                return;
-            }
-            var structuredOutput = structureOutput(status);
+	return function() {
+		fs.readFile('/proc/self/status', 'utf8', function(err, status) {
+			if(err) {
+				return;
+			}
+			var structuredOutput = structureOutput(status);
 
-            residentMemGauge.set(null, structuredOutput.VmRSS);
-            virtualMemGauge.set(null, structuredOutput.VmSize);
-            heapSizeMemGauge.set(null, structuredOutput.VmData);
-        });
-    };
+			residentMemGauge.set(null, structuredOutput.VmRSS);
+			virtualMemGauge.set(null, structuredOutput.VmSize);
+			heapSizeMemGauge.set(null, structuredOutput.VmData);
+		});
+	};
 };

--- a/lib/metrics/processCpuTotal.js
+++ b/lib/metrics/processCpuTotal.js
@@ -2,21 +2,21 @@
 
 var Counter = require('../counter');
 
-module.exports = function () {
-    // Don't do anything if the function doesn't exist (introduced in node@6.1.0)
-    if(typeof process.cpuUsage !== 'function') {
-        return function () {
-        };
-    }
+module.exports = function() {
+	// Don't do anything if the function doesn't exist (introduced in node@6.1.0)
+	if(typeof process.cpuUsage !== 'function') {
+		return function() {
+		};
+	}
 
-    var cpuUserCounter = new Counter('process_cpu_seconds_total', 'Total user and system CPU time spent in seconds.');
-		var lastCpuUsage = null;
+	var cpuUserCounter = new Counter('process_cpu_seconds_total', 'Total user and system CPU time spent in seconds.');
+	var lastCpuUsage = null;
 
-    return function () {
-        var cpuUsage = process.cpuUsage(lastCpuUsage);
-				lastCpuUsage = cpuUsage;
-        var totalUsageMicros = cpuUsage.user + cpuUsage.system;
+	return function() {
+		var cpuUsage = process.cpuUsage(lastCpuUsage);
+		lastCpuUsage = cpuUsage;
+		var totalUsageMicros = cpuUsage.user + cpuUsage.system;
 
-        cpuUserCounter.inc(totalUsageMicros / 1e6);
-    };
+		cpuUserCounter.inc(totalUsageMicros / 1e6);
+	};
 };

--- a/lib/metrics/processHandles.js
+++ b/lib/metrics/processHandles.js
@@ -3,15 +3,15 @@
 var Gauge = require('../gauge');
 
 module.exports = function() {
-    // Don't do anything if the function is removed in later nodes (exists in node@6)
-    if(typeof process._getActiveHandles !== 'function') {
-        return function () {
-        };
-    }
+	// Don't do anything if the function is removed in later nodes (exists in node@6)
+	if(typeof process._getActiveHandles !== 'function') {
+		return function() {
+		};
+	}
 
-    var gauge = new Gauge('node_active_handles_total', 'Number of active handles.');
+	var gauge = new Gauge('node_active_handles_total', 'Number of active handles.');
 
-    return function() {
-        gauge.set(process._getActiveHandles().length);
-    };
+	return function() {
+		gauge.set(process._getActiveHandles().length);
+	};
 };

--- a/lib/metrics/processMaxFileDescriptors.js
+++ b/lib/metrics/processMaxFileDescriptors.js
@@ -3,23 +3,23 @@
 var Gauge = require('../gauge');
 var fs = require('fs');
 
-module.exports = function () {
-    var isSet = false;
-    var fileDescriptorsGauge = new Gauge('process_max_fds', 'Maximum number of open file descriptors.');
+module.exports = function() {
+	var isSet = false;
+	var fileDescriptorsGauge = new Gauge('process_max_fds', 'Maximum number of open file descriptors.');
 
-    return function () {
-        if(isSet || process.platform !== 'linux') {
-            return;
-        }
+	return function() {
+		if(isSet || process.platform !== 'linux') {
+			return;
+		}
 
-        fs.readFile('/proc/sys/fs/file-max', 'utf8', function (err, maxFds) {
-            if(err) {
-                return;
-            }
+		fs.readFile('/proc/sys/fs/file-max', 'utf8', function(err, maxFds) {
+			if(err) {
+				return;
+			}
 
-            isSet = true;
+			isSet = true;
 
-            fileDescriptorsGauge.set(null, maxFds);
-        });
-    };
+			fileDescriptorsGauge.set(null, maxFds);
+		});
+	};
 };

--- a/lib/metrics/processOpenFileDescriptors.js
+++ b/lib/metrics/processOpenFileDescriptors.js
@@ -3,22 +3,22 @@
 var Gauge = require('../gauge');
 var fs = require('fs');
 
-module.exports = function () {
-    if(process !== 'linux') {
-        return function () {
-        };
-    }
+module.exports = function() {
+	if(process !== 'linux') {
+		return function() {
+		};
+	}
 
-    var fileDescriptorsGauge = new Gauge('process_open_fds', 'Number of open file descriptors.');
+	var fileDescriptorsGauge = new Gauge('process_open_fds', 'Number of open file descriptors.');
 
-    return function () {
-        fs.readdir('/proc/self/fd', function (err, list) {
-            if(err) {
-                return;
-            }
+	return function() {
+		fs.readdir('/proc/self/fd', function(err, list) {
+			if(err) {
+				return;
+			}
 
-            // Minus 1, as this invocation created one
-            fileDescriptorsGauge.set(null, list.length - 1);
-        });
-    };
+			// Minus 1, as this invocation created one
+			fileDescriptorsGauge.set(null, list.length - 1);
+		});
+	};
 };

--- a/lib/metrics/processRequests.js
+++ b/lib/metrics/processRequests.js
@@ -3,14 +3,14 @@
 var Gauge = require('../gauge');
 
 module.exports = function() {    // Don't do anything if the function is removed in later nodes (exists in node@6)
-    if(typeof process._getActiveRequests !== 'function') {
-        return function () {
-        };
-    }
+	if(typeof process._getActiveRequests !== 'function') {
+		return function() {
+		};
+	}
 
-    var gauge = new Gauge('node_active_requests_total', 'Number of active requests.');
+	var gauge = new Gauge('node_active_requests_total', 'Number of active requests.');
 
-    return function() {
-        gauge.set(process._getActiveRequests().length);
-    };
+	return function() {
+		gauge.set(process._getActiveRequests().length);
+	};
 };

--- a/lib/metrics/processStartTime.js
+++ b/lib/metrics/processStartTime.js
@@ -3,15 +3,15 @@
 var Gauge = require('../gauge');
 var nowInSeconds = Math.round(Date.now() / 1000 - process.uptime());
 
-module.exports = function () {
-    var cpuUserGauge = new Gauge('process_start_time_seconds', 'Start time of the process since unix epoch in seconds.');
-    var isSet = false;
+module.exports = function() {
+	var cpuUserGauge = new Gauge('process_start_time_seconds', 'Start time of the process since unix epoch in seconds.');
+	var isSet = false;
 
-    return function () {
-        if(isSet) {
-            return;
-        }
-        cpuUserGauge.set(null, nowInSeconds);
-        isSet = true;
-    };
+	return function() {
+		if(isSet) {
+			return;
+		}
+		cpuUserGauge.set(null, nowInSeconds);
+		isSet = true;
+	};
 };

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -68,7 +68,7 @@ function generateGroupings(groupings) {
 		return '';
 	}
 	return Object.keys(groupings).map(function(key) {
-		return [ '/', encodeURIComponent(key), '/', encodeURIComponent(groupings[key])].join('');
+		return ['/', encodeURIComponent(key), '/', encodeURIComponent(groupings[key])].join('');
 	}).join('');
 }
 

--- a/lib/register.js
+++ b/lib/register.js
@@ -49,9 +49,9 @@ var clearMetrics = function clearMetrics() {
 };
 
 var getMetricsAsJSON = function getMetricsAsJSON() {
-  return metrics.map(function(metric) {
-    return metric.get();
-  });
+	return metrics.map(function(metric) {
+		return metric.get();
+	});
 };
 
 module.exports = {

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -62,7 +62,7 @@ Summary.prototype.get = function() {
 	var values = [];
 	data.forEach(function(s) {
 		extractSummariesForExport(s, summary.percentiles).forEach(function(v) {
-				values.push(v);
+			values.push(v);
 		});
 		values.push(getSumForExport(s, summary));
 		values.push(getCountForExport(s, summary));
@@ -88,7 +88,7 @@ Summary.prototype.reset = function() {
 function extractSummariesForExport(summaryOfLabels, percentiles) {
 	summaryOfLabels.td.compress();
 
-	return percentiles.map(function (percentile) {
+	return percentiles.map(function(percentile) {
 		var percentileValue = summaryOfLabels.td.percentile(percentile);
 		return {
 			labels: extend({ quantile: percentile }, summaryOfLabels.labels),
@@ -171,7 +171,7 @@ function validateInput(name, help, labels) {
 }
 
 function configurePercentiles(configuredPercentiles) {
-	var defaultPercentiles = [ 0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999 ];
+	var defaultPercentiles = [0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999];
 	return [].concat((configuredPercentiles || defaultPercentiles)).sort(sortAscending);
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -10,7 +10,7 @@ exports.getPropertiesFromObj = function(hashMap) {
 };
 
 exports.incValue = function createValue(hashMap, value, labels, hash) {
-	if(hashMap[hash]){
+	if(hashMap[hash]) {
 		hashMap[hash].value += value || 1;
 	} else {
 		hashMap[hash] = { value: value || 1, labels: labels || {} };
@@ -30,7 +30,7 @@ exports.getLabels = function(labelNames, args) {
 	}
 
 	var argsAsArray = Array.prototype.slice.call(args);
-	return labelNames.reduce(function(acc, label, index){
+	return labelNames.reduce(function(acc, label, index) {
 		acc[label] = argsAsArray[index];
 		return acc;
 	}, {});
@@ -55,7 +55,9 @@ function hashObject(labels) {
 		elems.push(keys[i] + ':' + labels[keys[i]]);
 	}
 	return elems.join(',');
-};
+}
 exports.hashObject = hashObject;
 
-function isNumber(obj) { return !isNaN(parseFloat(obj)); };
+function isNumber(obj) {
+	return !isNaN(parseFloat(obj));
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "test": "npm run lint && npm run test-unit",
-    "lint": "eslint --ignore-pattern doc/ --ignore-path .gitignore .",
+    "lint": "node-version-gte-4 && eslint . || node-version-lt-4",
     "test-unit": "mocha --recursive test/"
   },
   "repository": {
@@ -29,10 +29,11 @@
   "homepage": "https://github.com/siimon/prom-client",
   "devDependencies": {
     "chai": "^3.4.1",
-    "eslint": "^2.13.1",
+    "eslint": "^3.5.0",
     "express": "^4.13.3",
     "mocha": "^2.3.4",
     "nock": "^8.0.0",
+    "node-version-check": "^2.1.1",
     "sinon": "^1.17.2"
   },
   "dependencies": {

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,15 +1,8 @@
 {
 	"env": {
-		"node": true,
 		"mocha": true
 	},
 	"rules": {
-		"quotes": [2, "single"],
-		"eol-last": [0],
-		"no-underscore-dangle": [0],
-		"no-mixed-requires": [0],
-		"no-use-before-define": [0],
-		"handle-callback-err": [0],
 		"no-console": 0,
 		"no-unused-vars": 0,
 		"no-shadow": 0,

--- a/test/defaultMetrics.js
+++ b/test/defaultMetrics.js
@@ -8,7 +8,7 @@ describe('defaultMetrics', function() {
 	var cpuUsage;
 	var interval;
 
-	before(function () {
+	before(function() {
 		platform = process.platform;
 		cpuUsage = process.cpuUsage;
 
@@ -18,12 +18,12 @@ describe('defaultMetrics', function() {
 
 		if(cpuUsage) {
 			Object.defineProperty(process, 'cpuUsage', {
-				value: function () {
+				value: function() {
 					return { user: 1000, system: 10 };
 				}
 			});
 		} else {
-			process.cpuUsage = function () {
+			process.cpuUsage = function() {
 				return { user: 1000, system: 10 };
 			};
 		}
@@ -31,7 +31,7 @@ describe('defaultMetrics', function() {
 		register.clear();
 	});
 
-	after(function () {
+	after(function() {
 		Object.defineProperty(process, 'platform', {
 			value: platform
 		});

--- a/test/metrics/eventLoopLagTest.js
+++ b/test/metrics/eventLoopLagTest.js
@@ -1,31 +1,31 @@
 'use strict';
 
-describe('eventLoopLag', function () {
-    var expect = require('chai').expect;
-    var register = require('../../index').register;
-    var eventLoopLag = require('../../lib/metrics/eventLoopLag');
+describe('eventLoopLag', function() {
+	var expect = require('chai').expect;
+	var register = require('../../index').register;
+	var eventLoopLag = require('../../lib/metrics/eventLoopLag');
 
-    before(function () {
-        register.clear();
-    });
+	before(function() {
+		register.clear();
+	});
 
-    afterEach(function () {
-        register.clear();
-    });
+	afterEach(function() {
+		register.clear();
+	});
 
-    it('should add metric to the registry', function (done) {
-        expect(register.getMetricsAsJSON()).to.have.length(0);
-        eventLoopLag()();
+	it('should add metric to the registry', function(done) {
+		expect(register.getMetricsAsJSON()).to.have.length(0);
+		eventLoopLag()();
 
-        setTimeout(function () {
-            var metrics = register.getMetricsAsJSON();
-            expect(metrics).to.have.length(1);
+		setTimeout(function() {
+			var metrics = register.getMetricsAsJSON();
+			expect(metrics).to.have.length(1);
 
-            expect(metrics[0].help).to.equal('Lag of event loop in milliseconds.');
-            expect(metrics[0].type).to.equal('gauge');
-            expect(metrics[0].name).to.equal('node_eventloop_lag_milliseconds');
+			expect(metrics[0].help).to.equal('Lag of event loop in milliseconds.');
+			expect(metrics[0].type).to.equal('gauge');
+			expect(metrics[0].name).to.equal('node_eventloop_lag_milliseconds');
 
-            done();
-        }, 5);
-    });
+			done();
+		}, 5);
+	});
 });

--- a/test/metrics/heapSizeAndUsedTest.js
+++ b/test/metrics/heapSizeAndUsedTest.js
@@ -15,13 +15,17 @@ describe('heapSizeAndUsed', function() {
 	});
 
 	it('should set total heap size gauge with total from memoryUsage', function() {
-		process.memoryUsage = function() { return { heapTotal: 1000, heapUsed: 500 }; };
+		process.memoryUsage = function() {
+			return { heapTotal: 1000, heapUsed: 500 };
+		};
 		var totalGauge = heapSizeAndUsed()().total.get();
 		expect(totalGauge.values[0].value).to.equal(1000);
 	});
 
 	it('should set used gauge with used from memoryUsage', function() {
-		process.memoryUsage = function() { return { heapTotal: 1000, heapUsed: 500 }; };
+		process.memoryUsage = function() {
+			return { heapTotal: 1000, heapUsed: 500 };
+		};
 		var gauge = heapSizeAndUsed()().used.get();
 		expect(gauge.values[0].value).to.equal(500);
 	});

--- a/test/metrics/processHandlesTest.js
+++ b/test/metrics/processHandlesTest.js
@@ -1,28 +1,28 @@
 'use strict';
 
-describe('processHandles', function () {
-    var expect = require('chai').expect;
-    var register = require('../../index').register;
-    var processHandles = require('../../lib/metrics/processHandles');
+describe('processHandles', function() {
+	var expect = require('chai').expect;
+	var register = require('../../index').register;
+	var processHandles = require('../../lib/metrics/processHandles');
 
-    before(function () {
-        register.clear();
-    });
+	before(function() {
+		register.clear();
+	});
 
-    afterEach(function () {
-        register.clear();
-    });
+	afterEach(function() {
+		register.clear();
+	});
 
-    it('should add metric to the registry', function () {
-        expect(register.getMetricsAsJSON()).to.have.length(0);
+	it('should add metric to the registry', function() {
+		expect(register.getMetricsAsJSON()).to.have.length(0);
 
-        processHandles()();
+		processHandles()();
 
-        var metrics = register.getMetricsAsJSON();
+		var metrics = register.getMetricsAsJSON();
 
-        expect(metrics).to.have.length(1);
-        expect(metrics[0].help).to.equal('Number of active handles.');
-        expect(metrics[0].type).to.equal('gauge');
-        expect(metrics[0].name).to.equal('node_active_handles_total');
-    });
+		expect(metrics).to.have.length(1);
+		expect(metrics[0].help).to.equal('Number of active handles.');
+		expect(metrics[0].type).to.equal('gauge');
+		expect(metrics[0].name).to.equal('node_active_handles_total');
+	});
 });

--- a/test/metrics/processRequestsTest.js
+++ b/test/metrics/processRequestsTest.js
@@ -1,28 +1,28 @@
 'use strict';
 
-describe('processRequests', function () {
-    var expect = require('chai').expect;
-    var register = require('../../index').register;
-    var processRequests = require('../../lib/metrics/processRequests');
+describe('processRequests', function() {
+	var expect = require('chai').expect;
+	var register = require('../../index').register;
+	var processRequests = require('../../lib/metrics/processRequests');
 
-    before(function () {
-        register.clear();
-    });
+	before(function() {
+		register.clear();
+	});
 
-    afterEach(function () {
-        register.clear();
-    });
+	afterEach(function() {
+		register.clear();
+	});
 
-    it('should add metric to the registry', function () {
-        expect(register.getMetricsAsJSON()).to.have.length(0);
+	it('should add metric to the registry', function() {
+		expect(register.getMetricsAsJSON()).to.have.length(0);
 
-        processRequests()();
+		processRequests()();
 
-        var metrics = register.getMetricsAsJSON();
+		var metrics = register.getMetricsAsJSON();
 
-        expect(metrics).to.have.length(1);
-        expect(metrics[0].help).to.equal('Number of active requests.');
-        expect(metrics[0].type).to.equal('gauge');
-        expect(metrics[0].name).to.equal('node_active_requests_total');
-    });
+		expect(metrics).to.have.length(1);
+		expect(metrics[0].help).to.equal('Number of active requests.');
+		expect(metrics[0].type).to.equal('gauge');
+		expect(metrics[0].name).to.equal('node_active_requests_total');
+	});
 });


### PR DESCRIPTION
Noticed that there's horribly mixed spaces and tabs (most of the spaces come from my PR, but not all).

This enforces tabs using eslint, and adds an editorconfig to help IDEs use it automatically.

The second commit upgrades to latest major of eslint. Breaking is mostly dropping support for node older than 4, which is why I included a dep that checks for the node version