### PR TITLE
Displaying a single metric as a Prometheus string

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,11 +203,11 @@ You can get all metrics by running `register.metrics()`, which will output a str
 
 ##### Geting a single metric for Prometheus displaying
 
-If you need to output a single metric for Prometheus, you can use `register.getSingleMetric(*name of metric*)`, it will output a string for Prometheus to consume.
+If you need to output a single metric for Prometheus, you can use `register.getSingleMetricAsString(*name of metric*)`, it will output a string for Prometheus to consume.
 
-##### Getting a single metric object
+##### Getting a single metric
 
-If you need to get a reference to a previously registered metric, you can use `register.getSingleMetricObject(*name of metric*)`.
+If you need to get a reference to a previously registered metric, you can use `register.getSingleMetric(*name of metric*)`.
 
 ##### Removing metrics
 
@@ -216,7 +216,7 @@ You can remove all metrics by calling `register.clear()`. You can also remove a 
 
 #### Pushgateway
 
-It is possible to push metrics via a [Pushgateway](https://github.com/prometheus/pushgateway). 
+It is possible to push metrics via a [Pushgateway](https://github.com/prometheus/pushgateway).
 
 ```js
 var client = require('prom-client');
@@ -236,7 +236,7 @@ gateway = new client.Pushgateway('http://127.0.0.1:9091', { timeout: 5000 }); //
 
 #### Utilites
 
-For convenience, there are 2 bucket generator functions - linear and exponential. 
+For convenience, there are 2 bucket generator functions - linear and exponential.
 
 ```js
 var client = require('prom-client');

--- a/README.md
+++ b/README.md
@@ -201,9 +201,13 @@ xhrRequest(function(err, res) {
 
 You can get all metrics by running `register.metrics()`, which will output a string for prometheus to consume.
 
-##### Getting a single metric
+##### Geting a single metric for Prometheus displaying
 
-If you need to get a reference to a previously registered metric, you can use `register.getSingleMetric(*name of metric*)`.
+If you need to output a single metric for Prometheus, you can use `register.getSingleMetric(*name of metric*)`, it will output a string for Prometheus to consume.
+
+##### Getting a single metric object
+
+If you need to get a reference to a previously registered metric, you can use `register.getSingleMetricObject(*name of metric*)`.
 
 ##### Removing metrics
 

--- a/example/server.js
+++ b/example/server.js
@@ -44,7 +44,7 @@ server.get('/metrics', function(req, res) {
 
 server.get('/metrics/counter', function(req, res) {
 	res.set('Content-Type', register.contentType);
-	res.end(register.getSingleMetric('test_counter'));
+	res.end(register.getSingleMetricAsString('test_counter'));
 });
 
 server.listen(3000);

--- a/example/server.js
+++ b/example/server.js
@@ -42,4 +42,9 @@ server.get('/metrics', function(req, res) {
 	res.end(register.metrics());
 });
 
+server.get('/metrics/counter', function(req, res) {
+	res.set('Content-Type', register.contentType);
+	res.end(register.getSingleMetric('test_counter'));
+});
+
 server.listen(3000);

--- a/lib/register.js
+++ b/lib/register.js
@@ -73,11 +73,11 @@ var removeSingleMetric = function removeSingleMetric(name) {
 	delete metrics[name];
 };
 
-var getSingleMetric = function getSingleMetric(name) {
+var getSingleMetricAsString = function getSingleMetricAsString(name) {
 	return getMetricAsPrometheusString(metrics[name]);
 };
 
-var getSingleMetricObject = function getSingleMetricObject(name) {
+var getSingleMetric = function getSingleMetric(name) {
 	return metrics[name];
 };
 
@@ -88,6 +88,6 @@ module.exports = {
 	getMetricsAsJSON: getMetricsAsJSON,
 	removeSingleMetric: removeSingleMetric,
 	getSingleMetric: getSingleMetric,
-	getSingleMetricObject: getSingleMetricObject,
+	getSingleMetricAsString: getSingleMetricAsString,
 	contentType: 'text/plain; version=0.0.4; charset=utf-8'
 };

--- a/lib/register.js
+++ b/lib/register.js
@@ -9,32 +9,36 @@ function getMetricsAsArray() {
 		});
 }
 
-var getMetrics = function getMetrics() {
-	return getMetricsAsArray().reduce(function(acc, metric) {
-		var item = metric.get();
-		var name = escapeString(item.name);
-		var help = escapeString(item.help);
-		help = ['#', 'HELP', name, help].join(' ');
-		var type = ['#', 'TYPE', name, item.type].join(' ');
+function getMetricAsPrometheusString(metric) {
+	var item = metric.get();
+	var name = escapeString(item.name);
+	var help = escapeString(item.help);
+	help = ['#', 'HELP', name, help].join(' ');
+	var type = ['#', 'TYPE', name, item.type].join(' ');
 
-		var values = (item.values || []).reduce(function(valAcc, val) {
-			var labels = Object.keys(val.labels || {}).map(function(key) {
-				return key + '="' + escapeLabelValue(val.labels[key]) + '"';
-			});
+	var values = (item.values || []).reduce(function(valAcc, val) {
+		var labels = Object.keys(val.labels || {}).map(function(key) {
+			return key + '="' + escapeLabelValue(val.labels[key]) + '"';
+		});
 
-			var metricName = val.metricName || item.name;
-			if(labels.length) {
-				metricName += '{' + labels.join(',') + '}';
-			}
+		var metricName = val.metricName || item.name;
+		if(labels.length) {
+			metricName += '{' + labels.join(',') + '}';
+		}
 
-			valAcc += [metricName, val.value].join(' ');
-			valAcc += '\n';
-			return valAcc;
-		}, '');
-
-		acc += [help, type, values].join('\n');
-		return acc;
+		valAcc += [metricName, val.value].join(' ');
+		valAcc += '\n';
+		return valAcc;
 	}, '');
+
+	var acc = [help, type, values].join('\n');
+	return acc;
+}
+
+var getMetrics = function getMetrics() {
+	return getMetricsAsArray()
+		.map(getMetricAsPrometheusString)
+		.join('\n');
 };
 
 function escapeString(str) {
@@ -70,6 +74,10 @@ var removeSingleMetric = function removeSingleMetric(name) {
 };
 
 var getSingleMetric = function getSingleMetric(name) {
+	return getMetricAsPrometheusString(metrics[name]);
+};
+
+var getSingleMetricObject = function getSingleMetricObject(name) {
 	return metrics[name];
 };
 
@@ -80,5 +88,6 @@ module.exports = {
 	getMetricsAsJSON: getMetricsAsJSON,
 	removeSingleMetric: removeSingleMetric,
 	getSingleMetric: getSingleMetric,
+	getSingleMetricObject: getSingleMetricObject,
 	contentType: 'text/plain; version=0.0.4; charset=utf-8'
 };

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -126,7 +126,7 @@ describe('register', function() {
 		var metric = getMetric();
 		register.registerMetric(metric);
 
-		var output = register.getSingleMetric('test_metric');
+		var output = register.getSingleMetricObject('test_metric');
 		expect(output).to.equal(metric);
 	});
 

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -126,7 +126,7 @@ describe('register', function() {
 		var metric = getMetric();
 		register.registerMetric(metric);
 
-		var output = register.getSingleMetricObject('test_metric');
+		var output = register.getSingleMetric('test_metric');
 		expect(output).to.equal(metric);
 	});
 


### PR DESCRIPTION
I've recently faced an issue: I needed to display 2 different metrics on 2 different endpoints (they would be fetched with two different intervals by Prometheus). `prom-client` doesn't provide a way to get a single metric as a Prometheus string. So I've implemented it.

I changed a `register.getSingleMetric()` to return a Prometheus string, added `register.getSingleMetricObject()` to get metric by name (instead of `register.getSingleMetric()`), provided an example of these changes and README entry for them and fixed tests to reflect these changes.

There would be 1 breaking change (the `register.getSingleMetric()` would return a string instead of an object), I think my naming is better (if you have other ideas how to name methods, please tell).