### PR TITLE
Non-global registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,16 +212,14 @@ counter.inc(1, new Date()); // Increment counter with timestamp
 By default, metrics are automatically registered to the global registry (located at `require('prom-client').register`).
 You can prevent this by setting last parameter when creating the metric to `false` (depending on metric, this might be 4th or 5th parameter).
 
-Using non-global registries requires creating Registry instance and calling `registry.registerMetric(metricInstance)`.
+Using non-global registries requires creating Registry instance and adding it inside `registers` inside the configuration object. Alternatively
+you can pass an empty `registers` array and register it manually.
 
 ```js
 var client = require('prom-client');
 var registry = new client.Registry();
-var counter = new client.Counter('metric_name', 'metric_help');
-var histogram = new client.Histogram('metric_name', 'metric_help', [ 'status_code' ], {
-	buckets: [ 0.10, 5, 15, 50, 100, 500 ]
-}, false);
-registry.registerMetric(counter);
+var counter = new client.Counter({name: 'metric_name', help: 'metric_help', registers: [ registry ]});
+var histogram = new client.Histogram({name: 'metric_name', help: 'metric_help', registers: [ ]});
 registry.registerMetric(histogram);
 counter.inc();
 ```
@@ -269,15 +267,15 @@ For convenience, there are 2 bucket generator functions - linear and exponential
 
 ```js
 var client = require('prom-client');
-new client.Histogram({ 
-	name: 'metric_name', 
+new client.Histogram({
+	name: 'metric_name',
 	help: 'metric_help',
 	buckets: client.linearBuckets(0, 10, 20) //Create 20 buckets, starting on 0 and a width of 10
 });
 
-new client.Histogram({ 
+new client.Histogram({
 	name: 'metric_name',
-	help: 'metric_help', 
+	help: 'metric_help',
 	buckets: client.exponentialBuckets(1, 2, 5) //Create 5 buckets, starting on 1 and with a factor of 2
 });
 ```

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ xhrRequest(function(err, res) {
 
 #### Histogram
 
-Histograms track sizes and frequency of events.  
+Histograms track sizes and frequency of events.
 
 **Configuration**
 
@@ -199,7 +199,7 @@ xhrRequest(function(err, res) {
 
 #### Timestamps
 
-Counter and gauge metrics can take a timestamp argument after the value argument. 
+Counter and gauge metrics can take a timestamp argument after the value argument.
 This argument must be a Date or a number (milliseconds since Unix epoch, i.e. 1970-01-01 00:00:00 UTC, excluding leap seconds).
 
 ```js
@@ -210,6 +210,25 @@ gauge.labels('GET', '200').set(100, new Date()); // Same as above
 
 counter.inc(1, new Date()); // Increment counter with timestamp
 
+```
+
+#### Multiple registries
+
+By default, metrics are automatically registered to the global registry (located at `require('prom-client').register`).
+You can prevent this by setting last parameter when creating the metric to `false` (depending on metric, this might be 4th or 5th parameter).
+
+Using non-global registries requires creating Registry instance and calling `registry.registerMetric(metricInstance)`.
+
+```js
+var client = require('prom-client');
+var registry = new client.Registry();
+var counter = new client.Counter('metric_name', 'metric_help');
+var histogram = new client.Histogram('metric_name', 'metric_help', [ 'status_code' ], {
+	buckets: [ 0.10, 5, 15, 50, 100, 500 ]
+}, false);
+registry.registerMetric(counter);
+registry.registerMetric(histogram);
+counter.inc();
 ```
 
 #### Register

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@
 /**
  * Container for all registered metrics
  */
-export interface Registry {
+export class Registry {
 	/**
 	 * Get string representation for all metrics
 	 */
@@ -63,7 +63,8 @@ interface labelValues {
 export interface CounterConfiguration {
 	name: string,
 	help: string,
-	labels: string []
+	labels: string [],
+	register: Registry[]
 }
 
 /**
@@ -80,9 +81,8 @@ export class Counter {
 	 * @param name The name of the metric
 	 * @param help Help description
 	 * @param labels Label keys
-	 * @param register Register to default registry
 	 */
-	constructor(name: string, help: string, labels?: string[], register?: boolean)
+	constructor(name: string, help: string, labels?: string[])
 
 	/**
 	 * Increment for given labels
@@ -123,7 +123,8 @@ export namespace Counter {
 export interface GaugeConfiguration{
 	name: string,
 	help: string,
-	labels: string[]
+	labels: string[],
+	register: Registry[]
 }
 
 /**
@@ -140,9 +141,8 @@ export class Gauge {
 	 * @param name The name of the metric
 	 * @param help Help description
 	 * @param labels Label keys
-	 * @param register Register to default registry
 	 */
-	constructor(name: string, help: string, labels?: string[], register?: boolean)
+	constructor(name: string, help: string, labels?: string[])
 
 	/**
 	 * Increment gauge for given labels
@@ -250,7 +250,8 @@ export interface HistogramConfiguration {
 	name: string,
 	help: string,
 	labels: string[],
-	buckets: number[]
+	buckets: number[],
+	register: Registry[]
 }
 
 /**
@@ -268,9 +269,8 @@ export class Histogram {
 	 * @param help Help description
 	 * @param labels Label keys
 	 * @param config Configuration object for Histograms
-	 * @param register Register to default registry
 	 */
-	constructor(name: string, help: string, labels?: string[], config?: Histogram.Config, register?: boolean)
+	constructor(name: string, help: string, labels?: string[], config?: Histogram.Config)
 	/**
 	 * @param name The name of metric
 	 * @param help Help description
@@ -334,7 +334,8 @@ export interface SummaryConfiguration{
 	name: string,
 	help: string,
 	labels: string[]
-	percentiles: number[]
+	percentiles: number[],
+	register: Registry[]
 }
 
 /**
@@ -352,9 +353,8 @@ export class Summary {
 	 * @param help Help description
 	 * @param labels Label keys
 	 * @param config Configuration object
-	 * @param register Register to default registry
 	 */
-	constructor(name: string, help: string, labels?: string[], config?: Summary.Config, register?: boolean)
+	constructor(name: string, help: string, labels?: string[], config?: Summary.Config)
 	/**
 	 * @param name The name of the metric
 	 * @param help Help description

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@
 /**
  * Container for all registered metrics
  */
-export interface register {
+export interface Registry {
 	/**
 	 * Get string representation for all metrics
 	 */
@@ -37,7 +37,7 @@ export interface register {
 /**
  * The register that contains all metrics
  */
-export const register: register
+export const register: Registry
 
 /**
 * General metric type
@@ -68,8 +68,9 @@ export class Counter {
 	 * @param name The name of the metric
 	 * @param help Help description
 	 * @param labels Label keys
+	 * @param register Register to default registry
 	 */
-	constructor(name: string, help: string, labels?: string[])
+	constructor(name: string, help: string, labels?: string[], register?: boolean)
 
 	/**
 	 * Increment for given labels
@@ -112,8 +113,9 @@ export class Gauge {
 	 * @param name The name of the metric
 	 * @param help Help description
 	 * @param labels Label keys
+	 * @param register Register to default registry
 	 */
-	constructor(name: string, help: string, labels?: string[])
+	constructor(name: string, help: string, labels?: string[], register?: boolean)
 
 	/**
 	 * Increment gauge for given labels
@@ -218,8 +220,9 @@ export class Histogram {
 	 * @param help Help description
 	 * @param labels Label keys
 	 * @param config Configuration object for Histograms
+	 * @param register Register to default registry
 	 */
-	constructor(name: string, help: string, labels?: string[], config?: Histogram.Config)
+	constructor(name: string, help: string, labels?: string[], config?: Histogram.Config, register?: boolean)
 	/**
 	 * @param name The name of metric
 	 * @param help Help description
@@ -288,8 +291,9 @@ export class Summary {
 	 * @param help Help description
 	 * @param labels Label keys
 	 * @param config Configuration object
+	 * @param register Register to default registry
 	 */
-	constructor(name: string, help: string, labels?: string[], config?: Summary.Config)
+	constructor(name: string, help: string, labels?: string[], config?: Summary.Config, register?: boolean)
 	/**
 	 * @param name The name of the metric
 	 * @param help Help description
@@ -356,8 +360,9 @@ export namespace Summary {
 export class Pushgateway {
 	/**
 	 * @param url Complete url to the Pushgateway. If port is needed append url with :port
+	 * @param registry Registry
 	 */
-	constructor(url: string)
+	constructor(url: string, registry?: Registry)
 
 	/**
 	 * Add metric and overwrite old ones

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,7 +64,7 @@ export interface CounterConfiguration {
 	name: string,
 	help: string,
 	labels: string [],
-	register: Registry[]
+	registers: Registry[]
 }
 
 /**
@@ -124,7 +124,7 @@ export interface GaugeConfiguration{
 	name: string,
 	help: string,
 	labels: string[],
-	register: Registry[]
+	registers: Registry[]
 }
 
 /**
@@ -251,7 +251,7 @@ export interface HistogramConfiguration {
 	help: string,
 	labels: string[],
 	buckets: number[],
-	register: Registry[]
+	registers: Registry[]
 }
 
 /**
@@ -335,7 +335,7 @@ export interface SummaryConfiguration{
 	help: string,
 	labels: string[]
 	percentiles: number[],
-	register: Registry[]
+	registers: Registry[]
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@
 'use strict';
 
 exports.register = require('./lib/register');
+exports.Registry = require('./lib/registry');
 exports.contentType = require('./lib/register').contentType;
 
 exports.Counter = require('./lib/counter');

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -2,7 +2,7 @@
  * Counter metric
  */
 'use strict';
-var register = require('./register');
+var registry = require('./register');
 var type = 'counter';
 var isNumber = require('./util').isNumber;
 var isDate = require('./util').isDate;
@@ -19,9 +19,10 @@ var getLabels = require('./util').getLabels;
  * @param {string} name - Name of the metric
  * @param {string} help - Help description for the metric
  * @param {Array.<string>} labels - Labels
+ * @param {object} register - Register to default registry
  * @constructor
  */
-function Counter(name, help, labels) {
+function Counter(name, help, labels, register) {
 	if(!help) {
 		throw new Error('Missing mandatory help parameter');
 	}
@@ -35,13 +36,21 @@ function Counter(name, help, labels) {
 	if(!validateLabelNames(labels)) {
 		throw new Error('Invalid label name');
 	}
+
+	if(register === undefined) {
+		register = true;
+	}
+
 	this.name = name;
 	this.hashMap = {};
 
 	this.labelNames = (labels || []);
 
 	this.help = help;
-	register.registerMetric(this);
+	if(register) {
+		registry.registerMetric(this);
+	}
+	return this;
 }
 
 /**

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -28,12 +28,8 @@ function Counter(name, help, labels) {
 	if(isObject(name)) {
 		config = extend({
 			labelNames: [],
+			registers: [ globalRegistry ]
 		}, name);
-		if(name.registers !== undefined) {
-			config.registers = name.registers;
-		} else {
-			config.registers = [ globalRegistry ];
-		}
 	} else {
 		//Backwards compability - will be depricated
 		config = {

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -2,7 +2,7 @@
  * Counter metric
  */
 'use strict';
-var registry = require('./register');
+var globalRegistry = require('./register');
 var type = 'counter';
 var isNumber = require('./util').isNumber;
 var isDate = require('./util').isDate;
@@ -32,7 +32,7 @@ function Counter(name, help, labels) {
 		if(name.registers !== undefined) {
 			config.registers = name.registers;
 		} else {
-			config.registers = [ registry ];
+			config.registers = [ globalRegistry ];
 		}
 	} else {
 		//Backwards compability - will be depricated
@@ -40,7 +40,7 @@ function Counter(name, help, labels) {
 			name: name,
 			help: help,
 			labelNames: labels,
-			registers: [ registry ]
+			registers: [ globalRegistry ]
 		};
 	}
 
@@ -67,8 +67,8 @@ function Counter(name, help, labels) {
 	this.help = config.help;
 
 	var metric = this;
-	config.registers.forEach(function(registerFromConfig) {
-		registerFromConfig.registerMetric(metric);
+	config.registers.forEach(function(registryInstance) {
+		registryInstance.registerMetric(metric);
 	});
 }
 

--- a/lib/defaultMetrics.js
+++ b/lib/defaultMetrics.js
@@ -47,7 +47,7 @@ module.exports = function startDefaultMetrics(disabledMetrics, interval) {
 		.map(function(metric) {
 			var defaultMetric = metrics[metric];
 			if(!init) {
-				defaultMetric.metricNames.forEach(register.removeSingleMetric);
+				defaultMetric.metricNames.map(register.removeSingleMetric, register);
 			}
 
 			return defaultMetric();

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -3,7 +3,7 @@
  */
 'use strict';
 
-var register = require('./register');
+var registry = require('./register');
 var type = 'gauge';
 
 var isNumber = require('./util').isNumber;
@@ -22,9 +22,15 @@ var validateLabelNames = require('./validation').validateLabelName;
  * @param {string} name - Name of the metric
  * @param {string} help - Help for the metric
  * @param {Array.<string>} labels - Array with strings, all label keywords supported
+ * @param {bool} register - Register to default registry
  * @constructor
  */
-function Gauge(name, help, labels) {
+function Gauge(name, help, labels, register) {
+
+	if(register === undefined) {
+		register = true;
+	}
+
 	if(!help) {
 		throw new Error('Missing mandatory help parameter');
 	}
@@ -43,7 +49,10 @@ function Gauge(name, help, labels) {
 	this.hashMap = {};
 
 	this.help = help;
-	register.registerMetric(this);
+	if(register) {
+		registry.registerMetric(this);
+	}
+	return this;
 }
 
 /**

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -3,7 +3,7 @@
  */
 'use strict';
 
-var registry = require('./register');
+var globalRegistry = require('./register');
 var type = 'gauge';
 
 var isNumber = require('./util').isNumber;
@@ -35,14 +35,14 @@ function Gauge(name, help, labels) {
 		if(name.registers !== undefined) {
 			config.registers = name.registers;
 		} else {
-			config.registers = [ registry ];
+			config.registers = [ globalRegistry ];
 		}
 	} else {
 		config = {
 			name: name,
 			help: help,
 			labelNames: labels,
-			registers: [ registry ]
+			registers: [ globalRegistry ]
 		};
 	}
 
@@ -65,8 +65,8 @@ function Gauge(name, help, labels) {
 	this.help = config.help;
 
 	var metric = this;
-	config.registers.forEach(function(registerFromConfig) {
-		registerFromConfig.registerMetric(metric);
+	config.registers.forEach(function(registryInstance) {
+		registryInstance.registerMetric(metric);
 	});
 }
 

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -31,12 +31,8 @@ function Gauge(name, help, labels) {
 	if(isObject(name)) {
 		config = extend({
 			labelNames: [],
+			registers: [ globalRegistry ],
 		}, name);
-		if(name.registers !== undefined) {
-			config.registers = name.registers;
-		} else {
-			config.registers = [ globalRegistry ];
-		}
 	} else {
 		config = {
 			name: name,

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -30,12 +30,8 @@ function Histogram(name, help, labelsOrConf, conf) {
 		config = extend( {
 			buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
 			labelNames: [],
+			registers: [ globalRegistry ],
 		}, name);
-		if(name.registers !== undefined) {
-			config.registers = name.registers;
-		} else {
-			config.registers = [ globalRegistry ];
-		}
 	} else {
 		var obj;
 		var labels = [];

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -3,7 +3,7 @@
  */
 'use strict';
 
-var register = require('./register');
+var registry = require('./register');
 var type = 'histogram';
 var isNumber = require('./util').isNumber;
 var extend = require('util-extend');
@@ -20,11 +20,16 @@ var validateLabelNames = require('./validation').validateLabelName;
  * @param {string} help - Help for the metric
  * @param {object|Array.<string>} labelsOrConf - Either array of label names or config object as a key-value object
  * @param {object} conf - Configuration object
+ * @param {bool} register - Register to default registry
  * @constructor
  */
-function Histogram(name, help, labelsOrConf, conf) {
+function Histogram(name, help, labelsOrConf, conf, register) {
 	var obj;
 	var labels = [];
+
+	if(register === undefined) {
+		register = true;
+	}
 
 	if(Array.isArray(labelsOrConf)) {
 		obj = conf || {};
@@ -32,7 +37,6 @@ function Histogram(name, help, labelsOrConf, conf) {
 	} else {
 		obj = labelsOrConf || {};
 	}
-
 	validateInput(name, help, labels);
 
 	this.name = name;
@@ -51,7 +55,10 @@ function Histogram(name, help, labelsOrConf, conf) {
 
 	this.hashMap = {};
 	this.labelNames = labels || [];
-	register.registerMetric(this);
+	if(register) {
+		registry.registerMetric(this);
+	}
+	return this;
 }
 
 /**

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -3,7 +3,7 @@
  */
 'use strict';
 
-var register = require('./register');
+var globalRegistry = require('./register');
 var type = 'histogram';
 var isNumber = require('./util').isNumber;
 var extend = require('util-extend');
@@ -34,7 +34,7 @@ function Histogram(name, help, labelsOrConf, conf) {
 		if(name.registers !== undefined) {
 			config.registers = name.registers;
 		} else {
-			config.registers = [ register ];
+			config.registers = [ globalRegistry ];
 		}
 	} else {
 		var obj;
@@ -52,7 +52,7 @@ function Histogram(name, help, labelsOrConf, conf) {
 			labelNames: labels,
 			help: help,
 			buckets: configureUpperbounds(obj.buckets),
-			registers: [ register ]
+			registers: [ globalRegistry ]
 		};
 	}
 	validateInput(config.name, config.help, config.labelNames);
@@ -75,8 +75,8 @@ function Histogram(name, help, labelsOrConf, conf) {
 	this.labelNames = config.labelNames || [];
 
 	var metric = this;
-	config.registers.forEach(function(registerFromConfig) {
-		registerFromConfig.registerMetric(metric);
+	config.registers.forEach(function(registryInstance) {
+		registryInstance.registerMetric(metric);
 	});
 }
 

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -5,7 +5,11 @@ var http = require('http');
 var https = require('https');
 var register = require('./register');
 
-function Pushgateway(gatewayUrl, options) {
+function Pushgateway(gatewayUrl, options, registry) {
+	if(!registry) {
+		registry = register;
+	}
+	this.registry = registry;
 	this.gatewayUrl = gatewayUrl;
 	this.requestOptions = Object.assign({}, options);
 }
@@ -58,7 +62,7 @@ function useGateway(method, job, groupings, callback) {
 	});
 
 	if(method !== 'DELETE') {
-		req.write(register.metrics());
+		req.write(this.registry.metrics());
 	}
 	req.end();
 }

--- a/lib/register.js
+++ b/lib/register.js
@@ -1,93 +1,26 @@
 'use strict';
+var Registry = require('./registry');
 
-var metrics = {};
-
-function getMetricsAsArray() {
-	return Object.keys(metrics)
-		.map(function(key) {
-			return metrics[key];
-		});
+function isFunction(functionToCheck) {
+	var getType = {};
+	return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]';
 }
+// Singleton instance to keep backwards compatibility
+var _registry = new Registry();
+var wrapper = {};
 
-function getMetricAsPrometheusString(metric) {
-	var item = metric.get();
-	var name = escapeString(item.name);
-	var help = escapeString(item.help);
-	help = ['#', 'HELP', name, help].join(' ');
-	var type = ['#', 'TYPE', name, item.type].join(' ');
-
-	var values = (item.values || []).reduce(function(valAcc, val) {
-		var labels = Object.keys(val.labels || {}).map(function(key) {
-			return key + '="' + escapeLabelValue(val.labels[key]) + '"';
-		});
-
-		var metricName = val.metricName || item.name;
-		if(labels.length) {
-			metricName += '{' + labels.join(',') + '}';
-		}
-
-		valAcc += [metricName, val.value, val.timestamp].join(' ').trim();
-		valAcc += '\n';
-		return valAcc;
-	}, '');
-
-	var acc = [help, type, values].join('\n');
-	return acc;
-}
-
-var getMetrics = function getMetrics() {
-	return getMetricsAsArray()
-		.map(getMetricAsPrometheusString)
-		.join('\n');
+// Wrapper function to keep "this" context in Registry
+var wrapFunction = function(fn){
+	return function(){
+		return fn.apply(this, arguments);
+	};
 };
 
-function escapeString(str) {
-	return str.replace(/\n/g, '\\n').replace(/\\(?!n)/g, '\\\\');
-}
-function escapeLabelValue(str) {
-	if(typeof str !== 'string') {
-		return str;
+for(var prop in _registry) {
+	if(isFunction(_registry[prop])) {
+		wrapper[prop] = wrapFunction.call(_registry, _registry[prop]);
+	} else {
+		wrapper[prop] = _registry[prop];
 	}
-	return escapeString(str).replace(/"/g, '\\"');
 }
-
-var registerMetric = function registerMetric(metricFn) {
-	if(metrics[metricFn.name]) {
-		throw new Error('A metric with the name ' + metricFn.name + ' has already been registered.');
-	}
-
-	metrics[metricFn.name] = metricFn;
-};
-
-var clearMetrics = function clearMetrics() {
-	metrics = {};
-};
-
-var getMetricsAsJSON = function getMetricsAsJSON() {
-	return getMetricsAsArray().map(function(metric) {
-		return metric.get();
-	});
-};
-
-var removeSingleMetric = function removeSingleMetric(name) {
-	delete metrics[name];
-};
-
-var getSingleMetricAsString = function getSingleMetricAsString(name) {
-	return getMetricAsPrometheusString(metrics[name]);
-};
-
-var getSingleMetric = function getSingleMetric(name) {
-	return metrics[name];
-};
-
-module.exports = {
-	registerMetric: registerMetric,
-	metrics: getMetrics,
-	clear: clearMetrics,
-	getMetricsAsJSON: getMetricsAsJSON,
-	removeSingleMetric: removeSingleMetric,
-	getSingleMetric: getSingleMetric,
-	getSingleMetricAsString: getSingleMetricAsString,
-	contentType: 'text/plain; version=0.0.4; charset=utf-8'
-};
+module.exports = wrapper;

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,0 +1,89 @@
+'use strict';
+
+function escapeString(str) {
+	return str.replace(/\n/g, '\\n').replace(/\\(?!n)/g, '\\\\');
+}
+function escapeLabelValue(str) {
+	if(typeof str !== 'string') {
+		return str;
+	}
+	return escapeString(str).replace(/"/g, '\\"');
+}
+var registry = (function() {
+	var _metrics = {};
+	var self;
+	function Registry() {
+		self = this;
+	}
+
+	var getMetricsAsArray = function() {
+		return Object.keys(_metrics)
+			.map(self.getSingleMetric, self);
+	};
+
+	Registry.prototype.getMetricAsPrometheusString = function(metric) {
+		var item = metric.get();
+		var name = escapeString(item.name);
+		var help = escapeString(item.help);
+		help = ['#', 'HELP', name, help].join(' ');
+		var type = ['#', 'TYPE', name, item.type].join(' ');
+
+		var values = (item.values || []).reduce(function(valAcc, val) {
+			var labels = Object.keys(val.labels || {}).map(function(key) {
+				return key + '="' + escapeLabelValue(val.labels[key]) + '"';
+			});
+
+			var metricName = val.metricName || item.name;
+			if(labels.length) {
+				metricName += '{' + labels.join(',') + '}';
+			}
+
+			valAcc += [metricName, val.value, val.timestamp].join(' ').trim();
+			valAcc += '\n';
+			return valAcc;
+		}, '');
+
+		var acc = [help, type, values].join('\n');
+		return acc;
+	};
+
+	Registry.prototype.metrics = function() {
+		return getMetricsAsArray()
+			.map(this.getMetricAsPrometheusString, this)
+			.join('\n');
+	};
+
+	Registry.prototype.registerMetric = function(metricFn) {
+		if(_metrics[metricFn.name]) {
+			throw new Error('A metric with the name ' + metricFn.name + ' has already been registered.');
+		}
+
+		_metrics[metricFn.name] = metricFn;
+	};
+
+	Registry.prototype.clear = function() {
+		_metrics = {};
+	};
+
+	Registry.prototype.getMetricsAsJSON = function() {
+		return getMetricsAsArray().map(function(metric) {
+			return metric.get();
+		});
+	};
+
+	Registry.prototype.removeSingleMetric = function(name) {
+		delete _metrics[name];
+	};
+
+	Registry.prototype.getSingleMetricAsString = function(name) {
+		return this.getMetricAsPrometheusString(_metrics[name]);
+	};
+
+	Registry.prototype.getSingleMetric = function(name) {
+		return _metrics[name];
+	};
+
+	Registry.prototype.contentType = 'text/plain; version=0.0.4; charset=utf-8';
+	return new Registry();
+});
+module.exports = registry;

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -31,12 +31,8 @@ function Summary(name, help, labelsOrConf, conf) {
 		config = extend({
 			percentiles: [0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999],
 			labelNames: [],
+			registers: [ globalRegistry ],
 		}, name);
-		if(name.registers !== undefined) {
-			config.registers = name.registers;
-		} else {
-			config.registers = [ globalRegistry ];
-		}
 	} else {
 		var obj;
 		var labels = [];

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -3,7 +3,7 @@
  */
 'use strict';
 
-var register = require('./register');
+var globalRegistry = require('./register');
 var type = 'summary';
 var isNumber = require('./util').isNumber;
 var extend = require('util-extend');
@@ -35,7 +35,7 @@ function Summary(name, help, labelsOrConf, conf) {
 		if(name.registers !== undefined) {
 			config.registers = name.registers;
 		} else {
-			config.registers = [ register ];
+			config.registers = [ globalRegistry ];
 		}
 	} else {
 		var obj;
@@ -53,7 +53,7 @@ function Summary(name, help, labelsOrConf, conf) {
 			help: help,
 			labelNames: labels,
 			percentiles: configurePercentiles(obj.percentiles),
-			registers: [ register ]
+			registers: [ globalRegistry ]
 		};
 	}
 
@@ -67,8 +67,8 @@ function Summary(name, help, labelsOrConf, conf) {
 	this.labelNames = config.labelNames || [];
 
 	var metric = this;
-	config.registers.forEach(function(registerFromConfig) {
-		registerFromConfig.registerMetric(metric);
+	config.registers.forEach(function(registryInstance) {
+		registryInstance.registerMetric(metric);
 	});
 }
 

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -3,7 +3,7 @@
  */
 'use strict';
 
-var register = require('./register');
+var registry = require('./register');
 var type = 'summary';
 var isNumber = require('./util').isNumber;
 var extend = require('util-extend');
@@ -21,11 +21,16 @@ var TDigest = require('tdigest').TDigest;
  * @param {string} help - Help for the metric
  * @param {object|Array.<string>} labelsOrConf - Either array of label names or config object as a key-value object
  * @param {object} conf - Configuration object
+ * @param {bool} register - Register to default registry
  * @constructor
  */
-function Summary(name, help, labelsOrConf, conf) {
+function Summary(name, help, labelsOrConf, conf, register) {
 	var obj;
 	var labels = [];
+
+	if(register === undefined) {
+		register = true;
+	}
 
 	if(Array.isArray(labelsOrConf)) {
 		obj = conf || {};
@@ -42,7 +47,10 @@ function Summary(name, help, labelsOrConf, conf) {
 	this.percentiles = configurePercentiles(obj.percentiles);
 	this.hashMap = {};
 	this.labelNames = labels || [];
-	register.registerMetric(this);
+	if(register) {
+		registry.registerMetric(this);
+	}
+	return this;
 }
 
 /**

--- a/test/counterTest.js
+++ b/test/counterTest.js
@@ -3,7 +3,7 @@
 describe('counter', function() {
 	var Counter = require('../index').Counter;
 	var Registry = require('../index').Registry;
-	var register = require('../index').register;
+	var globalRegistry = require('../index').register;
 	var expect = require('chai').expect;
 	var instance;
 
@@ -15,7 +15,7 @@ describe('counter', function() {
 			});
 
 			afterEach(function() {
-				register.clear();
+				globalRegistry.clear();
 			});
 			it('should increment counter', function() {
 				instance.inc();
@@ -102,7 +102,7 @@ describe('counter', function() {
 			instance = new Counter({ name: 'gauge_test', help: 'test' });
 		});
 		afterEach(function() {
-			register.clear();
+			globalRegistry.clear();
 		});
 
 		it('should increment counter', function() {
@@ -191,21 +191,21 @@ describe('counter', function() {
 		});
 		it('should increment counter', function() {
 			instance.inc();
-			expect(register.getMetricsAsJSON().length).to.equal(0);
+			expect(globalRegistry.getMetricsAsJSON().length).to.equal(0);
 			expect(instance.get().values[0].value).to.equal(1);
 			expect(instance.get().values[0].timestamp).to.equal(undefined);
 		});
 	});
 	describe('registry instance', function() {
-		var registry;
+		var registryInstance;
 		beforeEach(function() {
-			registry = new Registry();
-			instance = new Counter({ name: 'gauge_test', help: 'test', registers: [ registry ] });
+			registryInstance = new Registry();
+			instance = new Counter({ name: 'gauge_test', help: 'test', registers: [ registryInstance ] });
 		});
 		it('should increment counter', function() {
 			instance.inc();
-			expect(register.getMetricsAsJSON().length).to.equal(0);
-			expect(registry.getMetricsAsJSON().length).to.equal(1);
+			expect(globalRegistry.getMetricsAsJSON().length).to.equal(0);
+			expect(registryInstance.getMetricsAsJSON().length).to.equal(1);
 			expect(instance.get().values[0].value).to.equal(1);
 			expect(instance.get().values[0].timestamp).to.equal(undefined);
 		});

--- a/test/counterTest.js
+++ b/test/counterTest.js
@@ -2,88 +2,118 @@
 
 describe('counter', function() {
 	var Counter = require('../index').Counter;
+	var Registry = require('../index').Registry;
 	var register = require('../index').register;
 	var expect = require('chai').expect;
 	var instance;
 
-	beforeEach(function() {
-		instance = new Counter('gauge_test', 'test');
-	});
+	describe('global registry', function() {
 
-	afterEach(function() {
-		register.clear();
-	});
-
-	it('should increment counter', function() {
-		instance.inc();
-		expect(instance.get().values[0].value).to.equal(1);
-		expect(instance.get().values[0].timestamp).to.equal(undefined);
-	});
-	it('should increment with a provided value', function() {
-		instance.inc(100);
-		expect(instance.get().values[0].value).to.equal(100);
-		expect(instance.get().values[0].timestamp).to.equal(undefined);
-	});
-	it('should increment with a provided value and timestamp', function() {
-		instance.inc(100, 1485392700000);
-		expect(instance.get().values[0].value).to.equal(100);
-		expect(instance.get().values[0].timestamp).to.equal(1485392700000);
-	});
-	it('should not allow non number as timestamp', function() {
-		var fn = function() {
-			instance.inc(1, 'blah');
-		};
-		expect(fn).to.throw(Error);
-	});
-	it('should not allow invalid date as timestamp', function() {
-		var fn = function() {
-			instance.inc(1, new Date('blah'));
-		};
-		expect(fn).to.throw(Error);
-	});
-	it('should not be possible to decrease a counter', function() {
-		var fn = function() {
-			instance.inc(-100);
-		};
-		expect(fn).to.throw(Error);
-	});
-	it('should handle incrementing with 0', function() {
-		instance.inc(0);
-		expect(instance.get().values[0].value).to.equal(0);
-	});
-
-	describe('labels', function() {
 		beforeEach(function() {
-			instance = new Counter('gauge_test_2', 'help', [ 'method', 'endpoint']);
+			instance = new Counter('gauge_test', 'test');
 		});
 
-		it('should handle 1 value per label', function() {
-			instance.labels('GET', '/test').inc();
-			instance.labels('POST', '/test').inc();
-
-			var values = instance.get().values;
-			expect(values).to.have.length(2);
+		afterEach(function() {
+			register.clear();
 		});
 
-		it('should handle labels which are provided as arguments to inc()', function() {
-			instance.inc({method: 'GET', endpoint: '/test'});
-			instance.inc({method: 'POST', endpoint: '/test'});
-
-			var values = instance.get().values;
-			expect(values).to.have.length(2);
+		it('should increment counter', function() {
+			instance.inc();
+			expect(instance.get().values[0].value).to.equal(1);
+			expect(instance.get().values[0].timestamp).to.equal(undefined);
 		});
-
-		it('should throw error if label lengths does not match', function() {
+		it('should increment with a provided value', function() {
+			instance.inc(100);
+			expect(instance.get().values[0].value).to.equal(100);
+			expect(instance.get().values[0].timestamp).to.equal(undefined);
+		});
+		it('should increment with a provided value and timestamp', function() {
+			instance.inc(100, 1485392700000);
+			expect(instance.get().values[0].value).to.equal(100);
+			expect(instance.get().values[0].timestamp).to.equal(1485392700000);
+		});
+		it('should not allow non number as timestamp', function() {
 			var fn = function() {
-				instance.labels('GET').inc();
+				instance.inc(1, 'blah');
 			};
 			expect(fn).to.throw(Error);
 		});
+		it('should not allow invalid date as timestamp', function() {
+			var fn = function() {
+				instance.inc(1, new Date('blah'));
+			};
+			expect(fn).to.throw(Error);
+		});
+		it('should not be possible to decrease a counter', function() {
+			var fn = function() {
+				instance.inc(-100);
+			};
+			expect(fn).to.throw(Error);
+		});
+		it('should handle incrementing with 0', function() {
+			instance.inc(0);
+			expect(instance.get().values[0].value).to.equal(0);
+		});
 
-		it('should increment label value with provided value', function() {
-			instance.labels('GET', '/test').inc(100);
-			var values = instance.get().values;
-			expect(values[0].value).to.equal(100);
+		describe('labels', function() {
+			beforeEach(function() {
+				instance = new Counter('gauge_test_2', 'help', [ 'method', 'endpoint']);
+			});
+
+			it('should handle 1 value per label', function() {
+				instance.labels('GET', '/test').inc();
+				instance.labels('POST', '/test').inc();
+
+				var values = instance.get().values;
+				expect(values).to.have.length(2);
+			});
+
+			it('should handle labels which are provided as arguments to inc()', function() {
+				instance.inc({method: 'GET', endpoint: '/test'});
+				instance.inc({method: 'POST', endpoint: '/test'});
+
+				var values = instance.get().values;
+				expect(values).to.have.length(2);
+			});
+
+			it('should throw error if label lengths does not match', function() {
+				var fn = function() {
+					instance.labels('GET').inc();
+				};
+				expect(fn).to.throw(Error);
+			});
+
+			it('should increment label value with provided value', function() {
+				instance.labels('GET', '/test').inc(100);
+				var values = instance.get().values;
+				expect(values[0].value).to.equal(100);
+			});
+		});
+	});
+	describe('without registry', function() {
+		beforeEach(function() {
+			instance = new Counter('gauge_test', 'test', null, false);
+		});
+		it('should increment counter', function() {
+			instance.inc();
+			expect(register.getMetricsAsJSON().length).to.equal(0);
+			expect(instance.get().values[0].value).to.equal(1);
+			expect(instance.get().values[0].timestamp).to.equal(undefined);
+		});
+	});
+	describe('registry instance', function() {
+		var registry;
+		beforeEach(function() {
+			registry = new Registry();
+			instance = new Counter('gauge_test', 'test', null, false);
+			registry.registerMetric(instance);
+		});
+		it('should increment counter', function() {
+			instance.inc();
+			expect(register.getMetricsAsJSON().length).to.equal(0);
+			expect(registry.getMetricsAsJSON().length).to.equal(1);
+			expect(instance.get().values[0].value).to.equal(1);
+			expect(instance.get().values[0].timestamp).to.equal(undefined);
 		});
 	});
 });

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -4,13 +4,13 @@ describe('gauge', function() {
 	var expect = require('chai').expect;
 	var Gauge = require('../index').Gauge;
 	var Registry = require('../index').Registry;
-	var register = require('../index').register;
+	var globalRegistry = require('../index').register;
 	var sinon = require('sinon');
 	var instance;
 
 	describe('global registry', function() {
 		afterEach(function() {
-			register.clear();
+			globalRegistry.clear();
 		});
 		describe('with a parameter for each variable', function() {
 			beforeEach(function() {
@@ -293,7 +293,7 @@ describe('gauge', function() {
 	});
 	describe('without registry', function() {
 		afterEach(function() {
-			register.clear();
+			globalRegistry.clear();
 		});
 		beforeEach(function() {
 			instance = new Gauge({ name: 'gauge_test', help: 'help', registers: [] });
@@ -301,25 +301,25 @@ describe('gauge', function() {
 		});
 		it('should set a gauge to provided value', function() {
 			expectValue(10);
-			expect(register.getMetricsAsJSON().length).to.equal(0);
+			expect(globalRegistry.getMetricsAsJSON().length).to.equal(0);
 		});
 	});
 	describe('registry instance', function() {
-		var registry;
+		var registryInstance;
 		beforeEach(function() {
-			registry = new Registry();
-			instance = new Gauge({ name: 'gauge_test', help: 'help', registers: [ registry ] });
+			registryInstance = new Registry();
+			instance = new Gauge({ name: 'gauge_test', help: 'help', registers: [ registryInstance ] });
 			instance.set(10);
 		});
 		it('should set a gauge to provided value', function() {
-			expect(register.getMetricsAsJSON().length).to.equal(0);
-			expect(registry.getMetricsAsJSON().length).to.equal(1);
+			expect(globalRegistry.getMetricsAsJSON().length).to.equal(0);
+			expect(registryInstance.getMetricsAsJSON().length).to.equal(1);
 			expectValue(10);
 		});
 
 		describe('with timestamp', function() {
 			beforeEach(function() {
-				instance = new Gauge( { name: 'name', help: 'help', labelNames: ['code'], registers: [ registry ] });
+				instance = new Gauge( { name: 'name', help: 'help', labelNames: ['code'], registers: [ registryInstance ] });
 				instance.set({ 'code': '200' }, 20);
 			});
 			it('should be able to set value and timestamp as Date', function() {

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -3,147 +3,174 @@
 describe('gauge', function() {
 	var expect = require('chai').expect;
 	var Gauge = require('../index').Gauge;
+	var Registry = require('../index').Registry;
 	var register = require('../index').register;
 	var sinon = require('sinon');
 	var instance;
-	beforeEach(function() {
-		instance = new Gauge('gauge_test', 'help');
-		instance.set(10);
-	});
-
-	afterEach(function() {
-		register.clear();
-	});
-
-	it('should set a gauge to provided value', function() {
-		expectValue(10);
-	});
-
-	it('should increase with 1 if no param provided', function() {
-		instance.inc();
-		expectValue(11);
-	});
-
-	it('should increase with param value if provided', function() {
-		instance.inc(5);
-		expectValue(15);
-	});
-
-	it('should decrease with 1 if no param provided', function() {
-		instance.dec();
-		expectValue(9);
-	});
-
-	it('should decrease with param if provided', function() {
-		instance.dec(5);
-		expectValue(5);
-	});
-
-	it('should start a timer and set a gauge to elapsed in seconds', function() {
-		var clock = sinon.useFakeTimers();
-		var doneFn = instance.startTimer();
-		clock.tick(500);
-		doneFn();
-		expectValue(0.5);
-		clock.restore();
-	});
-
-	it('should set to current time', function() {
-		var clock = sinon.useFakeTimers();
-		instance.setToCurrentTime();
-		expectValue(new Date().getTime());
-		clock.restore();
-	});
-
-	it('should not allow non numbers', function() {
-		var fn = function() {
-			instance.set('asd');
-		};
-		expect(fn).to.throw(Error);
-	});
-
-	describe('with labels', function() {
+	describe('global registry', function() {
 		beforeEach(function() {
-			instance = new Gauge('name', 'help', ['code']);
-			instance.set({ 'code': '200' }, 20);
+			instance = new Gauge('gauge_test', 'help');
+			instance.set(10);
 		});
-		it('should be able to increment', function() {
-			instance.labels('200').inc();
-			expectValue(21);
+
+		afterEach(function() {
+			register.clear();
 		});
-		it('should be able to decrement', function() {
-			instance.labels('200').dec();
-			expectValue(19);
+
+		it('should set a gauge to provided value', function() {
+			expectValue(10);
 		});
-		it('should be able to set value', function() {
-			instance.labels('200').set(500);
-			expectValue(500);
+
+		it('should increase with 1 if no param provided', function() {
+			instance.inc();
+			expectValue(11);
 		});
-		it('should be able to set value to current time', function() {
+
+		it('should increase with param value if provided', function() {
+			instance.inc(5);
+			expectValue(15);
+		});
+
+		it('should decrease with 1 if no param provided', function() {
+			instance.dec();
+			expectValue(9);
+		});
+
+		it('should decrease with param if provided', function() {
+			instance.dec(5);
+			expectValue(5);
+		});
+
+		it('should start a timer and set a gauge to elapsed in seconds', function() {
 			var clock = sinon.useFakeTimers();
-			instance.labels('200').setToCurrentTime();
+			var doneFn = instance.startTimer();
+			clock.tick(500);
+			doneFn();
+			expectValue(0.5);
+			clock.restore();
+		});
+
+		it('should set to current time', function() {
+			var clock = sinon.useFakeTimers();
+			instance.setToCurrentTime();
 			expectValue(new Date().getTime());
 			clock.restore();
 		});
-		it('should be able to start a timer', function(){
-			var clock = sinon.useFakeTimers();
-			var end = instance.labels('200').startTimer();
-			clock.tick(1000);
-			end();
-			expectValue(1);
-			clock.restore();
-		});
-		it('should be able to start a timer and set labels afterwards', function(){
-			var clock = sinon.useFakeTimers();
-			var end = instance.startTimer();
-			clock.tick(1000);
-			end({ 'code': 200 });
-			expectValue(1);
-			clock.restore();
-		});
-		it('should allow labels before and after timers', function(){
-			instance = new Gauge('name_2', 'help', ['code', 'success']);
-			var clock = sinon.useFakeTimers();
-			var end = instance.startTimer({ 'code': 200 });
-			clock.tick(1000);
-			end({ 'success': 'SUCCESS' });
-			expectValue(1);
-			clock.restore();
-		});
-	});
 
-	describe('with timestamp', function() {
-		beforeEach(function() {
-			instance = new Gauge('name', 'help', ['code']);
-			instance.set({ 'code': '200' }, 20);
-		});
-		it('should be able to set value and timestamp as Date', function() {
-			instance.labels('200').set(500, new Date('2017-01-26T01:05Z'));
-			expectValue(500, 1485392700000);
-		});
-		it('should be able to set value and timestamp as number', function() {
-			instance.labels('200').set(500, 1485392700000);
-			expectValue(500, 1485392700000);
-		});
 		it('should not allow non numbers', function() {
 			var fn = function() {
-				instance.labels('200').set(500, 'blah');
+				instance.set('asd');
 			};
 			expect(fn).to.throw(Error);
 		});
-		it('should not allow invalid dates', function() {
-			var fn = function() {
-				instance.labels('200').set(500, new Date('blah'));
-			};
-			expect(fn).to.throw(Error);
+
+		describe('with labels', function() {
+			beforeEach(function() {
+				instance = new Gauge('name', 'help', ['code']);
+				instance.set({ 'code': '200' }, 20);
+			});
+			it('should be able to increment', function() {
+				instance.labels('200').inc();
+				expectValue(21);
+			});
+			it('should be able to decrement', function() {
+				instance.labels('200').dec();
+				expectValue(19);
+			});
+			it('should be able to set value', function() {
+				instance.labels('200').set(500);
+				expectValue(500);
+			});
+			it('should be able to set value to current time', function() {
+				var clock = sinon.useFakeTimers();
+				instance.labels('200').setToCurrentTime();
+				expectValue(new Date().getTime());
+				clock.restore();
+			});
+			it('should be able to start a timer', function(){
+				var clock = sinon.useFakeTimers();
+				var end = instance.labels('200').startTimer();
+				clock.tick(1000);
+				end();
+				expectValue(1);
+				clock.restore();
+			});
+			it('should be able to start a timer and set labels afterwards', function(){
+				var clock = sinon.useFakeTimers();
+				var end = instance.startTimer();
+				clock.tick(1000);
+				end({ 'code': 200 });
+				expectValue(1);
+				clock.restore();
+			});
+			it('should allow labels before and after timers', function(){
+				instance = new Gauge('name_2', 'help', ['code', 'success']);
+				var clock = sinon.useFakeTimers();
+				var end = instance.startTimer({ 'code': 200 });
+				clock.tick(1000);
+				end({ 'success': 'SUCCESS' });
+				expectValue(1);
+				clock.restore();
+			});
 		});
-		it('should be able to increment', function() {
-			instance.labels('200').inc(1, 1485392700000);
-			expectValue(21, 1485392700000);
+
+		describe('with timestamp', function() {
+			beforeEach(function() {
+				instance = new Gauge('name', 'help', ['code']);
+				instance.set({ 'code': '200' }, 20);
+			});
+			it('should be able to set value and timestamp as Date', function() {
+				instance.labels('200').set(500, new Date('2017-01-26T01:05Z'));
+				expectValue(500, 1485392700000);
+			});
+			it('should be able to set value and timestamp as number', function() {
+				instance.labels('200').set(500, 1485392700000);
+				expectValue(500, 1485392700000);
+			});
+			it('should not allow non numbers', function() {
+				var fn = function() {
+					instance.labels('200').set(500, 'blah');
+				};
+				expect(fn).to.throw(Error);
+			});
+			it('should not allow invalid dates', function() {
+				var fn = function() {
+					instance.labels('200').set(500, new Date('blah'));
+				};
+				expect(fn).to.throw(Error);
+			});
+			it('should be able to increment', function() {
+				instance.labels('200').inc(1, 1485392700000);
+				expectValue(21, 1485392700000);
+			});
+			it('should be able to decrement', function() {
+				instance.labels('200').dec(1, 1485392700000);
+				expectValue(19, 1485392700000);
+			});
 		});
-		it('should be able to decrement', function() {
-			instance.labels('200').dec(1, 1485392700000);
-			expectValue(19, 1485392700000);
+	});
+	describe('without registry', function() {
+		beforeEach(function() {
+			instance = new Gauge('gauge_test', 'help', null, false);
+			instance.set(10);
+		});
+		it('should set a gauge to provided value', function() {
+			expectValue(10);
+			expect(register.getMetricsAsJSON().length).to.equal(0);
+		});
+	});
+	describe('registry instance', function() {
+		var registry;
+		beforeEach(function() {
+			registry = new Registry();
+			instance = new Gauge('gauge_test', 'help', null, false);
+			instance.set(10);
+			registry.registerMetric(instance);
+		});
+		it('should set a gauge to provided value', function() {
+			expect(register.getMetricsAsJSON().length).to.equal(0);
+			expect(registry.getMetricsAsJSON().length).to.equal(1);
+			expectValue(10);
 		});
 	});
 

--- a/test/histogramTest.js
+++ b/test/histogramTest.js
@@ -2,168 +2,197 @@
 
 describe('histogram', function() {
 	var Histogram = require('../index').Histogram;
+	var Registry = require('../index').Registry;
 	var register = require('../index').register;
 	var sinon = require('sinon');
 	var expect = require('chai').expect;
 	var instance;
-	beforeEach(function() {
-		instance = new Histogram('test_histogram', 'test');
-	});
-	afterEach(function() {
-		instance = null;
-		register.clear();
-	});
-
-	it('should increase count', function() {
-		instance.observe(0.5);
-		var valuePair = getValueByName('test_histogram_count', instance.get().values);
-		expect(valuePair.value).to.equal(1);
-	});
-	it('should be able to observe 0s', function() {
-		instance.observe(0);
-		var valuePair = getValueByLabel(0.005, instance.get().values);
-		expect(valuePair.value).to.equal(1);
-	});
-	it('should increase sum', function() {
-		instance.observe(0.5);
-		var valuePair = getValueByName('test_histogram_sum', instance.get().values);
-		expect(valuePair.value).to.equal(0.5);
-	});
-	it('should add item in upper bound bucket', function() {
-		instance.observe(1);
-		var valuePair = getValueByLabel(1, instance.get().values);
-		expect(valuePair.value).to.equal(1);
-	});
-
-	it('should be able to monitor more than one item', function() {
-		instance.observe(0.05);
-		instance.observe(5);
-		var firstValuePair = getValueByLabel(0.05, instance.get().values);
-		var secondValuePair = getValueByLabel(5, instance.get().values);
-		expect(firstValuePair.value).to.equal(1);
-		expect(secondValuePair.value).to.equal(2);
-	});
-
-	it('should add a +Inf bucket with the same value as count', function() {
-		instance.observe(10);
-		var countValuePair = getValueByName('test_histogram_count', instance.get().values);
-		var infValuePair = getValueByLabel('+Inf', instance.get().values);
-		expect(infValuePair.value).to.equal(countValuePair.value);
-	});
-
-	it('should add buckets in increasing numerical order', function() {
-		var histogram = new Histogram('test_histogram_2', 'test', { buckets: [1, 5] });
-		histogram.observe(1.5);
-		var values = histogram.get().values;
-		expect(values[0].labels.le).to.equal(1);
-		expect(values[1].labels.le).to.equal(5);
-		expect(values[2].labels.le).to.equal('+Inf');
-	});
-	it('should group counts on each label set', function() {
-		var histogram = new Histogram('test_histogram_2', 'test', [ 'code' ]);
-		histogram.observe({ code: '200' }, 1);
-		histogram.observe({ code: '300' }, 1);
-		var values = getValuesByLabel(1, histogram.get().values);
-		expect(values[0].value).to.equal(1);
-		expect(values[1].value).to.equal(1);
-	});
-
-	it('should time requests', function() {
-		var clock = sinon.useFakeTimers();
-		var doneFn = instance.startTimer();
-		clock.tick(500);
-		doneFn();
-		var valuePair = getValueByLabel(0.5, instance.get().values);
-		expect(valuePair.value).to.equal(1);
-		clock.restore();
-	});
-
-	it('should not allow non numbers', function() {
-		var fn = function() {
-			instance.observe('asd');
-		};
-		expect(fn).to.throw(Error);
-	});
-
-	it('should allow custom labels', function() {
-		var i = new Histogram('histo', 'help', [ 'code' ]);
-		i.observe({ code: 'test'}, 1);
-		var pair = getValueByLeAndLabel(1, 'code', 'test', i.get().values);
-		expect(pair.value).to.equal(1);
-	});
-
-	it('should not allow le as a custom label', function() {
-		var fn = function() {
-			new Histogram('name', 'help', [ 'le' ]);
-		};
-		expect(fn).to.throw(Error);
-	});
-
-	it('should observe value if outside most upper bound', function() {
-		instance.observe(100000);
-		var values = instance.get().values;
-		var count = getValueByLabel('+Inf', values, 'le');
-		expect(count.value).to.equal(1);
-	});
-
-	it('should allow to be reset itself', function() {
-		instance.observe(0.5);
-		var valuePair = getValueByName('test_histogram_count', instance.get().values);
-		expect(valuePair.value).to.equal(1);
-		instance.reset();
-		valuePair = getValueByName('test_histogram_count', instance.get().values);
-		expect(valuePair.value).to.equal(undefined);
-	});
-
-	describe('labels', function() {
+	describe('global registry', function() {
 		beforeEach(function() {
-			instance = new Histogram('histogram_labels', 'Histogram with labels fn', [ 'method' ]);
+			instance = new Histogram('test_histogram', 'test');
+		});
+		afterEach(function() {
+			instance = null;
+			register.clear();
 		});
 
-		it('should observe', function() {
-			instance.labels('get').observe(4);
-			var res = getValueByLeAndLabel(5, 'method', 'get', instance.get().values);
-			expect(res.value).to.equal(1);
+		it('should increase count', function() {
+			instance.observe(0.5);
+			var valuePair = getValueByName('test_histogram_count', instance.get().values);
+			expect(valuePair.value).to.equal(1);
+		});
+		it('should be able to observe 0s', function() {
+			instance.observe(0);
+			var valuePair = getValueByLabel(0.005, instance.get().values);
+			expect(valuePair.value).to.equal(1);
+		});
+		it('should increase sum', function() {
+			instance.observe(0.5);
+			var valuePair = getValueByName('test_histogram_sum', instance.get().values);
+			expect(valuePair.value).to.equal(0.5);
+		});
+		it('should add item in upper bound bucket', function() {
+			instance.observe(1);
+			var valuePair = getValueByLabel(1, instance.get().values);
+			expect(valuePair.value).to.equal(1);
 		});
 
-		it('should not allow different number of labels', function() {
+		it('should be able to monitor more than one item', function() {
+			instance.observe(0.05);
+			instance.observe(5);
+			var firstValuePair = getValueByLabel(0.05, instance.get().values);
+			var secondValuePair = getValueByLabel(5, instance.get().values);
+			expect(firstValuePair.value).to.equal(1);
+			expect(secondValuePair.value).to.equal(2);
+		});
+
+		it('should add a +Inf bucket with the same value as count', function() {
+			instance.observe(10);
+			var countValuePair = getValueByName('test_histogram_count', instance.get().values);
+			var infValuePair = getValueByLabel('+Inf', instance.get().values);
+			expect(infValuePair.value).to.equal(countValuePair.value);
+		});
+
+		it('should add buckets in increasing numerical order', function() {
+			var histogram = new Histogram('test_histogram_2', 'test', { buckets: [1, 5] });
+			histogram.observe(1.5);
+			var values = histogram.get().values;
+			expect(values[0].labels.le).to.equal(1);
+			expect(values[1].labels.le).to.equal(5);
+			expect(values[2].labels.le).to.equal('+Inf');
+		});
+		it('should group counts on each label set', function() {
+			var histogram = new Histogram('test_histogram_2', 'test', [ 'code' ]);
+			histogram.observe({ code: '200' }, 1);
+			histogram.observe({ code: '300' }, 1);
+			var values = getValuesByLabel(1, histogram.get().values);
+			expect(values[0].value).to.equal(1);
+			expect(values[1].value).to.equal(1);
+		});
+
+		it('should time requests', function() {
+			var clock = sinon.useFakeTimers();
+			var doneFn = instance.startTimer();
+			clock.tick(500);
+			doneFn();
+			var valuePair = getValueByLabel(0.5, instance.get().values);
+			expect(valuePair.value).to.equal(1);
+			clock.restore();
+		});
+
+		it('should not allow non numbers', function() {
 			var fn = function() {
-				instance.labels('get', '500').observe(4);
+				instance.observe('asd');
 			};
 			expect(fn).to.throw(Error);
 		});
 
-		it('should start a timer', function() {
-			var clock = sinon.useFakeTimers();
-			var end = instance.labels('get').startTimer();
-			clock.tick(500);
-			end();
-			var res = getValueByLeAndLabel(0.5, 'method', 'get', instance.get().values);
-			expect(res.value).to.equal(1);
-			clock.restore();
+		it('should allow custom labels', function() {
+			var i = new Histogram('histo', 'help', [ 'code' ]);
+			i.observe({ code: 'test'}, 1);
+			var pair = getValueByLeAndLabel(1, 'code', 'test', i.get().values);
+			expect(pair.value).to.equal(1);
 		});
 
-		it('should start a timer and set labels afterwards', function(){
-			var clock = sinon.useFakeTimers();
-			var end = instance.startTimer();
-			clock.tick(500);
-			end({ 'method': 'get' });
-			var res = getValueByLeAndLabel(0.5, 'method', 'get', instance.get().values);
-			expect(res.value).to.equal(1);
-			clock.restore();
+		it('should not allow le as a custom label', function() {
+			var fn = function() {
+				new Histogram('name', 'help', [ 'le' ]);
+			};
+			expect(fn).to.throw(Error);
 		});
 
-		it('should allow labels before and after timers', function(){
-			instance = new Histogram('histogram_labels_2', 'Histogram with labels fn', [ 'method', 'success' ]);
-			var clock = sinon.useFakeTimers();
-			var end = instance.startTimer({ 'method': 'get' });
-			clock.tick(500);
-			end({ 'success': 'SUCCESS' });
-			var res1 = getValueByLeAndLabel(0.5, 'method', 'get', instance.get().values);
-			var res2 = getValueByLeAndLabel(0.5, 'success', 'SUCCESS', instance.get().values);
-			expect(res1.value).to.equal(1);
-			expect(res2.value).to.equal(1);
-			clock.restore();
+		it('should observe value if outside most upper bound', function() {
+			instance.observe(100000);
+			var values = instance.get().values;
+			var count = getValueByLabel('+Inf', values, 'le');
+			expect(count.value).to.equal(1);
+		});
+
+		it('should allow to be reset itself', function() {
+			instance.observe(0.5);
+			var valuePair = getValueByName('test_histogram_count', instance.get().values);
+			expect(valuePair.value).to.equal(1);
+			instance.reset();
+			valuePair = getValueByName('test_histogram_count', instance.get().values);
+			expect(valuePair.value).to.equal(undefined);
+		});
+
+		describe('labels', function() {
+			beforeEach(function() {
+				instance = new Histogram('histogram_labels', 'Histogram with labels fn', [ 'method' ]);
+			});
+
+			it('should observe', function() {
+				instance.labels('get').observe(4);
+				var res = getValueByLeAndLabel(5, 'method', 'get', instance.get().values);
+				expect(res.value).to.equal(1);
+			});
+
+			it('should not allow different number of labels', function() {
+				var fn = function() {
+					instance.labels('get', '500').observe(4);
+				};
+				expect(fn).to.throw(Error);
+			});
+
+			it('should start a timer', function() {
+				var clock = sinon.useFakeTimers();
+				var end = instance.labels('get').startTimer();
+				clock.tick(500);
+				end();
+				var res = getValueByLeAndLabel(0.5, 'method', 'get', instance.get().values);
+				expect(res.value).to.equal(1);
+				clock.restore();
+			});
+
+			it('should start a timer and set labels afterwards', function(){
+				var clock = sinon.useFakeTimers();
+				var end = instance.startTimer();
+				clock.tick(500);
+				end({ 'method': 'get' });
+				var res = getValueByLeAndLabel(0.5, 'method', 'get', instance.get().values);
+				expect(res.value).to.equal(1);
+				clock.restore();
+			});
+
+			it('should allow labels before and after timers', function(){
+				instance = new Histogram('histogram_labels_2', 'Histogram with labels fn', [ 'method', 'success' ]);
+				var clock = sinon.useFakeTimers();
+				var end = instance.startTimer({ 'method': 'get' });
+				clock.tick(500);
+				end({ 'success': 'SUCCESS' });
+				var res1 = getValueByLeAndLabel(0.5, 'method', 'get', instance.get().values);
+				var res2 = getValueByLeAndLabel(0.5, 'success', 'SUCCESS', instance.get().values);
+				expect(res1.value).to.equal(1);
+				expect(res2.value).to.equal(1);
+				clock.restore();
+			});
+		});
+	});
+	describe('without registry', function() {
+		beforeEach(function() {
+			instance = new Histogram('test_histogram', 'test', null, null, false);
+		});
+		it('should increase count', function() {
+			instance.observe(0.5);
+			var valuePair = getValueByName('test_histogram_count', instance.get().values);
+			expect(valuePair.value).to.equal(1);
+			expect(register.getMetricsAsJSON().length).to.equal(0);
+		});
+	});
+	describe('registry instance', function() {
+		var registry;
+		beforeEach(function() {
+			registry = new Registry();
+			instance = new Histogram('test_histogram', 'test', null, null, false);
+			registry.registerMetric(instance);
+		});
+		it('should increment counter', function() {
+			instance.observe(0.5);
+			var valuePair = getValueByName('test_histogram_count', instance.get().values);
+			expect(valuePair.value).to.equal(1);
+			expect(register.getMetricsAsJSON().length).to.equal(0);
+			expect(registry.getMetricsAsJSON().length).to.equal(1);
 		});
 	});
 

--- a/test/histogramTest.js
+++ b/test/histogramTest.js
@@ -3,14 +3,14 @@
 describe('histogram', function() {
 	var Histogram = require('../index').Histogram;
 	var Registry = require('../index').Registry;
-	var register = require('../index').register;
+	var globalRegistry = require('../index').register;
 	var sinon = require('sinon');
 	var expect = require('chai').expect;
 	var instance;
 
 	afterEach(function() {
 		instance = null;
-		register.clear();
+		globalRegistry.clear();
 	});
 
 	describe('with a parameter for each variable', function() {
@@ -339,21 +339,21 @@ describe('histogram', function() {
 				instance.observe(0.5);
 				var valuePair = getValueByName('test_histogram_count', instance.get().values);
 				expect(valuePair.value).to.equal(1);
-				expect(register.getMetricsAsJSON().length).to.equal(0);
+				expect(globalRegistry.getMetricsAsJSON().length).to.equal(0);
 			});
 		});
 		describe('registry instance', function() {
-			var registry;
+			var registryInstance;
 			beforeEach(function() {
-				registry = new Registry();
-				instance = new Histogram({ name: 'test_histogram', help: 'test', registers: [ registry ] });
+				registryInstance = new Registry();
+				instance = new Histogram({ name: 'test_histogram', help: 'test', registers: [ registryInstance ] });
 			});
 			it('should increment counter', function() {
 				instance.observe(0.5);
 				var valuePair = getValueByName('test_histogram_count', instance.get().values);
 				expect(valuePair.value).to.equal(1);
-				expect(register.getMetricsAsJSON().length).to.equal(0);
-				expect(registry.getMetricsAsJSON().length).to.equal(1);
+				expect(globalRegistry.getMetricsAsJSON().length).to.equal(0);
+				expect(registryInstance.getMetricsAsJSON().length).to.equal(1);
 			});
 		});
 	});

--- a/test/pushgatewayTest.js
+++ b/test/pushgatewayTest.js
@@ -5,133 +5,151 @@ describe('pushgateway', function() {
 	var nock = require('nock');
 	var expect = require('chai').expect;
 	var register = require('../index').register;
+	var Registry = require('../index').Registry;
 	var instance;
+	var registry = undefined;
 
-	beforeEach(function() {
-		instance = new Pushgateway('http://192.168.99.100:9091');
-		var Counter = new require('../index').Counter;
-		var cnt = new Counter('test', 'test');
-		cnt.inc(100);
-	});
-	afterEach(function() {
-		register.clear();
-	});
+	var tests = function() {
+		describe('pushAdd', function() {
+			it('should push metrics', function(done) {
+				setupNock(202, 'post', '/metrics/job/testJob');
 
-	describe('pushAdd', function() {
-		it('should push metrics', function(done) {
-			setupNock(202, 'post', '/metrics/job/testJob');
+				instance.pushAdd({ jobName: 'testJob' }, function(err) {
+					expect(err).to.not.exist;
+					done();
+				});
+			});
 
-			instance.pushAdd({ jobName: 'testJob' }, function(err) {
-				expect(err).to.not.exist;
-				done();
+			it('should use groupings', function(done) {
+				setupNock(202, 'post', '/metrics/job/testJob/key/value');
+
+				instance.pushAdd({ jobName: 'testJob', groupings: { key: 'value' } }, function(err) {
+					expect(err).to.not.exist;
+					done();
+				});
+			});
+
+			it('should escape groupings', function(done) {
+				setupNock(202, 'post', '/metrics/job/testJob/key/va%26lue');
+				instance.pushAdd({ jobName: 'testJob', groupings: { key: 'va&lue' } }, function(err) {
+					expect(err).to.not.exist;
+					done();
+				});
+			});
+
+		});
+
+		describe('push', function() {
+			it('should push with PUT', function(done) {
+				setupNock(202, 'put', '/metrics/job/testJob');
+
+				instance.push({ jobName: 'testJob' }, function(err) {
+					expect(err).to.not.exist;
+					done();
+				});
+			});
+
+			it('should uri encode url', function(done) {
+				setupNock(202, 'put', '/metrics/job/test%26Job');
+
+				instance.push({ jobName: 'test&Job' }, function(err) {
+					expect(err).to.not.exist;
+					done();
+				});
 			});
 		});
 
-		it('should use groupings', function(done) {
-			setupNock(202, 'post', '/metrics/job/testJob/key/value');
+		describe('delete', function() {
+			it('should push delete with no body', function(done) {
+				setupNock(202, 'delete', '/metrics/job/testJob');
 
-			instance.pushAdd({ jobName: 'testJob', groupings: { key: 'value' } }, function(err) {
-				expect(err).to.not.exist;
-				done();
+				instance.delete({ jobName: 'testJob' }, function(err) {
+					expect(err).to.not.exist;
+					done();
+				});
 			});
 		});
 
-		it('should escape groupings', function(done) {
-			setupNock(202, 'post', '/metrics/job/testJob/key/va%26lue');
-			instance.pushAdd({ jobName: 'testJob', groupings: { key: 'va&lue' } }, function(err) {
-				expect(err).to.not.exist;
-				done();
+		describe('when using basic authentication', function() {
+			var USERNAME = 'unittest';
+			var PASSWORD = 'unittest';
+
+			beforeEach(function() {
+				instance = new Pushgateway('http://' + USERNAME + ':' + PASSWORD + '@192.168.99.100:9091', null, registry);
 			});
-		});
 
-	});
+			function verifyResult(done, err, response) {
+				expect(err).not.to.exist;
+				expect(response.req.headers.authorization).to.match(/^Basic/);
 
-	describe('push', function() {
-		it('should push with PUT', function(done) {
-			setupNock(202, 'put', '/metrics/job/testJob');
-
-			instance.push({ jobName: 'testJob' }, function(err) {
-				expect(err).to.not.exist;
 				done();
-			});
-		});
-
-		it('should uri encode url', function(done) {
-			setupNock(202, 'put', '/metrics/job/test%26Job');
-
-			instance.push({ jobName: 'test&Job' }, function(err) {
-				expect(err).to.not.exist;
-				done();
-			});
-		});
-	});
-
-	describe('delete', function() {
-		it('should push delete with no body', function(done) {
-			setupNock(202, 'delete', '/metrics/job/testJob');
-
-			instance.delete({ jobName: 'testJob' }, function(err) {
-				expect(err).to.not.exist;
-				done();
-			});
-		});
-	});
-
-	describe('when using basic authentication', function() {
-		var USERNAME = 'unittest';
-		var PASSWORD = 'unittest';
-
-		beforeEach(function() {
-			instance = new Pushgateway('http://' + USERNAME + ':' + PASSWORD + '@192.168.99.100:9091');
-		});
-
-		function verifyResult(done, err, response) {
-			expect(err).not.to.exist;
-			expect(response.req.headers.authorization).to.match(/^Basic/);
-
-			done();
-		}
-
-		it('pushAdd should send POST request with basic auth data', function(done) {
-			setupNock(202, 'post', '/metrics/job/testJob');
-
-			instance.pushAdd({ jobName: 'testJob' }, verifyResult.bind({}, done));
-		});
-
-		it('push should send PUT request with basic auth data', function(done) {
-			setupNock(202, 'put', '/metrics/job/testJob');
-
-			instance.push({ jobName: 'testJob' }, verifyResult.bind({}, done));
-		});
-
-		it('delete should send DELETE request with basic auth data', function(done) {
-			setupNock(202, 'delete', '/metrics/job/testJob');
-
-			instance.delete({ jobName: 'testJob' }, verifyResult.bind({}, done));
-		});
-	});
-
-	it('should be possible to extend http/s requests with options', function(done) {
-
-		nock('http://192.168.99.100:9091', {'encodedQueryParams':true})
-		.matchHeader('unit-test', '1')
-		.put('/metrics/job/testJob')
-		.reply(202, '', {
-			'content-length': '0',
-			'content-type': 'text/plain; charset=utf-8',
-			connection: 'close' });
-
-		instance = new Pushgateway('http://192.168.99.100:9091', {
-			headers: {
-				'unit-test': '1'
 			}
+
+			it('pushAdd should send POST request with basic auth data', function(done) {
+				setupNock(202, 'post', '/metrics/job/testJob');
+
+				instance.pushAdd({ jobName: 'testJob' }, verifyResult.bind({}, done));
+			});
+
+			it('push should send PUT request with basic auth data', function(done) {
+				setupNock(202, 'put', '/metrics/job/testJob');
+
+				instance.push({ jobName: 'testJob' }, verifyResult.bind({}, done));
+			});
+
+			it('delete should send DELETE request with basic auth data', function(done) {
+				setupNock(202, 'delete', '/metrics/job/testJob');
+
+				instance.delete({ jobName: 'testJob' }, verifyResult.bind({}, done));
+			});
 		});
 
-		instance.push({ jobName: 'testJob' }, function(err, res, body) {
-			expect(err).to.not.exist;
-			expect(nock.isDone()).to.be.true;
-			done();
+		it('should be possible to extend http/s requests with options', function(done) {
+
+			nock('http://192.168.99.100:9091', {'encodedQueryParams':true})
+			.matchHeader('unit-test', '1')
+			.put('/metrics/job/testJob')
+			.reply(202, '', {
+				'content-length': '0',
+				'content-type': 'text/plain; charset=utf-8',
+				connection: 'close' });
+
+			instance = new Pushgateway('http://192.168.99.100:9091', {
+				headers: {
+					'unit-test': '1'
+				}
+			}, registry);
+
+			instance.push({ jobName: 'testJob' }, function(err, res, body) {
+				expect(err).to.not.exist;
+				expect(nock.isDone()).to.be.true;
+				done();
+			});
 		});
+	};
+	describe('global registry', function() {
+		afterEach(function() {
+			register.clear();
+		});
+		beforeEach(function() {
+			registry = undefined;
+			instance = new Pushgateway('http://192.168.99.100:9091');
+			var Counter = new require('../index').Counter;
+			var cnt = new Counter('test', 'test');
+			cnt.inc(100);
+		});
+		tests();
+	});
+	describe('registry instance', function() {
+		beforeEach(function() {
+			registry = new Registry();
+			instance = new Pushgateway('http://192.168.99.100:9091', null, registry);
+			var Counter = new require('../index').Counter;
+			var cnt = new Counter('test', 'test', null, false);
+			registry.registerMetric(cnt);
+			cnt.inc(100);
+		});
+		tests();
 	});
 
 	function setupNock(responseCode, method, path) {

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -2,243 +2,279 @@
 
 describe('summary', function() {
 	var Summary = require('../index').Summary;
+	var Registry = require('../index').Registry;
 	var register = require('../index').register;
 	var expect = require('chai').expect;
 	var sinon = require('sinon');
 	var instance;
-
-	beforeEach(function() {
-		instance = new Summary('summary_test', 'test');
-	});
-
-	afterEach(function() {
-		register.clear();
-	});
-
-	it('should add a value to the summary', function() {
-		instance.observe(100);
-		expect(instance.get().values[0].labels.quantile).to.equal(0.01);
-		expect(instance.get().values[0].value).to.equal(100);
-		expect(instance.get().values[7].metricName).to.equal('summary_test_sum');
-		expect(instance.get().values[7].value).to.equal(100);
-		expect(instance.get().values[8].metricName).to.equal('summary_test_count');
-		expect(instance.get().values[8].value).to.equal(1);
-	});
-
-	it('should be able to observe 0s', function() {
-		instance.observe(0);
-		expect(instance.get().values[8].value).to.equal(1);
-	});
-
-	it('should correctly calculate percentiles when more values are added to the summary', function() {
-		instance.observe(100);
-		instance.observe(100);
-		instance.observe(100);
-		instance.observe(50);
-		instance.observe(50);
-
-		expect(instance.get().values.length).to.equal(9);
-
-		expect(instance.get().values[0].labels.quantile).to.equal(0.01);
-		expect(instance.get().values[0].value).to.equal(50);
-
-		expect(instance.get().values[1].labels.quantile).to.equal(0.05);
-		expect(instance.get().values[1].value).to.equal(50);
-
-		expect(instance.get().values[2].labels.quantile).to.equal(0.5);
-		expect(instance.get().values[2].value).to.equal(80);
-
-		expect(instance.get().values[3].labels.quantile).to.equal(0.9);
-		expect(instance.get().values[3].value).to.equal(100);
-
-		expect(instance.get().values[4].labels.quantile).to.equal(0.95);
-		expect(instance.get().values[4].value).to.equal(100);
-
-		expect(instance.get().values[5].labels.quantile).to.equal(0.99);
-		expect(instance.get().values[5].value).to.equal(100);
-
-		expect(instance.get().values[6].labels.quantile).to.equal(0.999);
-		expect(instance.get().values[6].value).to.equal(100);
-
-		expect(instance.get().values[7].metricName).to.equal('summary_test_sum');
-		expect(instance.get().values[7].value).to.equal(400);
-
-		expect(instance.get().values[8].metricName).to.equal('summary_test_count');
-		expect(instance.get().values[8].value).to.equal(5);
-	});
-
-	it('should correctly use calculate other percentiles when configured', function() {
-		register.clear();
-		instance = new Summary('summary_test', 'test', { percentiles: [ 0.5, 0.9 ] });
-		instance.observe(100);
-		instance.observe(100);
-		instance.observe(100);
-		instance.observe(50);
-		instance.observe(50);
-
-		expect(instance.get().values.length).to.equal(4);
-
-		expect(instance.get().values[0].labels.quantile).to.equal(0.5);
-		expect(instance.get().values[0].value).to.equal(80);
-
-		expect(instance.get().values[1].labels.quantile).to.equal(0.9);
-		expect(instance.get().values[1].value).to.equal(100);
-
-		expect(instance.get().values[2].metricName).to.equal('summary_test_sum');
-		expect(instance.get().values[2].value).to.equal(400);
-
-		expect(instance.get().values[3].metricName).to.equal('summary_test_count');
-		expect(instance.get().values[3].value).to.equal(5);
-	});
-
-	it('should allow to reset itself', function() {
-		register.clear();
-		instance = new Summary('summary_test', 'test', { percentiles: [ 0.5 ] });
-		instance.observe(100);
-		expect(instance.get().values[0].labels.quantile).to.equal(0.5);
-		expect(instance.get().values[0].value).to.equal(100);
-
-		expect(instance.get().values[1].metricName).to.equal('summary_test_sum');
-		expect(instance.get().values[1].value).to.equal(100);
-
-		expect(instance.get().values[2].metricName).to.equal('summary_test_count');
-		expect(instance.get().values[2].value).to.equal(1);
-
-		instance.reset();
-
-		expect(instance.get().values[0].labels.quantile).to.equal(0.5);
-		expect(instance.get().values[0].value).to.equal(0);
-
-		expect(instance.get().values[1].metricName).to.equal('summary_test_sum');
-		expect(instance.get().values[1].value).to.equal(0);
-
-		expect(instance.get().values[2].metricName).to.equal('summary_test_count');
-		expect(instance.get().values[2].value).to.equal(0);
-	});
-
-	describe('labels', function() {
+	describe('global registry', function() {
 		beforeEach(function() {
+			instance = new Summary('summary_test', 'test');
+		});
+
+		afterEach(function() {
 			register.clear();
-			instance = new Summary('summary_test', 'help', [ 'method', 'endpoint'], { percentiles: [ 0.9 ] });
 		});
 
-		it('should record and calculate the correct values per label', function() {
-			instance.labels('GET', '/test').observe(50);
-			instance.labels('POST', '/test').observe(100);
-
-			var values = instance.get().values;
-			expect(values).to.have.length(6);
-			expect(values[0].labels.method).to.equal('GET');
-			expect(values[0].labels.endpoint).to.equal('/test');
-			expect(values[0].labels.quantile).to.equal(0.9);
-			expect(values[0].value).to.equal(50);
-
-			expect(values[1].metricName).to.equal('summary_test_sum');
-			expect(values[1].labels.method).to.equal('GET');
-			expect(values[1].labels.endpoint).to.equal('/test');
-			expect(values[1].value).to.equal(50);
-
-			expect(values[2].metricName).to.equal('summary_test_count');
-			expect(values[2].labels.method).to.equal('GET');
-			expect(values[2].labels.endpoint).to.equal('/test');
-			expect(values[2].value).to.equal(1);
-
-			expect(values[3].labels.quantile).to.equal(0.9);
-			expect(values[3].labels.method).to.equal('POST');
-			expect(values[3].labels.endpoint).to.equal('/test');
-			expect(values[3].value).to.equal(100);
-
-			expect(values[4].metricName).to.equal('summary_test_sum');
-			expect(values[4].labels.method).to.equal('POST');
-			expect(values[4].labels.endpoint).to.equal('/test');
-			expect(values[4].value).to.equal(100);
-
-			expect(values[5].metricName).to.equal('summary_test_count');
-			expect(values[5].labels.method).to.equal('POST');
-			expect(values[5].labels.endpoint).to.equal('/test');
-			expect(values[5].value).to.equal(1);
+		it('should add a value to the summary', function() {
+			instance.observe(100);
+			expect(instance.get().values[0].labels.quantile).to.equal(0.01);
+			expect(instance.get().values[0].value).to.equal(100);
+			expect(instance.get().values[7].metricName).to.equal('summary_test_sum');
+			expect(instance.get().values[7].value).to.equal(100);
+			expect(instance.get().values[8].metricName).to.equal('summary_test_count');
+			expect(instance.get().values[8].value).to.equal(1);
 		});
 
-		it('should throw error if label lengths does not match', function() {
-			var fn = function() {
-				instance.labels('GET').observe();
-			};
-			expect(fn).to.throw(Error);
+		it('should be able to observe 0s', function() {
+			instance.observe(0);
+			expect(instance.get().values[8].value).to.equal(1);
 		});
 
-		it('should start a timer', function() {
-			var clock = sinon.useFakeTimers();
-			var end = instance.labels('GET', '/test').startTimer();
-			clock.tick(1000);
-			end();
-			var values = instance.get().values;
-			expect(values).to.have.length(3);
-			expect(values[0].labels.method).to.equal('GET');
-			expect(values[0].labels.endpoint).to.equal('/test');
-			expect(values[0].labels.quantile).to.equal(0.9);
-			expect(values[0].value).to.equal(1);
+		it('should correctly calculate percentiles when more values are added to the summary', function() {
+			instance.observe(100);
+			instance.observe(100);
+			instance.observe(100);
+			instance.observe(50);
+			instance.observe(50);
 
-			expect(values[1].metricName).to.equal('summary_test_sum');
-			expect(values[1].labels.method).to.equal('GET');
-			expect(values[1].labels.endpoint).to.equal('/test');
-			expect(values[1].value).to.equal(1);
+			expect(instance.get().values.length).to.equal(9);
 
-			expect(values[2].metricName).to.equal('summary_test_count');
-			expect(values[2].labels.method).to.equal('GET');
-			expect(values[2].labels.endpoint).to.equal('/test');
-			expect(values[2].value).to.equal(1);
+			expect(instance.get().values[0].labels.quantile).to.equal(0.01);
+			expect(instance.get().values[0].value).to.equal(50);
 
-			clock.restore();
+			expect(instance.get().values[1].labels.quantile).to.equal(0.05);
+			expect(instance.get().values[1].value).to.equal(50);
+
+			expect(instance.get().values[2].labels.quantile).to.equal(0.5);
+			expect(instance.get().values[2].value).to.equal(80);
+
+			expect(instance.get().values[3].labels.quantile).to.equal(0.9);
+			expect(instance.get().values[3].value).to.equal(100);
+
+			expect(instance.get().values[4].labels.quantile).to.equal(0.95);
+			expect(instance.get().values[4].value).to.equal(100);
+
+			expect(instance.get().values[5].labels.quantile).to.equal(0.99);
+			expect(instance.get().values[5].value).to.equal(100);
+
+			expect(instance.get().values[6].labels.quantile).to.equal(0.999);
+			expect(instance.get().values[6].value).to.equal(100);
+
+			expect(instance.get().values[7].metricName).to.equal('summary_test_sum');
+			expect(instance.get().values[7].value).to.equal(400);
+
+			expect(instance.get().values[8].metricName).to.equal('summary_test_count');
+			expect(instance.get().values[8].value).to.equal(5);
 		});
 
-		it('should start a timer and set labels afterwards', function(){
-			var clock = sinon.useFakeTimers();
-			var end = instance.startTimer();
-			clock.tick(1000);
-			end({ 'method': 'GET', 'endpoint': '/test' });
-			var values = instance.get().values;
-			expect(values).to.have.length(3);
-			expect(values[0].labels.method).to.equal('GET');
-			expect(values[0].labels.endpoint).to.equal('/test');
-			expect(values[0].labels.quantile).to.equal(0.9);
-			expect(values[0].value).to.equal(1);
+		it('should correctly use calculate other percentiles when configured', function() {
+			register.clear();
+			instance = new Summary('summary_test', 'test', { percentiles: [ 0.5, 0.9 ] });
+			instance.observe(100);
+			instance.observe(100);
+			instance.observe(100);
+			instance.observe(50);
+			instance.observe(50);
 
-			expect(values[1].metricName).to.equal('summary_test_sum');
-			expect(values[1].labels.method).to.equal('GET');
-			expect(values[1].labels.endpoint).to.equal('/test');
-			expect(values[1].value).to.equal(1);
+			expect(instance.get().values.length).to.equal(4);
 
-			expect(values[2].metricName).to.equal('summary_test_count');
-			expect(values[2].labels.method).to.equal('GET');
-			expect(values[2].labels.endpoint).to.equal('/test');
-			expect(values[2].value).to.equal(1);
+			expect(instance.get().values[0].labels.quantile).to.equal(0.5);
+			expect(instance.get().values[0].value).to.equal(80);
 
-			clock.restore();
+			expect(instance.get().values[1].labels.quantile).to.equal(0.9);
+			expect(instance.get().values[1].value).to.equal(100);
+
+			expect(instance.get().values[2].metricName).to.equal('summary_test_sum');
+			expect(instance.get().values[2].value).to.equal(400);
+
+			expect(instance.get().values[3].metricName).to.equal('summary_test_count');
+			expect(instance.get().values[3].value).to.equal(5);
 		});
 
-		it('should allow labels before and after timers', function(){
-			var clock = sinon.useFakeTimers();
-			var end = instance.startTimer({ 'method': 'GET' });
-			clock.tick(1000);
-			end({ 'endpoint': '/test' });
-			var values = instance.get().values;
-			expect(values).to.have.length(3);
-			expect(values[0].labels.method).to.equal('GET');
-			expect(values[0].labels.endpoint).to.equal('/test');
-			expect(values[0].labels.quantile).to.equal(0.9);
-			expect(values[0].value).to.equal(1);
+		it('should allow to reset itself', function() {
+			register.clear();
+			instance = new Summary('summary_test', 'test', { percentiles: [ 0.5 ] });
+			instance.observe(100);
+			expect(instance.get().values[0].labels.quantile).to.equal(0.5);
+			expect(instance.get().values[0].value).to.equal(100);
 
-			expect(values[1].metricName).to.equal('summary_test_sum');
-			expect(values[1].labels.method).to.equal('GET');
-			expect(values[1].labels.endpoint).to.equal('/test');
-			expect(values[1].value).to.equal(1);
+			expect(instance.get().values[1].metricName).to.equal('summary_test_sum');
+			expect(instance.get().values[1].value).to.equal(100);
 
-			expect(values[2].metricName).to.equal('summary_test_count');
-			expect(values[2].labels.method).to.equal('GET');
-			expect(values[2].labels.endpoint).to.equal('/test');
-			expect(values[2].value).to.equal(1);
+			expect(instance.get().values[2].metricName).to.equal('summary_test_count');
+			expect(instance.get().values[2].value).to.equal(1);
 
-			clock.restore();
+			instance.reset();
+
+			expect(instance.get().values[0].labels.quantile).to.equal(0.5);
+			expect(instance.get().values[0].value).to.equal(0);
+
+			expect(instance.get().values[1].metricName).to.equal('summary_test_sum');
+			expect(instance.get().values[1].value).to.equal(0);
+
+			expect(instance.get().values[2].metricName).to.equal('summary_test_count');
+			expect(instance.get().values[2].value).to.equal(0);
+		});
+
+		describe('labels', function() {
+			beforeEach(function() {
+				register.clear();
+				instance = new Summary('summary_test', 'help', [ 'method', 'endpoint'], { percentiles: [ 0.9 ] });
+			});
+
+			it('should record and calculate the correct values per label', function() {
+				instance.labels('GET', '/test').observe(50);
+				instance.labels('POST', '/test').observe(100);
+
+				var values = instance.get().values;
+				expect(values).to.have.length(6);
+				expect(values[0].labels.method).to.equal('GET');
+				expect(values[0].labels.endpoint).to.equal('/test');
+				expect(values[0].labels.quantile).to.equal(0.9);
+				expect(values[0].value).to.equal(50);
+
+				expect(values[1].metricName).to.equal('summary_test_sum');
+				expect(values[1].labels.method).to.equal('GET');
+				expect(values[1].labels.endpoint).to.equal('/test');
+				expect(values[1].value).to.equal(50);
+
+				expect(values[2].metricName).to.equal('summary_test_count');
+				expect(values[2].labels.method).to.equal('GET');
+				expect(values[2].labels.endpoint).to.equal('/test');
+				expect(values[2].value).to.equal(1);
+
+				expect(values[3].labels.quantile).to.equal(0.9);
+				expect(values[3].labels.method).to.equal('POST');
+				expect(values[3].labels.endpoint).to.equal('/test');
+				expect(values[3].value).to.equal(100);
+
+				expect(values[4].metricName).to.equal('summary_test_sum');
+				expect(values[4].labels.method).to.equal('POST');
+				expect(values[4].labels.endpoint).to.equal('/test');
+				expect(values[4].value).to.equal(100);
+
+				expect(values[5].metricName).to.equal('summary_test_count');
+				expect(values[5].labels.method).to.equal('POST');
+				expect(values[5].labels.endpoint).to.equal('/test');
+				expect(values[5].value).to.equal(1);
+			});
+
+			it('should throw error if label lengths does not match', function() {
+				var fn = function() {
+					instance.labels('GET').observe();
+				};
+				expect(fn).to.throw(Error);
+			});
+
+			it('should start a timer', function() {
+				var clock = sinon.useFakeTimers();
+				var end = instance.labels('GET', '/test').startTimer();
+				clock.tick(1000);
+				end();
+				var values = instance.get().values;
+				expect(values).to.have.length(3);
+				expect(values[0].labels.method).to.equal('GET');
+				expect(values[0].labels.endpoint).to.equal('/test');
+				expect(values[0].labels.quantile).to.equal(0.9);
+				expect(values[0].value).to.equal(1);
+
+				expect(values[1].metricName).to.equal('summary_test_sum');
+				expect(values[1].labels.method).to.equal('GET');
+				expect(values[1].labels.endpoint).to.equal('/test');
+				expect(values[1].value).to.equal(1);
+
+				expect(values[2].metricName).to.equal('summary_test_count');
+				expect(values[2].labels.method).to.equal('GET');
+				expect(values[2].labels.endpoint).to.equal('/test');
+				expect(values[2].value).to.equal(1);
+
+				clock.restore();
+			});
+
+			it('should start a timer and set labels afterwards', function(){
+				var clock = sinon.useFakeTimers();
+				var end = instance.startTimer();
+				clock.tick(1000);
+				end({ 'method': 'GET', 'endpoint': '/test' });
+				var values = instance.get().values;
+				expect(values).to.have.length(3);
+				expect(values[0].labels.method).to.equal('GET');
+				expect(values[0].labels.endpoint).to.equal('/test');
+				expect(values[0].labels.quantile).to.equal(0.9);
+				expect(values[0].value).to.equal(1);
+
+				expect(values[1].metricName).to.equal('summary_test_sum');
+				expect(values[1].labels.method).to.equal('GET');
+				expect(values[1].labels.endpoint).to.equal('/test');
+				expect(values[1].value).to.equal(1);
+
+				expect(values[2].metricName).to.equal('summary_test_count');
+				expect(values[2].labels.method).to.equal('GET');
+				expect(values[2].labels.endpoint).to.equal('/test');
+				expect(values[2].value).to.equal(1);
+
+				clock.restore();
+			});
+
+			it('should allow labels before and after timers', function(){
+				var clock = sinon.useFakeTimers();
+				var end = instance.startTimer({ 'method': 'GET' });
+				clock.tick(1000);
+				end({ 'endpoint': '/test' });
+				var values = instance.get().values;
+				expect(values).to.have.length(3);
+				expect(values[0].labels.method).to.equal('GET');
+				expect(values[0].labels.endpoint).to.equal('/test');
+				expect(values[0].labels.quantile).to.equal(0.9);
+				expect(values[0].value).to.equal(1);
+
+				expect(values[1].metricName).to.equal('summary_test_sum');
+				expect(values[1].labels.method).to.equal('GET');
+				expect(values[1].labels.endpoint).to.equal('/test');
+				expect(values[1].value).to.equal(1);
+
+				expect(values[2].metricName).to.equal('summary_test_count');
+				expect(values[2].labels.method).to.equal('GET');
+				expect(values[2].labels.endpoint).to.equal('/test');
+				expect(values[2].value).to.equal(1);
+
+				clock.restore();
+			});
+		});
+	});
+	describe('without registry', function() {
+		beforeEach(function() {
+			instance = new Summary('summary_test', 'test', null, null, false);
+		});
+		it('should increase count', function() {
+			instance.observe(100);
+			expect(instance.get().values[0].labels.quantile).to.equal(0.01);
+			expect(instance.get().values[0].value).to.equal(100);
+			expect(instance.get().values[7].metricName).to.equal('summary_test_sum');
+			expect(instance.get().values[7].value).to.equal(100);
+			expect(instance.get().values[8].metricName).to.equal('summary_test_count');
+			expect(instance.get().values[8].value).to.equal(1);
+			expect(register.getMetricsAsJSON().length).to.equal(0);
+		});
+	});
+	describe('registry instance', function() {
+		var registry;
+		beforeEach(function() {
+			registry = new Registry();
+			instance = new Summary('summary_test', 'test', null, null, false);
+			registry.registerMetric(instance);
+		});
+		it('should increment counter', function() {
+			instance.observe(100);
+			expect(instance.get().values[0].labels.quantile).to.equal(0.01);
+			expect(instance.get().values[0].value).to.equal(100);
+			expect(instance.get().values[7].metricName).to.equal('summary_test_sum');
+			expect(instance.get().values[7].value).to.equal(100);
+			expect(instance.get().values[8].metricName).to.equal('summary_test_count');
+			expect(instance.get().values[8].value).to.equal(1);
+			expect(register.getMetricsAsJSON().length).to.equal(0);
+			expect(registry.getMetricsAsJSON().length).to.equal(1);
 		});
 	});
 });

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -3,7 +3,7 @@
 describe('summary', function() {
 	var Summary = require('../index').Summary;
 	var Registry = require('../index').Registry;
-	var register = require('../index').register;
+	var globalRegistry = require('../index').register;
 	var expect = require('chai').expect;
 	var sinon = require('sinon');
 	var instance;
@@ -11,7 +11,7 @@ describe('summary', function() {
 	describe('global registry', function() {
 
 		afterEach(function() {
-			register.clear();
+			globalRegistry.clear();
 		});
 
 		describe('with a parameter for each variable', function() {
@@ -72,7 +72,7 @@ describe('summary', function() {
 			});
 
 			it('should correctly use calculate other percentiles when configured', function() {
-				register.clear();
+				globalRegistry.clear();
 				instance = new Summary('summary_test', 'test', { percentiles: [ 0.5, 0.9 ] });
 				instance.observe(100);
 				instance.observe(100);
@@ -96,7 +96,7 @@ describe('summary', function() {
 			});
 
 			it('should allow to reset itself', function() {
-				register.clear();
+				globalRegistry.clear();
 				instance = new Summary('summary_test', 'test', { percentiles: [ 0.5 ] });
 				instance.observe(100);
 				expect(instance.get().values[0].labels.quantile).to.equal(0.5);
@@ -122,7 +122,7 @@ describe('summary', function() {
 
 			describe('labels', function() {
 				beforeEach(function() {
-					register.clear();
+					globalRegistry.clear();
 					instance = new Summary('summary_test', 'help', [ 'method', 'endpoint'], { percentiles: [ 0.9 ] });
 				});
 
@@ -305,7 +305,7 @@ describe('summary', function() {
 			});
 
 			it('should correctly use calculate other percentiles when configured', function() {
-				register.clear();
+				globalRegistry.clear();
 				instance = new Summary({ name: 'summary_test', help: 'test', percentiles: [ 0.5, 0.9 ] });
 				instance.observe(100);
 				instance.observe(100);
@@ -329,7 +329,7 @@ describe('summary', function() {
 			});
 
 			it('should allow to reset itself', function() {
-				register.clear();
+				globalRegistry.clear();
 				instance = new Summary({ name: 'summary_test', help: 'test', percentiles: [ 0.5 ] });
 				instance.observe(100);
 				expect(instance.get().values[0].labels.quantile).to.equal(0.5);
@@ -355,7 +355,7 @@ describe('summary', function() {
 
 			describe('labels', function() {
 				beforeEach(function() {
-					register.clear();
+					globalRegistry.clear();
 					instance = new Summary({ name: 'summary_test', help: 'help', labelNames: [ 'method', 'endpoint'], percentiles: [ 0.9 ] });
 				});
 
@@ -492,14 +492,14 @@ describe('summary', function() {
 			expect(instance.get().values[7].value).to.equal(100);
 			expect(instance.get().values[8].metricName).to.equal('summary_test_count');
 			expect(instance.get().values[8].value).to.equal(1);
-			expect(register.getMetricsAsJSON().length).to.equal(0);
+			expect(globalRegistry.getMetricsAsJSON().length).to.equal(0);
 		});
 	});
 	describe('registry instance', function() {
-		var registry;
+		var registryInstance;
 		beforeEach(function() {
-			registry = new Registry();
-			instance = new Summary({ name: 'summary_test', help: 'test', registers: [ registry ] });
+			registryInstance = new Registry();
+			instance = new Summary({ name: 'summary_test', help: 'test', registers: [ registryInstance ] });
 		});
 		it('should increment counter', function() {
 			instance.observe(100);
@@ -509,8 +509,8 @@ describe('summary', function() {
 			expect(instance.get().values[7].value).to.equal(100);
 			expect(instance.get().values[8].metricName).to.equal('summary_test_count');
 			expect(instance.get().values[8].value).to.equal(1);
-			expect(register.getMetricsAsJSON().length).to.equal(0);
-			expect(registry.getMetricsAsJSON().length).to.equal(1);
+			expect(globalRegistry.getMetricsAsJSON().length).to.equal(0);
+			expect(registryInstance.getMetricsAsJSON().length).to.equal(1);
 		});
 	});
 });


### PR DESCRIPTION
Currently the library registers all metrics in the global registry without a way to override this behavior & there isn't support for other registries. There are couple of downsides with this that we came across (there might be more):
* It's problematic for modules to use this library in the current state. This + #99 should make it easier for modules to expose metrics to application and application could then decide which ones it wants to expose
* If you want to expose different set of metrics on different endpoints, you would need to hardcode the metrics you want to expose on both endpoints.

I do realize there is still at least one problem left with the modules using library directly: When merging different registries, it's possible that there are clashes on names and there isn't currently a documented interface for changing the name. `metric.name` is public, but since it's not really documented, I would be a bit hesitant to use it & it might cause other issues as the registry uses it internally.

This PR adds support for `Registry`, converts current `register` to it and makes registration to global registry optional. All changes should be backwards-compatible as far as I know.