### PR TITLE
Passing authentication data through URI, when pushing to Pushgateway

### DIFF
--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -57,8 +57,7 @@ function useGateway(method, job, groupings, callback) {
 	});
 
 	if(method !== 'DELETE') {
-		var content = register.metrics();
-		req.write(content);
+		req.write(register.metrics());
 	}
 	req.end();
 }

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -1,11 +1,12 @@
 'use strict';
 
+var url = require('url');
 var http = require('http');
 var https = require('https');
 var register = require('./register');
 
-function Pushgateway(url) {
-	this.gatewayUrl = url;
+function Pushgateway(gatewayUrl) {
+	this.gatewayUrl = gatewayUrl;
 }
 
 Pushgateway.prototype.pushAdd = function(params, callback) {
@@ -30,18 +31,16 @@ Pushgateway.prototype.delete = function(params, callback) {
 	useGateway.call(this, 'DELETE', params.jobName, params.groupings, callback);
 };
 
+
 function useGateway(method, job, groupings, callback) {
-	var path = ['/metrics/job/', encodeURIComponent(job), generateGroupings(groupings)].join('');
+	var path = ['metrics/job/', encodeURIComponent(job), generateGroupings(groupings)].join('');
 
-	var httpModule = isHttps(this.gatewayUrl) ? https : http;
-
-	var hostAndPort = getHostAndPort(this.gatewayUrl);
-	var options = {
-		method: method,
-		hostname: hostAndPort.host,
-		port: hostAndPort.port,
-		path: path
-	};
+	var target = url.resolve(this.gatewayUrl, path);
+	var requestParams = url.parse(target);
+	var httpModule = isHttps(requestParams.href) ? https : http;
+	var options = Object.assign(requestParams, {
+		method: method
+	});
 
 	var req = httpModule.request(options, function(res) {
 		var body = '';
@@ -58,7 +57,8 @@ function useGateway(method, job, groupings, callback) {
 	});
 
 	if(method !== 'DELETE') {
-		req.write(register.metrics());
+		var content = register.metrics();
+		req.write(content);
 	}
 	req.end();
 }
@@ -72,21 +72,8 @@ function generateGroupings(groupings) {
 	}).join('');
 }
 
-function getHostAndPort(url) {
-	var host;
-	if(url.indexOf(':') === -1) {
-		return { host: url, port: isHttps(url) ? 443 : 80 };
-	}
-
-	var parts = url.match(/https?:\/\/(.*):(\d*)/);
-	return {
-		host: parts[1],
-		port: parts[2]
-	};
-}
-
-function isHttps(url) {
-	return url.search(/^https/) !== -1;
+function isHttps(href) {
+	return href.search(/^https/) !== -1;
 }
 
 module.exports = Pushgateway;

--- a/test/pushgatewayTest.js
+++ b/test/pushgatewayTest.js
@@ -77,12 +77,46 @@ describe('pushgateway', function() {
 		});
 	});
 
+	describe('when using basic authentication', function() {
+		var USERNAME = 'unittest';
+		var PASSWORD = 'unittest';
+
+		beforeEach(function() {
+			instance = new Pushgateway('http://' + USERNAME + ':' + PASSWORD + '@192.168.99.100:9091');
+		});
+
+		function verifyResult(done, err, response) {
+			expect(err).not.to.exist;
+			expect(response.req.headers.authorization).to.match(/^Basic/);
+
+			done();
+		}
+
+		it('pushAdd should send POST request with basic auth data', function(done) {
+			setupNock(202, 'post', '/metrics/job/testJob');
+
+			instance.pushAdd({ jobName: 'testJob' }, verifyResult.bind({}, done));
+		});
+
+		it('push should send PUT request with basic auth data', function(done) {
+			setupNock(202, 'put', '/metrics/job/testJob');
+
+			instance.push({ jobName: 'testJob' }, verifyResult.bind({}, done));
+		});
+
+		it('delete should send DELETE request with basic auth data', function(done) {
+			setupNock(202, 'delete', '/metrics/job/testJob');
+
+			instance.delete({ jobName: 'testJob' }, verifyResult.bind({}, done));
+		});
+	});
+
 	function setupNock(responseCode, method, path) {
-		nock('http://192.168.99.100:9091', {'encodedQueryParams':true})
-		[method](path)
-		.reply(202, '', {
-			'content-length': '0',
-			'content-type': 'text/plain; charset=utf-8',
-			connection: 'close' });
+		return nock('http://192.168.99.100:9091', {'encodedQueryParams':true})
+			[method](path)
+			.reply(202, '', {
+				'content-length': '0',
+				'content-type': 'text/plain; charset=utf-8',
+				connection: 'close' });
 	}
 });

--- a/test/pushgatewayTest.js
+++ b/test/pushgatewayTest.js
@@ -112,11 +112,11 @@ describe('pushgateway', function() {
 	});
 
 	function setupNock(responseCode, method, path) {
-		return nock('http://192.168.99.100:9091', {'encodedQueryParams':true})
-			[method](path)
-			.reply(202, '', {
-				'content-length': '0',
-				'content-type': 'text/plain; charset=utf-8',
-				connection: 'close' });
+		nock('http://192.168.99.100:9091', {'encodedQueryParams':true})
+		[method](path)
+		.reply(202, '', {
+			'content-length': '0',
+			'content-type': 'text/plain; charset=utf-8',
+			connection: 'close' });
 	}
 });


### PR DESCRIPTION
Hi,

I've done a small adjustment in `prom-client`, that you might be interested in merging into main branch.

In my setup, I run Pushgateway through proxy that requires basic client authentication, so I've modified the way requests are being made, to provide auth configuration through Pushgateway URL.

It's just a basic support for the URL format: `https://<username>:<password>@example.org`

Actual implementation just uses the standard NodeJS `url` module to construct HTTP request parameters that are not stripped of username and password parts of URL provided to Pushgateway object constructor.