### PR TITLE
Fix exception handling for process.memoryUsage()

### DIFF
--- a/lib/metrics/heapSizeAndUsed.js
+++ b/lib/metrics/heapSizeAndUsed.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Gauge = require('../gauge');
+var safeMemoryUsage = require('./helpers/safeMemoryUsage');
 
 var NODEJS_HEAP_SIZE_TOTAL = 'nodejs_heap_size_total_bytes';
 var NODEJS_HEAP_SIZE_USED = 'nodejs_heap_size_used_bytes';
@@ -15,15 +16,14 @@ module.exports = function() {
 	var heapSizeUsed = new Gauge(NODEJS_HEAP_SIZE_USED, 'Process heap size used from node.js in bytes.');
 
 	return function() {
-		// process.memoryUsage() can throw EMFILE errors, see #67
-		try {
-			var memUsage = process.memoryUsage();
+    // process.memoryUsage() can throw EMFILE errors, see #67
+		var memUsage = safeMemoryUsage();
+		if(memUsage) {
 			heapSizeTotal.set(memUsage.heapTotal);
 			heapSizeUsed.set(memUsage.heapUsed);
-		} catch (e) {
 		}
 
-		return { total: heapSizeTotal, used: heapSizeUsed };
+		return {total: heapSizeTotal, used: heapSizeUsed};
 	};
 };
 

--- a/lib/metrics/helpers/safeMemoryUsage.js
+++ b/lib/metrics/helpers/safeMemoryUsage.js
@@ -1,0 +1,14 @@
+'use strict';
+
+function safeMemoryUsage() {
+	var memoryUsage;
+	try {
+		memoryUsage = process.memoryUsage();
+	} catch (ex) {
+
+	}
+
+	return memoryUsage;
+}
+
+module.exports = safeMemoryUsage;

--- a/lib/metrics/osMemoryHeap.js
+++ b/lib/metrics/osMemoryHeap.js
@@ -2,6 +2,7 @@
 
 var Gauge = require('../gauge');
 var linuxVariant = require('./osMemoryHeapLinux');
+var safeMemoryUsage = require('./helpers/safeMemoryUsage');
 
 var PROCESS_RESIDENT_MEMORY = 'process_resident_memory_bytes';
 
@@ -9,10 +10,12 @@ var notLinuxVariant = function() {
 	var residentMemGauge = new Gauge(PROCESS_RESIDENT_MEMORY, 'Resident memory size in bytes.');
 
 	return function() {
-		var memoryUsage = process.memoryUsage();
+		var memUsage = safeMemoryUsage();
 
 		// I don't think the other things returned from `process.memoryUsage()` is relevant to a standard export
-		residentMemGauge.set(null, memoryUsage.rss);
+		if(memUsage) {
+			residentMemGauge.set(null, memUsage.rss);
+		}
 	};
 };
 


### PR DESCRIPTION
According to #67 `process.memoryUsage()` can throw exceptions sometimes. It was handled in one file, but  not in `osMemoryHeap.js`. I've moved wrapped function into separate helper module to use it in both cases.