### PR TITLE
Only register the `max_fds` if the OS is supported

### DIFF
--- a/lib/metrics/processMaxFileDescriptors.js
+++ b/lib/metrics/processMaxFileDescriptors.js
@@ -7,10 +7,16 @@ var PROCESS_MAX_FDS = 'process_max_fds';
 
 module.exports = function() {
 	var isSet = false;
+
+	if(process.platform !== 'linux') {
+		return function() {
+		};
+	}
+
 	var fileDescriptorsGauge = new Gauge(PROCESS_MAX_FDS, 'Maximum number of open file descriptors.');
 
 	return function() {
-		if(isSet || process.platform !== 'linux') {
+		if(isSet) {
 			return;
 		}
 

--- a/test/defaultMetrics.js
+++ b/test/defaultMetrics.js
@@ -53,13 +53,13 @@ describe('defaultMetrics', function() {
 	it('should add metrics to the registry', function() {
 		expect(register.getMetricsAsJSON()).to.have.length(0);
 		interval = defaultMetrics();
-		expect(register.getMetricsAsJSON()).to.have.length(9);
+		expect(register.getMetricsAsJSON()).to.have.length(8);
 	});
 
 	it('should allow blacklisting unwanted metrics', function() {
 		expect(register.getMetricsAsJSON()).to.have.length(0);
 		interval = defaultMetrics(['osMemoryHeap']);
-		expect(register.getMetricsAsJSON()).to.have.length(8);
+		expect(register.getMetricsAsJSON()).to.have.length(7);
 	});
 
 	it('should allow blacklisting all metrics', function() {


### PR DESCRIPTION
Currently it's always present. On my Mac, it's there, but never assigned.

Ref #36 

/cc @tcolgate 