### PR TITLE
Fix shadowing of nodejs_heap_size_*_bytes by spaces size

### DIFF
--- a/lib/metrics/heapSpacesSizeAndUsed.js
+++ b/lib/metrics/heapSpacesSizeAndUsed.js
@@ -19,7 +19,7 @@ var METRICS = [
 var NODEJS_HEAP_SIZE = {};
 
 METRICS.forEach(function(metricType) {
-	NODEJS_HEAP_SIZE[metricType] = 'nodejs_heap_size_' + metricType + '_bytes';
+	NODEJS_HEAP_SIZE[metricType] = 'nodejs_heap_space_size_' + metricType + '_bytes';
 });
 
 


### PR DESCRIPTION
I've found out that heap space metrics with labels can shadow simple heap stats. So I think it's better to move them to other "namespace".