### PR TITLE
Use hrtime for timing

### DIFF
--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -137,10 +137,10 @@ function setToCurrentTime(labels) {
 function startTimer(startLabels) {
 	var gauge = this;
 	return function() {
-		var start = new Date();
+		var start = process.hrtime();
 		return function(endLabels) {
-			var end = new Date();
-			gauge.set(extend(startLabels || {}, endLabels), (end - start) / 1000);
+			var delta = process.hrtime(start);
+			gauge.set(extend(startLabels || {}, endLabels), delta[0] + delta[1] / 1e9);
 		};
 	};
 }

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -109,10 +109,10 @@ Histogram.prototype.labels = function() {
 function startTimer(startLabels) {
 	var histogram = this;
 	return function() {
-		var start = new Date();
+		var start = process.hrtime();
 		return function(endLabels) {
-			var end = new Date();
-			histogram.observe(extend(startLabels || {}, endLabels), (end - start) / 1000);
+			var delta = process.hrtime(start);
+			histogram.observe(extend(startLabels || {}, endLabels),  delta[0] + delta[1] / 1e9);
 		};
 	};
 }

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -138,10 +138,10 @@ Summary.prototype.labels = function() {
 function startTimer(startLabels) {
 	var summary = this;
 	return function() {
-		var start = new Date();
+		var start = process.hrtime();
 		return function(endLabels) {
-			var end = new Date();
-			summary.observe(extend(startLabels || {}, endLabels), (end - start) / 1000);
+			var delta = process.hrtime(start);
+			summary.observe(extend(startLabels || {}, endLabels),  delta[0] + delta[1] / 1e9);
 		};
 	};
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "mockery": "^2.0.0",
     "nock": "^8.0.0",
     "node-version-check": "^2.1.1",
-    "sinon": "^1.17.2",
+    "sinon": "^2.0.0-pre.5",
     "typescript": "^2.0.3"
   },
   "dependencies": {


### PR DESCRIPTION
Using `new Date()` for timing is susceptible to clock reset issues via
ntp as well as leap seconds, resulting in incorrect or even negative
values. `process.hrtime()` is the recommended method of timing things
in node because it uses monotonic time and is not susceptible to issues
around wall clock resets. It also has the added benefit of being higher
resolution, although that wont really effect histograms/summaries much.

https://nodejs.org/api/process.html#process_process_hrtime_time

I had to use the pre release of sinon 2.x to get the tests to work for
this change, sinon 1.x does not support fake hrtime. As this is
just a dev dependency, I hope this is alright.