### PR TITLE
Remove single metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,15 @@ xhrRequest(function(err, res) {
 });
 ```
 
+#### Register
+
+You can get all metrics by running `register.metrics()`, which will output a string for prometheus to consume.
+
+##### Removing metrics
+
+You can remove all metrics by calling `register.clearMetrics()`. You can also remove a single metric by calling
+`register.removeSingleMetric(*name of metric*)`.
+
 #### Pushgateway
 
 It is possible to push metrics via a [Pushgateway](https://github.com/prometheus/pushgateway). 

--- a/lib/register.js
+++ b/lib/register.js
@@ -65,9 +65,14 @@ var getMetricsAsJSON = function getMetricsAsJSON() {
 	});
 };
 
+var removeSingleMetric = function removeSingleMetric(name) {
+	delete metrics[name];
+};
+
 module.exports = {
 	registerMetric: registerMetric,
 	metrics: getMetrics,
 	clear: clearMetrics,
-	getMetricsAsJSON: getMetricsAsJSON
+	getMetricsAsJSON: getMetricsAsJSON,
+	removeSingleMetric: removeSingleMetric
 };

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -107,12 +107,28 @@ describe('register', function() {
 		});
 	});
 
-	function getMetric() {
+	it('should allow removing single metrics', function() {
+		register.registerMetric(getMetric());
+		register.registerMetric(getMetric('some other name'));
+
+		var output = register.getMetricsAsJSON();
+		expect(output.length).to.equal(2);
+
+		register.removeSingleMetric('test_metric');
+
+		output = register.getMetricsAsJSON();
+
+		expect(output.length).to.equal(1);
+		expect(output[0].name).to.equal('some other name');
+	});
+
+	function getMetric(name) {
+		name = name || 'test_metric';
 		return {
-			name: 'test_metric',
+			name: name,
 			get: function() {
 				return {
-					name: 'test_metric',
+					name: name,
 					type: 'counter',
 					help: 'A test metric',
 					values: [ {


### PR DESCRIPTION
Builds on #41 

By having a single key, we can now easily remove a metric.

If you don't want #41, I can use the array as well (`removeMetricByName`). I prefer this way, though 😄 