### PR TITLE
Remove newline from process_max_fds value

### DIFF
--- a/lib/metrics/processMaxFileDescriptors.js
+++ b/lib/metrics/processMaxFileDescriptors.js
@@ -21,7 +21,7 @@ module.exports = function() {
 
 			isSet = true;
 
-			fileDescriptorsGauge.set(null, maxFds);
+			fileDescriptorsGauge.set(null, maxFds.replace(/\r?\n$/, ''));
 		});
 	};
 };


### PR DESCRIPTION
The value read from the file includes a new line, this is being passed
on tot he value, and printed in theoutput. It doesn't cause a problem
for scraping right now, but it could break things in the future.