### PR TITLE
Throw if there are duplicate default metric names

### DIFF
--- a/lib/defaultMetrics.js
+++ b/lib/defaultMetrics.js
@@ -28,6 +28,9 @@ var metrics = {
 };
 
 var existingInterval = null;
+// This is used to ensure the program throws on duplicate metrics during first run
+// We might want to consider not supporting running the default metrics function more than once
+var init = true;
 
 module.exports = function startDefaultMetrics(disabledMetrics, interval) {
 	if(existingInterval !== null) {
@@ -43,7 +46,9 @@ module.exports = function startDefaultMetrics(disabledMetrics, interval) {
 		})
 		.map(function(metric) {
 			var defaultMetric = metrics[metric];
-			defaultMetric.metricNames.forEach(register.removeSingleMetric);
+			if(!init) {
+				defaultMetric.metricNames.forEach(register.removeSingleMetric);
+			}
 
 			return defaultMetric();
 		});
@@ -57,6 +62,8 @@ module.exports = function startDefaultMetrics(disabledMetrics, interval) {
 	updateAllMetrics();
 
 	existingInterval = setInterval(updateAllMetrics, interval).unref();
+
+	init = false;
 
 	return existingInterval;
 };


### PR DESCRIPTION
See #86 

This currently errors out, because of what #86 is trying to fix. So merging first that then rebasing this should make it green.

I never considered the case where the included metrics could clash when adding the throw...
This change makes the first run add all, and only on subsequent invocations of the function will it clean out the old metric