### PR TITLE
cpu usage: Fix increasing cpu usage

### DIFF
--- a/lib/metrics/processCpuTotal.js
+++ b/lib/metrics/processCpuTotal.js
@@ -11,12 +11,13 @@ module.exports = function() {
 	}
 
 	var cpuUserCounter = new Counter(PROCESS_CPU_SECONDS, 'Total user and system CPU time spent in seconds.');
-	var lastCpuUsage = null;
+	var lastCpuUsage = process.cpuUsage();
 
 	return function() {
-		var cpuUsage = process.cpuUsage(lastCpuUsage);
+		var cpuUsage = process.cpuUsage();
+		var totalUsageMicros = (cpuUsage.user - lastCpuUsage.user)
+			+ (cpuUsage.system - lastCpuUsage.system);
 		lastCpuUsage = cpuUsage;
-		var totalUsageMicros = cpuUsage.user + cpuUsage.system;
 
 		cpuUserCounter.inc(totalUsageMicros / 1e6);
 	};


### PR DESCRIPTION
When using process.cpuUsage(lastCpuUsage), only the delta is returned.
One either needs to add this to lastCpuUsage manually, or do the
math operations.

This should fix issue #57

Signed-off-by: Simen Bekkhus (@SimenB) <sbekkhus91@gmail.com>
Signed-off-by: Arne-Christian Blystad (@Blystad) <arne.christian@blystad.me>