### PR TITLE
Add file with disabled default metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ clearInterval(client.defaultMetrics());
 client.register.clear();
 ```
 
+Also you can require file `noDefaultMetrics` instead. It doesn't contain default metrics:
+
+```js
+var client = require('prom-client/noDefaultMetrics');
+```
+
 #### Counter
 
 Counters go up, and reset when the process restarts.

--- a/noDefaultMetrics.js
+++ b/noDefaultMetrics.js
@@ -1,0 +1,18 @@
+/**
+ * Prometheus client
+ * @module Prometheus client
+ */
+
+'use strict';
+
+exports.register = require('./lib/register');
+exports.contentType = require('./lib/register').contentType;
+
+exports.Counter = require('./lib/counter');
+exports.Gauge = require('./lib/gauge');
+exports.Histogram = require('./lib/histogram');
+exports.Summary = require('./lib/summary');
+exports.Pushgateway = require('./lib/pushgateway');
+
+exports.linearBuckets = require('./lib/bucketGenerators').linearBuckets;
+exports.exponentialBuckets = require('./lib/bucketGenerators').exponentialBuckets;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "files": [
     "lib/",
     "index.js",
-    "index.d.ts"
+    "index.d.ts",
+    "noDefaultMetrics.js"
   ],
   "directories": {
     "test": "test"


### PR DESCRIPTION
I've added a file that contains all exports from `index.js` excluding default metrics. It will be useful in modules like `node-prometheus-gc-stats` when those metrics aren't needed. I think that enabling collection of default metrics upon require is not good for using client library in some custom modules, because it will create useless metrics in registry.

Probably later it will be better to allow users manually trigger start of default metrics (including creation of proper gauges, counters, etc. in register) by calling some method. But it will be definitely breaking change, so for now this PR should give an option to users easily use client without default metrics.

Also I can modify `index.js` and add require of `noDefaultMetrics` to avoid copy-paste. WDYT?