### PR TITLE
Include node.js version in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ automatically for you when you do `require('prom-client')`.
 
 NOTE: Some of the metrics, concerning File Descriptors and Memory, are only available on Linux.
 
-In addition, some Node-specific metrics are included, such as event loop lag, and active handles. See what metrics there are in
+In addition, some Node-specific metrics are included, such as event loop lag, active handles and Node.js version. See what metrics there are in
 [lib/metrics](lib/metrics).
 
 The function returned from `defaultMetrics` takes 2 options, a blacklist of metrics to skip, and a timeout for how often the probe should

--- a/lib/defaultMetrics.js
+++ b/lib/defaultMetrics.js
@@ -10,6 +10,7 @@ var processHandles = require('./metrics/processHandles');
 var processRequests = require('./metrics/processRequests');
 var heapSizeAndUsed = require('./metrics/heapSizeAndUsed');
 var heapSpacesSizeAndUsed = require('./metrics/heapSpacesSizeAndUsed');
+var version = require('./metrics/version');
 var register = require('./register');
 
 var metrics = {
@@ -22,7 +23,8 @@ var metrics = {
 	processHandles: processHandles,
 	processRequests: processRequests,
 	heapSizeAndUsed: heapSizeAndUsed,
-	heapSpacesSizeAndUsed: heapSpacesSizeAndUsed
+	heapSpacesSizeAndUsed: heapSpacesSizeAndUsed,
+	version: version
 };
 
 var existingInterval = null;

--- a/lib/metrics/version.js
+++ b/lib/metrics/version.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var Gauge = require('../gauge');
+var version = process.version;
+var versionSegments = version.slice(1).split('.').map(Number);
+
+var NODE_VERSION_INFO = 'nodejs_version_info';
+
+module.exports = function() {
+	var nodeVersionGauge = new Gauge(NODE_VERSION_INFO, 'Node.js version info.', ['version', 'major', 'minor', 'patch']);
+	var isSet = false;
+
+	return function() {
+		if(isSet) {
+			return;
+		}
+		nodeVersionGauge.labels(version, versionSegments[0], versionSegments[1], versionSegments[2]).set(1);
+		isSet = true;
+	};
+};
+
+module.exports.metricNames = [NODE_VERSION_INFO];

--- a/test/metrics/versionTest.js
+++ b/test/metrics/versionTest.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var nodeVersion = process.version;
+var versionSegments = nodeVersion.slice(1).split('.').map(Number);
+
+describe('version', function() {
+	var expect = require('chai').expect;
+	var register = require('../../index').register;
+	var version = require('../../lib/metrics/version');
+
+	before(function() {
+		register.clear();
+	});
+
+	afterEach(function() {
+		register.clear();
+	});
+
+	it('should add metric to the registry', function(done) {
+		expect(register.getMetricsAsJSON()).to.have.length(0);
+		expect(versionSegments[0]).to.be.a('number');
+		expect(versionSegments[1]).to.be.a('number');
+		expect(versionSegments[2]).to.be.a('number');
+
+		version()();
+
+		setTimeout(function() {
+			var metrics = register.getMetricsAsJSON();
+			expect(metrics).to.have.length(1);
+
+			expect(metrics[0].help).to.equal('Node.js version info.');
+			expect(metrics[0].type).to.equal('gauge');
+			expect(metrics[0].name).to.equal('nodejs_version_info');
+			expect(metrics[0].values[0].labels.version).to.equal(nodeVersion);
+			expect(metrics[0].values[0].labels.major).to.equal(versionSegments[0]);
+			expect(metrics[0].values[0].labels.minor).to.equal(versionSegments[1]);
+			expect(metrics[0].values[0].labels.patch).to.equal(versionSegments[2]);
+
+			done();
+		}, 5);
+	});
+});


### PR DESCRIPTION
It'll look like this:

```
# HELP nodejs_version_info Node.js version info.
# TYPE nodejs_version_info gauge
nodejs_version_info{version="v6.10.0",major="6",minor="10",patch="0"} 1
```

Inspired by https://github.com/prometheus/client_java/commit/bdc6f2507a81029c1aec6cd8b5276661bb6c7ee1

Java looks like:

```
# HELP jvm_info JVM version info
# TYPE jvm_info gauge
jvm_info{version="1.8.0_121-b13",vendor="Oracle Corporation",} 1.0
```