### PR TITLE
Added scheme to Pushgateway example code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ It is possible to push metrics via a [Pushgateway](https://github.com/prometheus
 
 ```js
 var client = require('prom-client');
-var gateway = new client.Pushgateway('127.0.0.1:9091');
+var gateway = new client.Pushgateway('http://127.0.0.1:9091');
 
 gateway.pushAdd({ jobName: 'test' }, function(err, resp, body) { }); //Add metric and overwrite old ones
 gateway.push({ jobName: 'test' }, function(err, resp, body) { }); //Overwrite all metrics (use PUT)


### PR DESCRIPTION
[This section](https://github.com/siimon/prom-client/blob/089aa1de703ef1648df3ae48f974a8ff74aa5602/lib/pushgateway.js#L81-L85) fails if the provided Pushgateway URL does not include the scheme, which the example did not include.

I don't see any reason to not require it so better to just update the documentation.