### PR TITLE
Fix getSingleMetric type and add exported Metric type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,13 +26,18 @@ export interface register {
 	 * Get a single metric
 	 * @param name The name of the metric to remove
 	 */
-	getSingleMetric(name:string): metric
+	getSingleMetric(name:string): Metric
 }
 
 /**
  * The register that contains all metrics
  */
 export const register: register
+
+/**
+* General metric type
+*/
+export type Metric = Counter | Gauge | Summary | Histogram
 
 export enum MetricType {
 	Counter,


### PR DESCRIPTION
I'm sorry, yesterday I've made a PR with "outdated" typing fix (forgot to push correct fix into my fork). Obviously `getSingleMetric` function returns one of Counter, Gauge, Summary or Histogram. For those reasons I've also added export type called `Metric` which corresponds to one of that types. It is very handy when you're writing something in typescript.