### PR TITLE
Add method to get a registred metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ xhrRequest(function(err, res) {
 
 You can get all metrics by running `register.metrics()`, which will output a string for prometheus to consume.
 
+##### Getting a single metric
+
+If you need to get a reference to a previously registered metric, you can use `register.getSingleMetric(*name of metric*)`.
+
 ##### Removing metrics
 
 You can remove all metrics by calling `register.clear()`. You can also remove a single metric by calling

--- a/lib/register.js
+++ b/lib/register.js
@@ -69,10 +69,15 @@ var removeSingleMetric = function removeSingleMetric(name) {
 	delete metrics[name];
 };
 
+var getSingleMetric = function getSingleMetric(name) {
+	return metrics[name];
+};
+
 module.exports = {
 	registerMetric: registerMetric,
 	metrics: getMetrics,
 	clear: clearMetrics,
 	getMetricsAsJSON: getMetricsAsJSON,
-	removeSingleMetric: removeSingleMetric
+	removeSingleMetric: removeSingleMetric,
+	getSingleMetric: getSingleMetric
 };

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -122,6 +122,14 @@ describe('register', function() {
 		expect(output[0].name).to.equal('some other name');
 	});
 
+	it('should allow getting single metrics', function() {
+		var metric = getMetric();
+		register.registerMetric(metric);
+
+		var output = register.getSingleMetric('test_metric');
+		expect(output).to.equal(metric);
+	});
+
 	function getMetric(name) {
 		name = name || 'test_metric';
 		return {


### PR DESCRIPTION
We create a metric inside a function, which might be called multiple times (with different labels). Instead of introducing some sort of state handling into our module, it'd be prettier if we could just fetch a the metric from the register itself.