### PR TITLE
Use object instead of separate params as constructor parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Counters go up, and reset when the process restarts.
 
 ```js
 var client = require('prom-client');
-var counter = new client.Counter('metric_name', 'metric_help');
+var counter = new client.Counter({ name: 'metric_name', help: 'metric_help' });
 counter.inc(); // Inc with 1
 counter.inc(10); // Inc with 10
 ```
@@ -87,7 +87,7 @@ Gauges are similar to Counters but Gauges value can be decreased.
 
 ```js
 var client = require('prom-client');
-var gauge = new client.Gauge('metric_name', 'metric_help');
+var gauge = new client.Gauge({ name: 'metric_name', help: 'metric_help' });
 gauge.set(10); // Set to 10
 gauge.inc(); // Inc with 1
 gauge.inc(10); // Inc with 10
@@ -115,23 +115,19 @@ Histograms track sizes and frequency of events.
 The defaults buckets are intended to cover usual web/rpc requests, this can however be overriden.
 ```js
 var client = require('prom-client');
-new client.Histogram('metric_name', 'metric_help', {
-	buckets: [ 0.10, 5, 15, 50, 100, 500 ]
-});
+new client.Histogram({ name: 'metric_name', help: 'metric_help', buckets: [ 0.10, 5, 15, 50, 100, 500 ] });
 ```
 If you need to include labels as well as configuration, you can also include those as the third parameter.
 ```js
 var client = require('prom-client');
-new client.Histogram('metric_name', 'metric_help', [ 'status_code' ], {
-	buckets: [ 0.10, 5, 15, 50, 100, 500 ]
-});
+new client.Histogram({ name: 'metric_name', help: 'metric_help', labels: [ 'status_code' ], buckets: [ 0.10, 5, 15, 50, 100, 500 ] });
 ```
 
 Examples
 
 ```js
 var client = require('prom-client');
-var histogram = new client.Histogram('metric_name', 'metric_help');
+var histogram = new client.Histogram({ name: 'metric_name', help: 'metric_help' });
 histogram.observe(10); // Observe value in histogram
 ```
 
@@ -153,16 +149,14 @@ The default percentiles are: 0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999. But they c
 
 ```js
 var client = require('prom-client');
-new client.Summary('metric_name', 'metric_help', {
-	percentiles: [ 0.01, 0.1, 0.9, 0.99 ]
-});
+new client.Summary({ name: 'metric_name', help: 'metric_help', percentiles: [ 0.01, 0.1, 0.9, 0.99 ] });
 ```
 
 Usage example
 
 ```js
 var client = require('prom-client');
-var summary = new client.Summary('metric_name', 'metric_help');
+var summary = new client.Summary({ name: 'metric_name', help: 'metric_help' });
 summary.observe(10);
 ```
 
@@ -179,7 +173,7 @@ xhrRequest(function(err, res) {
 All metrics take an array as 3rd parameter that should include all supported label keys. There are 2 ways to add values to the labels
 ```js
 var client = require('prom-client');
-var gauge = new client.Gauge('metric_name', 'metric_help', [ 'method', 'statusCode' ]);
+var gauge = new client.Gauge({ name: 'metric_name', help: 'metric_help', labels: [ 'method', 'statusCode' ] });
 
 gauge.set({ method: 'GET', statusCode: '200' }, 100); // 1st version, Set value 100 with method set to GET and statusCode to 200
 gauge.labels('GET', '200').set(100); // 2nd version, Same as above
@@ -255,11 +249,15 @@ For convenience, there are 2 bucket generator functions - linear and exponential
 
 ```js
 var client = require('prom-client');
-new client.Histogram('metric_name', 'metric_help', {
+new client.Histogram({ 
+	name: 'metric_name', 
+	help: 'metric_help',
 	buckets: client.linearBuckets(0, 10, 20) //Create 20 buckets, starting on 0 and a width of 10
 });
 
-new client.Histogram('metric_name', 'metric_help', {
+new client.Histogram({ 
+	name: 'metric_name',
+	help: 'metric_help', 
 	buckets: client.exponentialBuckets(1, 2, 5) //Create 5 buckets, starting on 1 and with a factor of 2
 });
 ```

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -11,6 +11,8 @@ var hashObject = require('./util').hashObject;
 var validateLabels = require('./validation').validateLabel;
 var validateMetricName = require('./validation').validateMetricName;
 var validateLabelNames = require('./validation').validateLabelName;
+var isObject = require('./util').isObject;
+var extend = require('util-extend');
 
 var getLabels = require('./util').getLabels;
 
@@ -21,26 +23,42 @@ var getLabels = require('./util').getLabels;
  * @param {Array.<string>} labels - Labels
  * @constructor
  */
+
+
 function Counter(name, help, labels) {
-	if(!help) {
+	var config;
+	if(isObject(name)) {
+		config = extend({
+			labels: []
+		}, name);
+	} else {
+		//Backwards compability - will be depricated
+		config = {
+			name: name,
+			help: help,
+			labels: labels
+		};
+	}
+
+	if(!config.help) {
 		throw new Error('Missing mandatory help parameter');
 	}
-	if(!name) {
+	if(!config.name) {
 		throw new Error('Missing mandatory name parameter');
 	}
-	if(!validateMetricName(name)) {
+	if(!validateMetricName(config.name)) {
 		throw new Error('Invalid metric name');
 	}
 
-	if(!validateLabelNames(labels)) {
+	if(!validateLabelNames(config.labels)) {
 		throw new Error('Invalid label name');
 	}
-	this.name = name;
+	this.name = config.name;
 	this.hashMap = {};
 
-	this.labelNames = (labels || []);
+	this.labelNames = (config.labels || []);
 
-	this.help = help;
+	this.help = config.help;
 	register.registerMetric(this);
 }
 

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -16,6 +16,8 @@ var hashObject = require('./util').hashObject;
 var validateMetricName = require('./validation').validateMetricName;
 var validateLabels = require('./validation').validateLabel;
 var validateLabelNames = require('./validation').validateLabelName;
+var isObject = require('./util').isObject;
+var extend = require('util-extend');
 
 /**
  * Gauge constructor
@@ -25,24 +27,37 @@ var validateLabelNames = require('./validation').validateLabelName;
  * @constructor
  */
 function Gauge(name, help, labels) {
-	if(!help) {
+	var config;
+	if(isObject(name)) {
+		config = extend({
+			labels: []
+		}, name);
+	} else {
+		config = {
+			name: name,
+			help: help,
+			labels: labels
+		};
+	}
+
+	if(!config.help) {
 		throw new Error('Missing mandatory help parameter');
 	}
-	if(!name) {
+	if(!config.name) {
 		throw new Error('Missing mandatory name parameter');
 	}
-	if(!validateMetricName(name)) {
+	if(!validateMetricName(config.name)) {
 		throw new Error('Invalid metric name');
 	}
-	if(!validateLabelNames(labels)) {
+	if(!validateLabelNames(config.labels)) {
 		throw new Error('Invalid label name');
 	}
 
-	this.name = name;
-	this.labelNames = labels || [];
+	this.name = config.name;
+	this.labelNames = config.labels || [];
 	this.hashMap = {};
 
-	this.help = help;
+	this.help = config.help;
 	register.registerMetric(this);
 }
 

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -13,6 +13,7 @@ var hashObject = require('./util').hashObject;
 var validateLabels = require('./validation').validateLabel;
 var validateMetricName = require('./validation').validateMetricName;
 var validateLabelNames = require('./validation').validateLabelName;
+var isObject = require('./util').isObject;
 
 /**
  * Histogram
@@ -23,22 +24,39 @@ var validateLabelNames = require('./validation').validateLabelName;
  * @constructor
  */
 function Histogram(name, help, labelsOrConf, conf) {
-	var obj;
-	var labels = [];
+	var config;
 
-	if(Array.isArray(labelsOrConf)) {
-		obj = conf || {};
-		labels = labelsOrConf;
+	if(isObject(name)) {
+		config = extend( {
+			buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+			labels: []
+		}, name);
 	} else {
-		obj = labelsOrConf || {};
+		var obj;
+		var labels = [];
+
+		if(Array.isArray(labelsOrConf)) {
+			obj = conf || {};
+			labels = labelsOrConf;
+		} else {
+			obj = labelsOrConf || {};
+		}
+
+		config = {
+			name: name,
+			labels: labels,
+			help: help,
+			buckets: configureUpperbounds(obj.buckets)
+		};
 	}
 
-	validateInput(name, help, labels);
 
-	this.name = name;
-	this.help = help;
+	validateInput(config.name, config.help, config.labels);
 
-	this.upperBounds = configureUpperbounds(obj.buckets);
+	this.name = config.name;
+	this.help = config.help;
+
+	this.upperBounds = config.buckets;
 	this.bucketValues = this.upperBounds.reduce(function(acc, upperBound) {
 		acc[upperBound] = 0;
 		return acc;
@@ -50,7 +68,7 @@ function Histogram(name, help, labelsOrConf, conf) {
 	this.count = 0;
 
 	this.hashMap = {};
-	this.labelNames = labels || [];
+	this.labelNames = config.labels || [];
 	register.registerMetric(this);
 }
 

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -14,6 +14,8 @@ var validateLabels = require('./validation').validateLabel;
 var validateMetricName = require('./validation').validateMetricName;
 var validateLabelNames = require('./validation').validateLabelName;
 var TDigest = require('tdigest').TDigest;
+var isObject = require('util').isObject;
+var extend = require('util-extend');
 
 /**
  * Summary
@@ -24,24 +26,39 @@ var TDigest = require('tdigest').TDigest;
  * @constructor
  */
 function Summary(name, help, labelsOrConf, conf) {
-	var obj;
-	var labels = [];
-
-	if(Array.isArray(labelsOrConf)) {
-		obj = conf || {};
-		labels = labelsOrConf;
+	var config;
+	if(isObject(name)) {
+		config = extend({
+			percentiles: [0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999],
+			labels: []
+		}, name);
 	} else {
-		obj = labelsOrConf || {};
+		var obj;
+		var labels = [];
+
+		if(Array.isArray(labelsOrConf)) {
+			obj = conf || {};
+			labels = labelsOrConf;
+		} else {
+			obj = labelsOrConf || {};
+		}
+
+		config = {
+			name: name,
+			help: help,
+			labels: labels,
+			percentiles: configurePercentiles(obj.percentiles)
+		};
 	}
 
-	validateInput(name, help, labels);
+	validateInput(config.name, config.help, config.labels);
 
-	this.name = name;
-	this.help = help;
+	this.name = config.name;
+	this.help = config.help;
 
-	this.percentiles = configurePercentiles(obj.percentiles);
+	this.percentiles = config.percentiles;
 	this.hashMap = {};
-	this.labelNames = labels || [];
+	this.labelNames = config.labels || [];
 	register.registerMetric(this);
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -62,3 +62,6 @@ function isNumber(obj) {
 function isDate(obj) {
 	return obj instanceof Date && !isNaN(obj.valueOf());
 }
+exports.isObject = function isObject(obj) {
+	return obj === Object(obj);
+};

--- a/test/counterTest.js
+++ b/test/counterTest.js
@@ -6,84 +6,166 @@ describe('counter', function() {
 	var expect = require('chai').expect;
 	var instance;
 
-	beforeEach(function() {
-		instance = new Counter('gauge_test', 'test');
-	});
-
 	afterEach(function() {
 		register.clear();
 	});
 
-	it('should increment counter', function() {
-		instance.inc();
-		expect(instance.get().values[0].value).to.equal(1);
-		expect(instance.get().values[0].timestamp).to.equal(undefined);
-	});
-	it('should increment with a provided value', function() {
-		instance.inc(100);
-		expect(instance.get().values[0].value).to.equal(100);
-		expect(instance.get().values[0].timestamp).to.equal(undefined);
-	});
-	it('should increment with a provided value and timestamp', function() {
-		instance.inc(100, 1485392700000);
-		expect(instance.get().values[0].value).to.equal(100);
-		expect(instance.get().values[0].timestamp).to.equal(1485392700000);
-	});
-	it('should not allow non number as timestamp', function() {
-		var fn = function() {
-			instance.inc(1, 'blah');
-		};
-		expect(fn).to.throw(Error);
-	});
-	it('should not allow invalid date as timestamp', function() {
-		var fn = function() {
-			instance.inc(1, new Date('blah'));
-		};
-		expect(fn).to.throw(Error);
-	});
-	it('should not be possible to decrease a counter', function() {
-		var fn = function() {
-			instance.inc(-100);
-		};
-		expect(fn).to.throw(Error);
-	});
-	it('should handle incrementing with 0', function() {
-		instance.inc(0);
-		expect(instance.get().values[0].value).to.equal(0);
-	});
+	describe('with a parameter for each variable', function() {
 
-	describe('labels', function() {
 		beforeEach(function() {
-			instance = new Counter('gauge_test_2', 'help', [ 'method', 'endpoint']);
+			instance = new Counter('gauge_test', 'test');
 		});
 
-		it('should handle 1 value per label', function() {
-			instance.labels('GET', '/test').inc();
-			instance.labels('POST', '/test').inc();
-
-			var values = instance.get().values;
-			expect(values).to.have.length(2);
+		it('should increment counter', function() {
+			instance.inc();
+			expect(instance.get().values[0].value).to.equal(1);
+			expect(instance.get().values[0].timestamp).to.equal(undefined);
 		});
-
-		it('should handle labels which are provided as arguments to inc()', function() {
-			instance.inc({method: 'GET', endpoint: '/test'});
-			instance.inc({method: 'POST', endpoint: '/test'});
-
-			var values = instance.get().values;
-			expect(values).to.have.length(2);
+		it('should increment with a provided value', function() {
+			instance.inc(100);
+			expect(instance.get().values[0].value).to.equal(100);
+			expect(instance.get().values[0].timestamp).to.equal(undefined);
 		});
-
-		it('should throw error if label lengths does not match', function() {
+		it('should increment with a provided value and timestamp', function() {
+			instance.inc(100, 1485392700000);
+			expect(instance.get().values[0].value).to.equal(100);
+			expect(instance.get().values[0].timestamp).to.equal(1485392700000);
+		});
+		it('should not allow non number as timestamp', function() {
 			var fn = function() {
-				instance.labels('GET').inc();
+				instance.inc(1, 'blah');
 			};
 			expect(fn).to.throw(Error);
 		});
+		it('should not allow invalid date as timestamp', function() {
+			var fn = function() {
+				instance.inc(1, new Date('blah'));
+			};
+			expect(fn).to.throw(Error);
+		});
+		it('should not be possible to decrease a counter', function() {
+			var fn = function() {
+				instance.inc(-100);
+			};
+			expect(fn).to.throw(Error);
+		});
+		it('should handle incrementing with 0', function() {
+			instance.inc(0);
+			expect(instance.get().values[0].value).to.equal(0);
+		});
 
-		it('should increment label value with provided value', function() {
-			instance.labels('GET', '/test').inc(100);
-			var values = instance.get().values;
-			expect(values[0].value).to.equal(100);
+		describe('labels', function() {
+			beforeEach(function() {
+				instance = new Counter('gauge_test_2', 'help', [ 'method', 'endpoint']);
+			});
+
+			it('should handle 1 value per label', function() {
+				instance.labels('GET', '/test').inc();
+				instance.labels('POST', '/test').inc();
+
+				var values = instance.get().values;
+				expect(values).to.have.length(2);
+			});
+
+			it('should handle labels which are provided as arguments to inc()', function() {
+				instance.inc({method: 'GET', endpoint: '/test'});
+				instance.inc({method: 'POST', endpoint: '/test'});
+
+				var values = instance.get().values;
+				expect(values).to.have.length(2);
+			});
+
+			it('should throw error if label lengths does not match', function() {
+				var fn = function() {
+					instance.labels('GET').inc();
+				};
+				expect(fn).to.throw(Error);
+			});
+
+			it('should increment label value with provided value', function() {
+				instance.labels('GET', '/test').inc(100);
+				var values = instance.get().values;
+				expect(values[0].value).to.equal(100);
+			});
+		});
+	});
+
+	describe('with params as object', function() {
+		beforeEach(function() {
+			instance = new Counter({ name: 'gauge_test', help: 'test' });
+		});
+
+		it('should increment counter', function() {
+			instance.inc();
+			expect(instance.get().values[0].value).to.equal(1);
+			expect(instance.get().values[0].timestamp).to.equal(undefined);
+		});
+		it('should increment with a provided value', function() {
+			instance.inc(100);
+			expect(instance.get().values[0].value).to.equal(100);
+			expect(instance.get().values[0].timestamp).to.equal(undefined);
+		});
+		it('should increment with a provided value and timestamp', function() {
+			instance.inc(100, 1485392700000);
+			expect(instance.get().values[0].value).to.equal(100);
+			expect(instance.get().values[0].timestamp).to.equal(1485392700000);
+		});
+		it('should not allow non number as timestamp', function() {
+			var fn = function() {
+				instance.inc(1, 'blah');
+			};
+			expect(fn).to.throw(Error);
+		});
+		it('should not allow invalid date as timestamp', function() {
+			var fn = function() {
+				instance.inc(1, new Date('blah'));
+			};
+			expect(fn).to.throw(Error);
+		});
+		it('should not be possible to decrease a counter', function() {
+			var fn = function() {
+				instance.inc(-100);
+			};
+			expect(fn).to.throw(Error);
+		});
+		it('should handle incrementing with 0', function() {
+			instance.inc(0);
+			expect(instance.get().values[0].value).to.equal(0);
+		});
+
+		describe('labels', function() {
+			beforeEach(function() {
+				instance = new Counter({ name: 'gauge_test_2', help: 'help', labels: [ 'method', 'endpoint'] });
+			});
+
+			it('should handle 1 value per label', function() {
+				instance.labels('GET', '/test').inc();
+				instance.labels('POST', '/test').inc();
+
+				var values = instance.get().values;
+				expect(values).to.have.length(2);
+			});
+
+			it('should handle labels which are provided as arguments to inc()', function() {
+				instance.inc({method: 'GET', endpoint: '/test'});
+				instance.inc({method: 'POST', endpoint: '/test'});
+
+				var values = instance.get().values;
+				expect(values).to.have.length(2);
+			});
+
+			it('should throw error if label lengths does not match', function() {
+				var fn = function() {
+					instance.labels('GET').inc();
+				};
+				expect(fn).to.throw(Error);
+			});
+
+			it('should increment label value with provided value', function() {
+				instance.labels('GET', '/test').inc(100);
+				var values = instance.get().values;
+				expect(values[0].value).to.equal(100);
+			});
 		});
 	});
 });

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -6,145 +6,289 @@ describe('gauge', function() {
 	var register = require('../index').register;
 	var sinon = require('sinon');
 	var instance;
-	beforeEach(function() {
-		instance = new Gauge('gauge_test', 'help');
-		instance.set(10);
-	});
 
 	afterEach(function() {
 		register.clear();
 	});
 
-	it('should set a gauge to provided value', function() {
-		expectValue(10);
-	});
-
-	it('should increase with 1 if no param provided', function() {
-		instance.inc();
-		expectValue(11);
-	});
-
-	it('should increase with param value if provided', function() {
-		instance.inc(5);
-		expectValue(15);
-	});
-
-	it('should decrease with 1 if no param provided', function() {
-		instance.dec();
-		expectValue(9);
-	});
-
-	it('should decrease with param if provided', function() {
-		instance.dec(5);
-		expectValue(5);
-	});
-
-	it('should start a timer and set a gauge to elapsed in seconds', function() {
-		var clock = sinon.useFakeTimers();
-		var doneFn = instance.startTimer();
-		clock.tick(500);
-		doneFn();
-		expectValue(0.5);
-		clock.restore();
-	});
-
-	it('should set to current time', function() {
-		var clock = sinon.useFakeTimers();
-		instance.setToCurrentTime();
-		expectValue(new Date().getTime());
-		clock.restore();
-	});
-
-	it('should not allow non numbers', function() {
-		var fn = function() {
-			instance.set('asd');
-		};
-		expect(fn).to.throw(Error);
-	});
-
-	describe('with labels', function() {
+	describe('with a parameter for each variable', function() {
 		beforeEach(function() {
-			instance = new Gauge('name', 'help', ['code']);
-			instance.set({ 'code': '200' }, 20);
+			instance = new Gauge('gauge_test', 'help');
+			instance.set(10);
 		});
-		it('should be able to increment', function() {
-			instance.labels('200').inc();
-			expectValue(21);
+
+		it('should set a gauge to provided value', function() {
+			expectValue(10);
 		});
-		it('should be able to decrement', function() {
-			instance.labels('200').dec();
-			expectValue(19);
+
+		it('should increase with 1 if no param provided', function() {
+			instance.inc();
+			expectValue(11);
 		});
-		it('should be able to set value', function() {
-			instance.labels('200').set(500);
-			expectValue(500);
+
+		it('should increase with param value if provided', function() {
+			instance.inc(5);
+			expectValue(15);
 		});
-		it('should be able to set value to current time', function() {
+
+		it('should decrease with 1 if no param provided', function() {
+			instance.dec();
+			expectValue(9);
+		});
+
+		it('should decrease with param if provided', function() {
+			instance.dec(5);
+			expectValue(5);
+		});
+
+		it('should start a timer and set a gauge to elapsed in seconds', function() {
 			var clock = sinon.useFakeTimers();
-			instance.labels('200').setToCurrentTime();
+			var doneFn = instance.startTimer();
+			clock.tick(500);
+			doneFn();
+			expectValue(0.5);
+			clock.restore();
+		});
+
+		it('should set to current time', function() {
+			var clock = sinon.useFakeTimers();
+			instance.setToCurrentTime();
 			expectValue(new Date().getTime());
 			clock.restore();
 		});
-		it('should be able to start a timer', function(){
-			var clock = sinon.useFakeTimers();
-			var end = instance.labels('200').startTimer();
-			clock.tick(1000);
-			end();
-			expectValue(1);
-			clock.restore();
-		});
-		it('should be able to start a timer and set labels afterwards', function(){
-			var clock = sinon.useFakeTimers();
-			var end = instance.startTimer();
-			clock.tick(1000);
-			end({ 'code': 200 });
-			expectValue(1);
-			clock.restore();
-		});
-		it('should allow labels before and after timers', function(){
-			instance = new Gauge('name_2', 'help', ['code', 'success']);
-			var clock = sinon.useFakeTimers();
-			var end = instance.startTimer({ 'code': 200 });
-			clock.tick(1000);
-			end({ 'success': 'SUCCESS' });
-			expectValue(1);
-			clock.restore();
-		});
-	});
 
-	describe('with timestamp', function() {
-		beforeEach(function() {
-			instance = new Gauge('name', 'help', ['code']);
-			instance.set({ 'code': '200' }, 20);
-		});
-		it('should be able to set value and timestamp as Date', function() {
-			instance.labels('200').set(500, new Date('2017-01-26T01:05Z'));
-			expectValue(500, 1485392700000);
-		});
-		it('should be able to set value and timestamp as number', function() {
-			instance.labels('200').set(500, 1485392700000);
-			expectValue(500, 1485392700000);
-		});
 		it('should not allow non numbers', function() {
 			var fn = function() {
-				instance.labels('200').set(500, 'blah');
+				instance.set('asd');
 			};
 			expect(fn).to.throw(Error);
 		});
-		it('should not allow invalid dates', function() {
+
+		describe('with labels', function() {
+			beforeEach(function() {
+				instance = new Gauge('name', 'help', ['code']);
+				instance.set({ 'code': '200' }, 20);
+			});
+			it('should be able to increment', function() {
+				instance.labels('200').inc();
+				expectValue(21);
+			});
+			it('should be able to decrement', function() {
+				instance.labels('200').dec();
+				expectValue(19);
+			});
+			it('should be able to set value', function() {
+				instance.labels('200').set(500);
+				expectValue(500);
+			});
+			it('should be able to set value to current time', function() {
+				var clock = sinon.useFakeTimers();
+				instance.labels('200').setToCurrentTime();
+				expectValue(new Date().getTime());
+				clock.restore();
+			});
+			it('should be able to start a timer', function(){
+				var clock = sinon.useFakeTimers();
+				var end = instance.labels('200').startTimer();
+				clock.tick(1000);
+				end();
+				expectValue(1);
+				clock.restore();
+			});
+			it('should be able to start a timer and set labels afterwards', function(){
+				var clock = sinon.useFakeTimers();
+				var end = instance.startTimer();
+				clock.tick(1000);
+				end({ 'code': 200 });
+				expectValue(1);
+				clock.restore();
+			});
+			it('should allow labels before and after timers', function(){
+				instance = new Gauge('name_2', 'help', ['code', 'success']);
+				var clock = sinon.useFakeTimers();
+				var end = instance.startTimer({ 'code': 200 });
+				clock.tick(1000);
+				end({ 'success': 'SUCCESS' });
+				expectValue(1);
+				clock.restore();
+			});
+		});
+
+		describe('with timestamp', function() {
+			beforeEach(function() {
+				instance = new Gauge('name', 'help', ['code']);
+				instance.set({ 'code': '200' }, 20);
+			});
+			it('should be able to set value and timestamp as Date', function() {
+				instance.labels('200').set(500, new Date('2017-01-26T01:05Z'));
+				expectValue(500, 1485392700000);
+			});
+			it('should be able to set value and timestamp as number', function() {
+				instance.labels('200').set(500, 1485392700000);
+				expectValue(500, 1485392700000);
+			});
+			it('should not allow non numbers', function() {
+				var fn = function() {
+					instance.labels('200').set(500, 'blah');
+				};
+				expect(fn).to.throw(Error);
+			});
+			it('should not allow invalid dates', function() {
+				var fn = function() {
+					instance.labels('200').set(500, new Date('blah'));
+				};
+				expect(fn).to.throw(Error);
+			});
+			it('should be able to increment', function() {
+				instance.labels('200').inc(1, 1485392700000);
+				expectValue(21, 1485392700000);
+			});
+			it('should be able to decrement', function() {
+				instance.labels('200').dec(1, 1485392700000);
+				expectValue(19, 1485392700000);
+			});
+		});
+
+	});
+
+	describe('with parameters as object', function() {
+		beforeEach(function() {
+			instance = new Gauge({ name: 'gauge_test', help: 'help' });
+			instance.set(10);
+		});
+
+		it('should set a gauge to provided value', function() {
+			expectValue(10);
+		});
+
+		it('should increase with 1 if no param provided', function() {
+			instance.inc();
+			expectValue(11);
+		});
+
+		it('should increase with param value if provided', function() {
+			instance.inc(5);
+			expectValue(15);
+		});
+
+		it('should decrease with 1 if no param provided', function() {
+			instance.dec();
+			expectValue(9);
+		});
+
+		it('should decrease with param if provided', function() {
+			instance.dec(5);
+			expectValue(5);
+		});
+
+		it('should start a timer and set a gauge to elapsed in seconds', function() {
+			var clock = sinon.useFakeTimers();
+			var doneFn = instance.startTimer();
+			clock.tick(500);
+			doneFn();
+			expectValue(0.5);
+			clock.restore();
+		});
+
+		it('should set to current time', function() {
+			var clock = sinon.useFakeTimers();
+			instance.setToCurrentTime();
+			expectValue(new Date().getTime());
+			clock.restore();
+		});
+
+		it('should not allow non numbers', function() {
 			var fn = function() {
-				instance.labels('200').set(500, new Date('blah'));
+				instance.set('asd');
 			};
 			expect(fn).to.throw(Error);
 		});
-		it('should be able to increment', function() {
-			instance.labels('200').inc(1, 1485392700000);
-			expectValue(21, 1485392700000);
+
+		describe('with labels', function() {
+			beforeEach(function() {
+				instance = new Gauge( { name: 'name', help: 'help', labels: ['code'] });
+				instance.set({ 'code': '200' }, 20);
+			});
+			it('should be able to increment', function() {
+				instance.labels('200').inc();
+				expectValue(21);
+			});
+			it('should be able to decrement', function() {
+				instance.labels('200').dec();
+				expectValue(19);
+			});
+			it('should be able to set value', function() {
+				instance.labels('200').set(500);
+				expectValue(500);
+			});
+			it('should be able to set value to current time', function() {
+				var clock = sinon.useFakeTimers();
+				instance.labels('200').setToCurrentTime();
+				expectValue(new Date().getTime());
+				clock.restore();
+			});
+			it('should be able to start a timer', function(){
+				var clock = sinon.useFakeTimers();
+				var end = instance.labels('200').startTimer();
+				clock.tick(1000);
+				end();
+				expectValue(1);
+				clock.restore();
+			});
+			it('should be able to start a timer and set labels afterwards', function(){
+				var clock = sinon.useFakeTimers();
+				var end = instance.startTimer();
+				clock.tick(1000);
+				end({ 'code': 200 });
+				expectValue(1);
+				clock.restore();
+			});
+			it('should allow labels before and after timers', function(){
+				instance = new Gauge({ name: 'name_2', help: 'help', labels: ['code', 'success'] });
+				var clock = sinon.useFakeTimers();
+				var end = instance.startTimer({ 'code': 200 });
+				clock.tick(1000);
+				end({ 'success': 'SUCCESS' });
+				expectValue(1);
+				clock.restore();
+			});
 		});
-		it('should be able to decrement', function() {
-			instance.labels('200').dec(1, 1485392700000);
-			expectValue(19, 1485392700000);
+
+		describe('with timestamp', function() {
+			beforeEach(function() {
+				instance = new Gauge( { name: 'name', help: 'help', labels: ['code'] });
+				instance.set({ 'code': '200' }, 20);
+			});
+			it('should be able to set value and timestamp as Date', function() {
+				instance.labels('200').set(500, new Date('2017-01-26T01:05Z'));
+				expectValue(500, 1485392700000);
+			});
+			it('should be able to set value and timestamp as number', function() {
+				instance.labels('200').set(500, 1485392700000);
+				expectValue(500, 1485392700000);
+			});
+			it('should not allow non numbers', function() {
+				var fn = function() {
+					instance.labels('200').set(500, 'blah');
+				};
+				expect(fn).to.throw(Error);
+			});
+			it('should not allow invalid dates', function() {
+				var fn = function() {
+					instance.labels('200').set(500, new Date('blah'));
+				};
+				expect(fn).to.throw(Error);
+			});
+			it('should be able to increment', function() {
+				instance.labels('200').inc(1, 1485392700000);
+				expectValue(21, 1485392700000);
+			});
+			it('should be able to decrement', function() {
+				instance.labels('200').dec(1, 1485392700000);
+				expectValue(19, 1485392700000);
+			});
 		});
+
 	});
 
 	function expectValue(val, timestamp) {

--- a/test/histogramTest.js
+++ b/test/histogramTest.js
@@ -6,167 +6,328 @@ describe('histogram', function() {
 	var sinon = require('sinon');
 	var expect = require('chai').expect;
 	var instance;
-	beforeEach(function() {
-		instance = new Histogram('test_histogram', 'test');
-	});
 	afterEach(function() {
 		instance = null;
 		register.clear();
 	});
 
-	it('should increase count', function() {
-		instance.observe(0.5);
-		var valuePair = getValueByName('test_histogram_count', instance.get().values);
-		expect(valuePair.value).to.equal(1);
-	});
-	it('should be able to observe 0s', function() {
-		instance.observe(0);
-		var valuePair = getValueByLabel(0.005, instance.get().values);
-		expect(valuePair.value).to.equal(1);
-	});
-	it('should increase sum', function() {
-		instance.observe(0.5);
-		var valuePair = getValueByName('test_histogram_sum', instance.get().values);
-		expect(valuePair.value).to.equal(0.5);
-	});
-	it('should add item in upper bound bucket', function() {
-		instance.observe(1);
-		var valuePair = getValueByLabel(1, instance.get().values);
-		expect(valuePair.value).to.equal(1);
-	});
-
-	it('should be able to monitor more than one item', function() {
-		instance.observe(0.05);
-		instance.observe(5);
-		var firstValuePair = getValueByLabel(0.05, instance.get().values);
-		var secondValuePair = getValueByLabel(5, instance.get().values);
-		expect(firstValuePair.value).to.equal(1);
-		expect(secondValuePair.value).to.equal(2);
-	});
-
-	it('should add a +Inf bucket with the same value as count', function() {
-		instance.observe(10);
-		var countValuePair = getValueByName('test_histogram_count', instance.get().values);
-		var infValuePair = getValueByLabel('+Inf', instance.get().values);
-		expect(infValuePair.value).to.equal(countValuePair.value);
-	});
-
-	it('should add buckets in increasing numerical order', function() {
-		var histogram = new Histogram('test_histogram_2', 'test', { buckets: [1, 5] });
-		histogram.observe(1.5);
-		var values = histogram.get().values;
-		expect(values[0].labels.le).to.equal(1);
-		expect(values[1].labels.le).to.equal(5);
-		expect(values[2].labels.le).to.equal('+Inf');
-	});
-	it('should group counts on each label set', function() {
-		var histogram = new Histogram('test_histogram_2', 'test', [ 'code' ]);
-		histogram.observe({ code: '200' }, 1);
-		histogram.observe({ code: '300' }, 1);
-		var values = getValuesByLabel(1, histogram.get().values);
-		expect(values[0].value).to.equal(1);
-		expect(values[1].value).to.equal(1);
-	});
-
-	it('should time requests', function() {
-		var clock = sinon.useFakeTimers();
-		var doneFn = instance.startTimer();
-		clock.tick(500);
-		doneFn();
-		var valuePair = getValueByLabel(0.5, instance.get().values);
-		expect(valuePair.value).to.equal(1);
-		clock.restore();
-	});
-
-	it('should not allow non numbers', function() {
-		var fn = function() {
-			instance.observe('asd');
-		};
-		expect(fn).to.throw(Error);
-	});
-
-	it('should allow custom labels', function() {
-		var i = new Histogram('histo', 'help', [ 'code' ]);
-		i.observe({ code: 'test'}, 1);
-		var pair = getValueByLeAndLabel(1, 'code', 'test', i.get().values);
-		expect(pair.value).to.equal(1);
-	});
-
-	it('should not allow le as a custom label', function() {
-		var fn = function() {
-			new Histogram('name', 'help', [ 'le' ]);
-		};
-		expect(fn).to.throw(Error);
-	});
-
-	it('should observe value if outside most upper bound', function() {
-		instance.observe(100000);
-		var values = instance.get().values;
-		var count = getValueByLabel('+Inf', values, 'le');
-		expect(count.value).to.equal(1);
-	});
-
-	it('should allow to be reset itself', function() {
-		instance.observe(0.5);
-		var valuePair = getValueByName('test_histogram_count', instance.get().values);
-		expect(valuePair.value).to.equal(1);
-		instance.reset();
-		valuePair = getValueByName('test_histogram_count', instance.get().values);
-		expect(valuePair.value).to.equal(undefined);
-	});
-
-	describe('labels', function() {
+	describe('with a parameter for each variable', function() {
 		beforeEach(function() {
-			instance = new Histogram('histogram_labels', 'Histogram with labels fn', [ 'method' ]);
+			instance = new Histogram('test_histogram', 'test');
 		});
 
-		it('should observe', function() {
-			instance.labels('get').observe(4);
-			var res = getValueByLeAndLabel(5, 'method', 'get', instance.get().values);
-			expect(res.value).to.equal(1);
+		it('should increase count', function() {
+			instance.observe(0.5);
+			var valuePair = getValueByName('test_histogram_count', instance.get().values);
+			expect(valuePair.value).to.equal(1);
+		});
+		it('should be able to observe 0s', function() {
+			instance.observe(0);
+			var valuePair = getValueByLabel(0.005, instance.get().values);
+			expect(valuePair.value).to.equal(1);
+		});
+		it('should increase sum', function() {
+			instance.observe(0.5);
+			var valuePair = getValueByName('test_histogram_sum', instance.get().values);
+			expect(valuePair.value).to.equal(0.5);
+		});
+		it('should add item in upper bound bucket', function() {
+			instance.observe(1);
+			var valuePair = getValueByLabel(1, instance.get().values);
+			expect(valuePair.value).to.equal(1);
 		});
 
-		it('should not allow different number of labels', function() {
+		it('should be able to monitor more than one item', function() {
+			instance.observe(0.05);
+			instance.observe(5);
+			var firstValuePair = getValueByLabel(0.05, instance.get().values);
+			var secondValuePair = getValueByLabel(5, instance.get().values);
+			expect(firstValuePair.value).to.equal(1);
+			expect(secondValuePair.value).to.equal(2);
+		});
+
+		it('should add a +Inf bucket with the same value as count', function() {
+			instance.observe(10);
+			var countValuePair = getValueByName('test_histogram_count', instance.get().values);
+			var infValuePair = getValueByLabel('+Inf', instance.get().values);
+			expect(infValuePair.value).to.equal(countValuePair.value);
+		});
+
+		it('should add buckets in increasing numerical order', function() {
+			var histogram = new Histogram('test_histogram_2', 'test', { buckets: [1, 5] });
+			histogram.observe(1.5);
+			var values = histogram.get().values;
+			expect(values[0].labels.le).to.equal(1);
+			expect(values[1].labels.le).to.equal(5);
+			expect(values[2].labels.le).to.equal('+Inf');
+		});
+		it('should group counts on each label set', function() {
+			var histogram = new Histogram('test_histogram_2', 'test', [ 'code' ]);
+			histogram.observe({ code: '200' }, 1);
+			histogram.observe({ code: '300' }, 1);
+			var values = getValuesByLabel(1, histogram.get().values);
+			expect(values[0].value).to.equal(1);
+			expect(values[1].value).to.equal(1);
+		});
+
+		it('should time requests', function() {
+			var clock = sinon.useFakeTimers();
+			var doneFn = instance.startTimer();
+			clock.tick(500);
+			doneFn();
+			var valuePair = getValueByLabel(0.5, instance.get().values);
+			expect(valuePair.value).to.equal(1);
+			clock.restore();
+		});
+
+		it('should not allow non numbers', function() {
 			var fn = function() {
-				instance.labels('get', '500').observe(4);
+				instance.observe('asd');
 			};
 			expect(fn).to.throw(Error);
 		});
 
-		it('should start a timer', function() {
-			var clock = sinon.useFakeTimers();
-			var end = instance.labels('get').startTimer();
-			clock.tick(500);
-			end();
-			var res = getValueByLeAndLabel(0.5, 'method', 'get', instance.get().values);
-			expect(res.value).to.equal(1);
-			clock.restore();
+		it('should allow custom labels', function() {
+			var i = new Histogram('histo', 'help', [ 'code' ]);
+			i.observe({ code: 'test'}, 1);
+			var pair = getValueByLeAndLabel(1, 'code', 'test', i.get().values);
+			expect(pair.value).to.equal(1);
 		});
 
-		it('should start a timer and set labels afterwards', function(){
-			var clock = sinon.useFakeTimers();
-			var end = instance.startTimer();
-			clock.tick(500);
-			end({ 'method': 'get' });
-			var res = getValueByLeAndLabel(0.5, 'method', 'get', instance.get().values);
-			expect(res.value).to.equal(1);
-			clock.restore();
+		it('should not allow le as a custom label', function() {
+			var fn = function() {
+				new Histogram('name', 'help', [ 'le' ]);
+			};
+			expect(fn).to.throw(Error);
 		});
 
-		it('should allow labels before and after timers', function(){
-			instance = new Histogram('histogram_labels_2', 'Histogram with labels fn', [ 'method', 'success' ]);
-			var clock = sinon.useFakeTimers();
-			var end = instance.startTimer({ 'method': 'get' });
-			clock.tick(500);
-			end({ 'success': 'SUCCESS' });
-			var res1 = getValueByLeAndLabel(0.5, 'method', 'get', instance.get().values);
-			var res2 = getValueByLeAndLabel(0.5, 'success', 'SUCCESS', instance.get().values);
-			expect(res1.value).to.equal(1);
-			expect(res2.value).to.equal(1);
-			clock.restore();
+		it('should observe value if outside most upper bound', function() {
+			instance.observe(100000);
+			var values = instance.get().values;
+			var count = getValueByLabel('+Inf', values, 'le');
+			expect(count.value).to.equal(1);
+		});
+
+		it('should allow to be reset itself', function() {
+			instance.observe(0.5);
+			var valuePair = getValueByName('test_histogram_count', instance.get().values);
+			expect(valuePair.value).to.equal(1);
+			instance.reset();
+			valuePair = getValueByName('test_histogram_count', instance.get().values);
+			expect(valuePair.value).to.equal(undefined);
+		});
+
+		describe('labels', function() {
+			beforeEach(function() {
+				instance = new Histogram('histogram_labels', 'Histogram with labels fn', [ 'method' ]);
+			});
+
+			it('should observe', function() {
+				instance.labels('get').observe(4);
+				var res = getValueByLeAndLabel(5, 'method', 'get', instance.get().values);
+				expect(res.value).to.equal(1);
+			});
+
+			it('should not allow different number of labels', function() {
+				var fn = function() {
+					instance.labels('get', '500').observe(4);
+				};
+				expect(fn).to.throw(Error);
+			});
+
+			it('should start a timer', function() {
+				var clock = sinon.useFakeTimers();
+				var end = instance.labels('get').startTimer();
+				clock.tick(500);
+				end();
+				var res = getValueByLeAndLabel(0.5, 'method', 'get', instance.get().values);
+				expect(res.value).to.equal(1);
+				clock.restore();
+			});
+
+			it('should start a timer and set labels afterwards', function(){
+				var clock = sinon.useFakeTimers();
+				var end = instance.startTimer();
+				clock.tick(500);
+				end({ 'method': 'get' });
+				var res = getValueByLeAndLabel(0.5, 'method', 'get', instance.get().values);
+				expect(res.value).to.equal(1);
+				clock.restore();
+			});
+
+			it('should allow labels before and after timers', function(){
+				instance = new Histogram('histogram_labels_2', 'Histogram with labels fn', [ 'method', 'success' ]);
+				var clock = sinon.useFakeTimers();
+				var end = instance.startTimer({ 'method': 'get' });
+				clock.tick(500);
+				end({ 'success': 'SUCCESS' });
+				var res1 = getValueByLeAndLabel(0.5, 'method', 'get', instance.get().values);
+				var res2 = getValueByLeAndLabel(0.5, 'success', 'SUCCESS', instance.get().values);
+				expect(res1.value).to.equal(1);
+				expect(res2.value).to.equal(1);
+				clock.restore();
+			});
 		});
 	});
 
+	describe('with object as params', function() {
+		beforeEach(function() {
+			instance = new Histogram({ name: 'test_histogram', help: 'test' });
+		});
+
+		it('should increase count', function() {
+			instance.observe(0.5);
+			var valuePair = getValueByName('test_histogram_count', instance.get().values);
+			expect(valuePair.value).to.equal(1);
+		});
+		it('should be able to observe 0s', function() {
+			instance.observe(0);
+			var valuePair = getValueByLabel(0.005, instance.get().values);
+			expect(valuePair.value).to.equal(1);
+		});
+		it('should increase sum', function() {
+			instance.observe(0.5);
+			var valuePair = getValueByName('test_histogram_sum', instance.get().values);
+			expect(valuePair.value).to.equal(0.5);
+		});
+		it('should add item in upper bound bucket', function() {
+			instance.observe(1);
+			var valuePair = getValueByLabel(1, instance.get().values);
+			expect(valuePair.value).to.equal(1);
+		});
+
+		it('should be able to monitor more than one item', function() {
+			instance.observe(0.05);
+			instance.observe(5);
+			var firstValuePair = getValueByLabel(0.05, instance.get().values);
+			var secondValuePair = getValueByLabel(5, instance.get().values);
+			expect(firstValuePair.value).to.equal(1);
+			expect(secondValuePair.value).to.equal(2);
+		});
+
+		it('should add a +Inf bucket with the same value as count', function() {
+			instance.observe(10);
+			var countValuePair = getValueByName('test_histogram_count', instance.get().values);
+			var infValuePair = getValueByLabel('+Inf', instance.get().values);
+			expect(infValuePair.value).to.equal(countValuePair.value);
+		});
+
+		it('should add buckets in increasing numerical order', function() {
+			var histogram = new Histogram( { name :'test_histogram_2', help: 'test', buckets: [1, 5] });
+			histogram.observe(1.5);
+			var values = histogram.get().values;
+			expect(values[0].labels.le).to.equal(1);
+			expect(values[1].labels.le).to.equal(5);
+			expect(values[2].labels.le).to.equal('+Inf');
+		});
+		it('should group counts on each label set', function() {
+			var histogram = new Histogram({ name: 'test_histogram_2', help: 'test', labels: [ 'code' ] });
+			histogram.observe({ code: '200' }, 1);
+			histogram.observe({ code: '300' }, 1);
+			var values = getValuesByLabel(1, histogram.get().values);
+			expect(values[0].value).to.equal(1);
+			expect(values[1].value).to.equal(1);
+		});
+
+		it('should time requests', function() {
+			var clock = sinon.useFakeTimers();
+			var doneFn = instance.startTimer();
+			clock.tick(500);
+			doneFn();
+			var valuePair = getValueByLabel(0.5, instance.get().values);
+			expect(valuePair.value).to.equal(1);
+			clock.restore();
+		});
+
+		it('should not allow non numbers', function() {
+			var fn = function() {
+				instance.observe('asd');
+			};
+			expect(fn).to.throw(Error);
+		});
+
+		it('should allow custom labels', function() {
+			var i = new Histogram({ name: 'histo', help: 'help', labels: [ 'code' ] });
+			i.observe({ code: 'test'}, 1);
+			var pair = getValueByLeAndLabel(1, 'code', 'test', i.get().values);
+			expect(pair.value).to.equal(1);
+		});
+
+		it('should not allow le as a custom label', function() {
+			var fn = function() {
+				new Histogram({ name: 'name', help: 'help', labels: [ 'le' ] });
+			};
+			expect(fn).to.throw(Error);
+		});
+
+		it('should observe value if outside most upper bound', function() {
+			instance.observe(100000);
+			var values = instance.get().values;
+			var count = getValueByLabel('+Inf', values, 'le');
+			expect(count.value).to.equal(1);
+		});
+
+		it('should allow to be reset itself', function() {
+			instance.observe(0.5);
+			var valuePair = getValueByName('test_histogram_count', instance.get().values);
+			expect(valuePair.value).to.equal(1);
+			instance.reset();
+			valuePair = getValueByName('test_histogram_count', instance.get().values);
+			expect(valuePair.value).to.equal(undefined);
+		});
+
+		describe('labels', function() {
+			beforeEach(function() {
+				instance = new Histogram({ name: 'histogram_labels', help: 'Histogram with labels fn', labels: [ 'method' ] } );
+			});
+
+			it('should observe', function() {
+				instance.labels('get').observe(4);
+				var res = getValueByLeAndLabel(5, 'method', 'get', instance.get().values);
+				expect(res.value).to.equal(1);
+			});
+
+			it('should not allow different number of labels', function() {
+				var fn = function() {
+					instance.labels('get', '500').observe(4);
+				};
+				expect(fn).to.throw(Error);
+			});
+
+			it('should start a timer', function() {
+				var clock = sinon.useFakeTimers();
+				var end = instance.labels('get').startTimer();
+				clock.tick(500);
+				end();
+				var res = getValueByLeAndLabel(0.5, 'method', 'get', instance.get().values);
+				expect(res.value).to.equal(1);
+				clock.restore();
+			});
+
+			it('should start a timer and set labels afterwards', function(){
+				var clock = sinon.useFakeTimers();
+				var end = instance.startTimer();
+				clock.tick(500);
+				end({ 'method': 'get' });
+				var res = getValueByLeAndLabel(0.5, 'method', 'get', instance.get().values);
+				expect(res.value).to.equal(1);
+				clock.restore();
+			});
+
+			it('should allow labels before and after timers', function(){
+				instance = new Histogram({ name: 'histogram_labels_2', help: 'Histogram with labels fn', labels: [ 'method', 'success' ] });
+				var clock = sinon.useFakeTimers();
+				var end = instance.startTimer({ 'method': 'get' });
+				clock.tick(500);
+				end({ 'success': 'SUCCESS' });
+				var res1 = getValueByLeAndLabel(0.5, 'method', 'get', instance.get().values);
+				var res2 = getValueByLeAndLabel(0.5, 'success', 'SUCCESS', instance.get().values);
+				expect(res1.value).to.equal(1);
+				expect(res2.value).to.equal(1);
+				clock.restore();
+			});
+		});
+	});
 	function getValueByName(name, values) {
 		return values.length > 0 && values.reduce(function(acc, val) {
 			if(val.metricName === name) {

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -7,238 +7,473 @@ describe('summary', function() {
 	var sinon = require('sinon');
 	var instance;
 
-	beforeEach(function() {
-		instance = new Summary('summary_test', 'test');
-	});
-
 	afterEach(function() {
 		register.clear();
 	});
 
-	it('should add a value to the summary', function() {
-		instance.observe(100);
-		expect(instance.get().values[0].labels.quantile).to.equal(0.01);
-		expect(instance.get().values[0].value).to.equal(100);
-		expect(instance.get().values[7].metricName).to.equal('summary_test_sum');
-		expect(instance.get().values[7].value).to.equal(100);
-		expect(instance.get().values[8].metricName).to.equal('summary_test_count');
-		expect(instance.get().values[8].value).to.equal(1);
-	});
-
-	it('should be able to observe 0s', function() {
-		instance.observe(0);
-		expect(instance.get().values[8].value).to.equal(1);
-	});
-
-	it('should correctly calculate percentiles when more values are added to the summary', function() {
-		instance.observe(100);
-		instance.observe(100);
-		instance.observe(100);
-		instance.observe(50);
-		instance.observe(50);
-
-		expect(instance.get().values.length).to.equal(9);
-
-		expect(instance.get().values[0].labels.quantile).to.equal(0.01);
-		expect(instance.get().values[0].value).to.equal(50);
-
-		expect(instance.get().values[1].labels.quantile).to.equal(0.05);
-		expect(instance.get().values[1].value).to.equal(50);
-
-		expect(instance.get().values[2].labels.quantile).to.equal(0.5);
-		expect(instance.get().values[2].value).to.equal(80);
-
-		expect(instance.get().values[3].labels.quantile).to.equal(0.9);
-		expect(instance.get().values[3].value).to.equal(100);
-
-		expect(instance.get().values[4].labels.quantile).to.equal(0.95);
-		expect(instance.get().values[4].value).to.equal(100);
-
-		expect(instance.get().values[5].labels.quantile).to.equal(0.99);
-		expect(instance.get().values[5].value).to.equal(100);
-
-		expect(instance.get().values[6].labels.quantile).to.equal(0.999);
-		expect(instance.get().values[6].value).to.equal(100);
-
-		expect(instance.get().values[7].metricName).to.equal('summary_test_sum');
-		expect(instance.get().values[7].value).to.equal(400);
-
-		expect(instance.get().values[8].metricName).to.equal('summary_test_count');
-		expect(instance.get().values[8].value).to.equal(5);
-	});
-
-	it('should correctly use calculate other percentiles when configured', function() {
-		register.clear();
-		instance = new Summary('summary_test', 'test', { percentiles: [ 0.5, 0.9 ] });
-		instance.observe(100);
-		instance.observe(100);
-		instance.observe(100);
-		instance.observe(50);
-		instance.observe(50);
-
-		expect(instance.get().values.length).to.equal(4);
-
-		expect(instance.get().values[0].labels.quantile).to.equal(0.5);
-		expect(instance.get().values[0].value).to.equal(80);
-
-		expect(instance.get().values[1].labels.quantile).to.equal(0.9);
-		expect(instance.get().values[1].value).to.equal(100);
-
-		expect(instance.get().values[2].metricName).to.equal('summary_test_sum');
-		expect(instance.get().values[2].value).to.equal(400);
-
-		expect(instance.get().values[3].metricName).to.equal('summary_test_count');
-		expect(instance.get().values[3].value).to.equal(5);
-	});
-
-	it('should allow to reset itself', function() {
-		register.clear();
-		instance = new Summary('summary_test', 'test', { percentiles: [ 0.5 ] });
-		instance.observe(100);
-		expect(instance.get().values[0].labels.quantile).to.equal(0.5);
-		expect(instance.get().values[0].value).to.equal(100);
-
-		expect(instance.get().values[1].metricName).to.equal('summary_test_sum');
-		expect(instance.get().values[1].value).to.equal(100);
-
-		expect(instance.get().values[2].metricName).to.equal('summary_test_count');
-		expect(instance.get().values[2].value).to.equal(1);
-
-		instance.reset();
-
-		expect(instance.get().values[0].labels.quantile).to.equal(0.5);
-		expect(instance.get().values[0].value).to.equal(0);
-
-		expect(instance.get().values[1].metricName).to.equal('summary_test_sum');
-		expect(instance.get().values[1].value).to.equal(0);
-
-		expect(instance.get().values[2].metricName).to.equal('summary_test_count');
-		expect(instance.get().values[2].value).to.equal(0);
-	});
-
-	describe('labels', function() {
+	describe('with a parameter for each variable', function() {
 		beforeEach(function() {
+			instance = new Summary('summary_test', 'test');
+		});
+
+		it('should add a value to the summary', function() {
+			instance.observe(100);
+			expect(instance.get().values[0].labels.quantile).to.equal(0.01);
+			expect(instance.get().values[0].value).to.equal(100);
+			expect(instance.get().values[7].metricName).to.equal('summary_test_sum');
+			expect(instance.get().values[7].value).to.equal(100);
+			expect(instance.get().values[8].metricName).to.equal('summary_test_count');
+			expect(instance.get().values[8].value).to.equal(1);
+		});
+
+		it('should be able to observe 0s', function() {
+			instance.observe(0);
+			expect(instance.get().values[8].value).to.equal(1);
+		});
+
+		it('should correctly calculate percentiles when more values are added to the summary', function() {
+			instance.observe(100);
+			instance.observe(100);
+			instance.observe(100);
+			instance.observe(50);
+			instance.observe(50);
+
+			expect(instance.get().values.length).to.equal(9);
+
+			expect(instance.get().values[0].labels.quantile).to.equal(0.01);
+			expect(instance.get().values[0].value).to.equal(50);
+
+			expect(instance.get().values[1].labels.quantile).to.equal(0.05);
+			expect(instance.get().values[1].value).to.equal(50);
+
+			expect(instance.get().values[2].labels.quantile).to.equal(0.5);
+			expect(instance.get().values[2].value).to.equal(80);
+
+			expect(instance.get().values[3].labels.quantile).to.equal(0.9);
+			expect(instance.get().values[3].value).to.equal(100);
+
+			expect(instance.get().values[4].labels.quantile).to.equal(0.95);
+			expect(instance.get().values[4].value).to.equal(100);
+
+			expect(instance.get().values[5].labels.quantile).to.equal(0.99);
+			expect(instance.get().values[5].value).to.equal(100);
+
+			expect(instance.get().values[6].labels.quantile).to.equal(0.999);
+			expect(instance.get().values[6].value).to.equal(100);
+
+			expect(instance.get().values[7].metricName).to.equal('summary_test_sum');
+			expect(instance.get().values[7].value).to.equal(400);
+
+			expect(instance.get().values[8].metricName).to.equal('summary_test_count');
+			expect(instance.get().values[8].value).to.equal(5);
+		});
+
+		it('should correctly use calculate other percentiles when configured', function() {
 			register.clear();
-			instance = new Summary('summary_test', 'help', [ 'method', 'endpoint'], { percentiles: [ 0.9 ] });
+			instance = new Summary('summary_test', 'test', { percentiles: [ 0.5, 0.9 ] });
+			instance.observe(100);
+			instance.observe(100);
+			instance.observe(100);
+			instance.observe(50);
+			instance.observe(50);
+
+			expect(instance.get().values.length).to.equal(4);
+
+			expect(instance.get().values[0].labels.quantile).to.equal(0.5);
+			expect(instance.get().values[0].value).to.equal(80);
+
+			expect(instance.get().values[1].labels.quantile).to.equal(0.9);
+			expect(instance.get().values[1].value).to.equal(100);
+
+			expect(instance.get().values[2].metricName).to.equal('summary_test_sum');
+			expect(instance.get().values[2].value).to.equal(400);
+
+			expect(instance.get().values[3].metricName).to.equal('summary_test_count');
+			expect(instance.get().values[3].value).to.equal(5);
 		});
 
-		it('should record and calculate the correct values per label', function() {
-			instance.labels('GET', '/test').observe(50);
-			instance.labels('POST', '/test').observe(100);
+		it('should allow to reset itself', function() {
+			register.clear();
+			instance = new Summary('summary_test', 'test', { percentiles: [ 0.5 ] });
+			instance.observe(100);
+			expect(instance.get().values[0].labels.quantile).to.equal(0.5);
+			expect(instance.get().values[0].value).to.equal(100);
 
-			var values = instance.get().values;
-			expect(values).to.have.length(6);
-			expect(values[0].labels.method).to.equal('GET');
-			expect(values[0].labels.endpoint).to.equal('/test');
-			expect(values[0].labels.quantile).to.equal(0.9);
-			expect(values[0].value).to.equal(50);
+			expect(instance.get().values[1].metricName).to.equal('summary_test_sum');
+			expect(instance.get().values[1].value).to.equal(100);
 
-			expect(values[1].metricName).to.equal('summary_test_sum');
-			expect(values[1].labels.method).to.equal('GET');
-			expect(values[1].labels.endpoint).to.equal('/test');
-			expect(values[1].value).to.equal(50);
+			expect(instance.get().values[2].metricName).to.equal('summary_test_count');
+			expect(instance.get().values[2].value).to.equal(1);
 
-			expect(values[2].metricName).to.equal('summary_test_count');
-			expect(values[2].labels.method).to.equal('GET');
-			expect(values[2].labels.endpoint).to.equal('/test');
-			expect(values[2].value).to.equal(1);
+			instance.reset();
 
-			expect(values[3].labels.quantile).to.equal(0.9);
-			expect(values[3].labels.method).to.equal('POST');
-			expect(values[3].labels.endpoint).to.equal('/test');
-			expect(values[3].value).to.equal(100);
+			expect(instance.get().values[0].labels.quantile).to.equal(0.5);
+			expect(instance.get().values[0].value).to.equal(0);
 
-			expect(values[4].metricName).to.equal('summary_test_sum');
-			expect(values[4].labels.method).to.equal('POST');
-			expect(values[4].labels.endpoint).to.equal('/test');
-			expect(values[4].value).to.equal(100);
+			expect(instance.get().values[1].metricName).to.equal('summary_test_sum');
+			expect(instance.get().values[1].value).to.equal(0);
 
-			expect(values[5].metricName).to.equal('summary_test_count');
-			expect(values[5].labels.method).to.equal('POST');
-			expect(values[5].labels.endpoint).to.equal('/test');
-			expect(values[5].value).to.equal(1);
+			expect(instance.get().values[2].metricName).to.equal('summary_test_count');
+			expect(instance.get().values[2].value).to.equal(0);
 		});
 
-		it('should throw error if label lengths does not match', function() {
-			var fn = function() {
-				instance.labels('GET').observe();
-			};
-			expect(fn).to.throw(Error);
+		describe('labels', function() {
+			beforeEach(function() {
+				register.clear();
+				instance = new Summary('summary_test', 'help', [ 'method', 'endpoint'], { percentiles: [ 0.9 ] });
+			});
+
+			it('should record and calculate the correct values per label', function() {
+				instance.labels('GET', '/test').observe(50);
+				instance.labels('POST', '/test').observe(100);
+
+				var values = instance.get().values;
+				expect(values).to.have.length(6);
+				expect(values[0].labels.method).to.equal('GET');
+				expect(values[0].labels.endpoint).to.equal('/test');
+				expect(values[0].labels.quantile).to.equal(0.9);
+				expect(values[0].value).to.equal(50);
+
+				expect(values[1].metricName).to.equal('summary_test_sum');
+				expect(values[1].labels.method).to.equal('GET');
+				expect(values[1].labels.endpoint).to.equal('/test');
+				expect(values[1].value).to.equal(50);
+
+				expect(values[2].metricName).to.equal('summary_test_count');
+				expect(values[2].labels.method).to.equal('GET');
+				expect(values[2].labels.endpoint).to.equal('/test');
+				expect(values[2].value).to.equal(1);
+
+				expect(values[3].labels.quantile).to.equal(0.9);
+				expect(values[3].labels.method).to.equal('POST');
+				expect(values[3].labels.endpoint).to.equal('/test');
+				expect(values[3].value).to.equal(100);
+
+				expect(values[4].metricName).to.equal('summary_test_sum');
+				expect(values[4].labels.method).to.equal('POST');
+				expect(values[4].labels.endpoint).to.equal('/test');
+				expect(values[4].value).to.equal(100);
+
+				expect(values[5].metricName).to.equal('summary_test_count');
+				expect(values[5].labels.method).to.equal('POST');
+				expect(values[5].labels.endpoint).to.equal('/test');
+				expect(values[5].value).to.equal(1);
+			});
+
+			it('should throw error if label lengths does not match', function() {
+				var fn = function() {
+					instance.labels('GET').observe();
+				};
+				expect(fn).to.throw(Error);
+			});
+
+			it('should start a timer', function() {
+				var clock = sinon.useFakeTimers();
+				var end = instance.labels('GET', '/test').startTimer();
+				clock.tick(1000);
+				end();
+				var values = instance.get().values;
+				expect(values).to.have.length(3);
+				expect(values[0].labels.method).to.equal('GET');
+				expect(values[0].labels.endpoint).to.equal('/test');
+				expect(values[0].labels.quantile).to.equal(0.9);
+				expect(values[0].value).to.equal(1);
+
+				expect(values[1].metricName).to.equal('summary_test_sum');
+				expect(values[1].labels.method).to.equal('GET');
+				expect(values[1].labels.endpoint).to.equal('/test');
+				expect(values[1].value).to.equal(1);
+
+				expect(values[2].metricName).to.equal('summary_test_count');
+				expect(values[2].labels.method).to.equal('GET');
+				expect(values[2].labels.endpoint).to.equal('/test');
+				expect(values[2].value).to.equal(1);
+
+				clock.restore();
+			});
+
+			it('should start a timer and set labels afterwards', function(){
+				var clock = sinon.useFakeTimers();
+				var end = instance.startTimer();
+				clock.tick(1000);
+				end({ 'method': 'GET', 'endpoint': '/test' });
+				var values = instance.get().values;
+				expect(values).to.have.length(3);
+				expect(values[0].labels.method).to.equal('GET');
+				expect(values[0].labels.endpoint).to.equal('/test');
+				expect(values[0].labels.quantile).to.equal(0.9);
+				expect(values[0].value).to.equal(1);
+
+				expect(values[1].metricName).to.equal('summary_test_sum');
+				expect(values[1].labels.method).to.equal('GET');
+				expect(values[1].labels.endpoint).to.equal('/test');
+				expect(values[1].value).to.equal(1);
+
+				expect(values[2].metricName).to.equal('summary_test_count');
+				expect(values[2].labels.method).to.equal('GET');
+				expect(values[2].labels.endpoint).to.equal('/test');
+				expect(values[2].value).to.equal(1);
+
+				clock.restore();
+			});
+
+			it('should allow labels before and after timers', function(){
+				var clock = sinon.useFakeTimers();
+				var end = instance.startTimer({ 'method': 'GET' });
+				clock.tick(1000);
+				end({ 'endpoint': '/test' });
+				var values = instance.get().values;
+				expect(values).to.have.length(3);
+				expect(values[0].labels.method).to.equal('GET');
+				expect(values[0].labels.endpoint).to.equal('/test');
+				expect(values[0].labels.quantile).to.equal(0.9);
+				expect(values[0].value).to.equal(1);
+
+				expect(values[1].metricName).to.equal('summary_test_sum');
+				expect(values[1].labels.method).to.equal('GET');
+				expect(values[1].labels.endpoint).to.equal('/test');
+				expect(values[1].value).to.equal(1);
+
+				expect(values[2].metricName).to.equal('summary_test_count');
+				expect(values[2].labels.method).to.equal('GET');
+				expect(values[2].labels.endpoint).to.equal('/test');
+				expect(values[2].value).to.equal(1);
+
+				clock.restore();
+			});
+		});
+	});
+
+	describe('with param as object', function() {
+		beforeEach(function() {
+			instance = new Summary({ name: 'summary_test', help: 'test' });
 		});
 
-		it('should start a timer', function() {
-			var clock = sinon.useFakeTimers();
-			var end = instance.labels('GET', '/test').startTimer();
-			clock.tick(1000);
-			end();
-			var values = instance.get().values;
-			expect(values).to.have.length(3);
-			expect(values[0].labels.method).to.equal('GET');
-			expect(values[0].labels.endpoint).to.equal('/test');
-			expect(values[0].labels.quantile).to.equal(0.9);
-			expect(values[0].value).to.equal(1);
-
-			expect(values[1].metricName).to.equal('summary_test_sum');
-			expect(values[1].labels.method).to.equal('GET');
-			expect(values[1].labels.endpoint).to.equal('/test');
-			expect(values[1].value).to.equal(1);
-
-			expect(values[2].metricName).to.equal('summary_test_count');
-			expect(values[2].labels.method).to.equal('GET');
-			expect(values[2].labels.endpoint).to.equal('/test');
-			expect(values[2].value).to.equal(1);
-
-			clock.restore();
+		it('should add a value to the summary', function() {
+			instance.observe(100);
+			expect(instance.get().values[0].labels.quantile).to.equal(0.01);
+			expect(instance.get().values[0].value).to.equal(100);
+			expect(instance.get().values[7].metricName).to.equal('summary_test_sum');
+			expect(instance.get().values[7].value).to.equal(100);
+			expect(instance.get().values[8].metricName).to.equal('summary_test_count');
+			expect(instance.get().values[8].value).to.equal(1);
 		});
 
-		it('should start a timer and set labels afterwards', function(){
-			var clock = sinon.useFakeTimers();
-			var end = instance.startTimer();
-			clock.tick(1000);
-			end({ 'method': 'GET', 'endpoint': '/test' });
-			var values = instance.get().values;
-			expect(values).to.have.length(3);
-			expect(values[0].labels.method).to.equal('GET');
-			expect(values[0].labels.endpoint).to.equal('/test');
-			expect(values[0].labels.quantile).to.equal(0.9);
-			expect(values[0].value).to.equal(1);
-
-			expect(values[1].metricName).to.equal('summary_test_sum');
-			expect(values[1].labels.method).to.equal('GET');
-			expect(values[1].labels.endpoint).to.equal('/test');
-			expect(values[1].value).to.equal(1);
-
-			expect(values[2].metricName).to.equal('summary_test_count');
-			expect(values[2].labels.method).to.equal('GET');
-			expect(values[2].labels.endpoint).to.equal('/test');
-			expect(values[2].value).to.equal(1);
-
-			clock.restore();
+		it('should be able to observe 0s', function() {
+			instance.observe(0);
+			expect(instance.get().values[8].value).to.equal(1);
 		});
 
-		it('should allow labels before and after timers', function(){
-			var clock = sinon.useFakeTimers();
-			var end = instance.startTimer({ 'method': 'GET' });
-			clock.tick(1000);
-			end({ 'endpoint': '/test' });
-			var values = instance.get().values;
-			expect(values).to.have.length(3);
-			expect(values[0].labels.method).to.equal('GET');
-			expect(values[0].labels.endpoint).to.equal('/test');
-			expect(values[0].labels.quantile).to.equal(0.9);
-			expect(values[0].value).to.equal(1);
+		it('should correctly calculate percentiles when more values are added to the summary', function() {
+			instance.observe(100);
+			instance.observe(100);
+			instance.observe(100);
+			instance.observe(50);
+			instance.observe(50);
 
-			expect(values[1].metricName).to.equal('summary_test_sum');
-			expect(values[1].labels.method).to.equal('GET');
-			expect(values[1].labels.endpoint).to.equal('/test');
-			expect(values[1].value).to.equal(1);
+			expect(instance.get().values.length).to.equal(9);
 
-			expect(values[2].metricName).to.equal('summary_test_count');
-			expect(values[2].labels.method).to.equal('GET');
-			expect(values[2].labels.endpoint).to.equal('/test');
-			expect(values[2].value).to.equal(1);
+			expect(instance.get().values[0].labels.quantile).to.equal(0.01);
+			expect(instance.get().values[0].value).to.equal(50);
 
-			clock.restore();
+			expect(instance.get().values[1].labels.quantile).to.equal(0.05);
+			expect(instance.get().values[1].value).to.equal(50);
+
+			expect(instance.get().values[2].labels.quantile).to.equal(0.5);
+			expect(instance.get().values[2].value).to.equal(80);
+
+			expect(instance.get().values[3].labels.quantile).to.equal(0.9);
+			expect(instance.get().values[3].value).to.equal(100);
+
+			expect(instance.get().values[4].labels.quantile).to.equal(0.95);
+			expect(instance.get().values[4].value).to.equal(100);
+
+			expect(instance.get().values[5].labels.quantile).to.equal(0.99);
+			expect(instance.get().values[5].value).to.equal(100);
+
+			expect(instance.get().values[6].labels.quantile).to.equal(0.999);
+			expect(instance.get().values[6].value).to.equal(100);
+
+			expect(instance.get().values[7].metricName).to.equal('summary_test_sum');
+			expect(instance.get().values[7].value).to.equal(400);
+
+			expect(instance.get().values[8].metricName).to.equal('summary_test_count');
+			expect(instance.get().values[8].value).to.equal(5);
+		});
+
+		it('should correctly use calculate other percentiles when configured', function() {
+			register.clear();
+			instance = new Summary({ name: 'summary_test', help: 'test', percentiles: [ 0.5, 0.9 ] });
+			instance.observe(100);
+			instance.observe(100);
+			instance.observe(100);
+			instance.observe(50);
+			instance.observe(50);
+
+			expect(instance.get().values.length).to.equal(4);
+
+			expect(instance.get().values[0].labels.quantile).to.equal(0.5);
+			expect(instance.get().values[0].value).to.equal(80);
+
+			expect(instance.get().values[1].labels.quantile).to.equal(0.9);
+			expect(instance.get().values[1].value).to.equal(100);
+
+			expect(instance.get().values[2].metricName).to.equal('summary_test_sum');
+			expect(instance.get().values[2].value).to.equal(400);
+
+			expect(instance.get().values[3].metricName).to.equal('summary_test_count');
+			expect(instance.get().values[3].value).to.equal(5);
+		});
+
+		it('should allow to reset itself', function() {
+			register.clear();
+			instance = new Summary({ name: 'summary_test', help: 'test', percentiles: [ 0.5 ] });
+			instance.observe(100);
+			expect(instance.get().values[0].labels.quantile).to.equal(0.5);
+			expect(instance.get().values[0].value).to.equal(100);
+
+			expect(instance.get().values[1].metricName).to.equal('summary_test_sum');
+			expect(instance.get().values[1].value).to.equal(100);
+
+			expect(instance.get().values[2].metricName).to.equal('summary_test_count');
+			expect(instance.get().values[2].value).to.equal(1);
+
+			instance.reset();
+
+			expect(instance.get().values[0].labels.quantile).to.equal(0.5);
+			expect(instance.get().values[0].value).to.equal(0);
+
+			expect(instance.get().values[1].metricName).to.equal('summary_test_sum');
+			expect(instance.get().values[1].value).to.equal(0);
+
+			expect(instance.get().values[2].metricName).to.equal('summary_test_count');
+			expect(instance.get().values[2].value).to.equal(0);
+		});
+
+		describe('labels', function() {
+			beforeEach(function() {
+				register.clear();
+				instance = new Summary({ name: 'summary_test', help: 'help', labels: [ 'method', 'endpoint'], percentiles: [ 0.9 ] });
+			});
+
+			it('should record and calculate the correct values per label', function() {
+				instance.labels('GET', '/test').observe(50);
+				instance.labels('POST', '/test').observe(100);
+
+				var values = instance.get().values;
+				expect(values).to.have.length(6);
+				expect(values[0].labels.method).to.equal('GET');
+				expect(values[0].labels.endpoint).to.equal('/test');
+				expect(values[0].labels.quantile).to.equal(0.9);
+				expect(values[0].value).to.equal(50);
+
+				expect(values[1].metricName).to.equal('summary_test_sum');
+				expect(values[1].labels.method).to.equal('GET');
+				expect(values[1].labels.endpoint).to.equal('/test');
+				expect(values[1].value).to.equal(50);
+
+				expect(values[2].metricName).to.equal('summary_test_count');
+				expect(values[2].labels.method).to.equal('GET');
+				expect(values[2].labels.endpoint).to.equal('/test');
+				expect(values[2].value).to.equal(1);
+
+				expect(values[3].labels.quantile).to.equal(0.9);
+				expect(values[3].labels.method).to.equal('POST');
+				expect(values[3].labels.endpoint).to.equal('/test');
+				expect(values[3].value).to.equal(100);
+
+				expect(values[4].metricName).to.equal('summary_test_sum');
+				expect(values[4].labels.method).to.equal('POST');
+				expect(values[4].labels.endpoint).to.equal('/test');
+				expect(values[4].value).to.equal(100);
+
+				expect(values[5].metricName).to.equal('summary_test_count');
+				expect(values[5].labels.method).to.equal('POST');
+				expect(values[5].labels.endpoint).to.equal('/test');
+				expect(values[5].value).to.equal(1);
+			});
+
+			it('should throw error if label lengths does not match', function() {
+				var fn = function() {
+					instance.labels('GET').observe();
+				};
+				expect(fn).to.throw(Error);
+			});
+
+			it('should start a timer', function() {
+				var clock = sinon.useFakeTimers();
+				var end = instance.labels('GET', '/test').startTimer();
+				clock.tick(1000);
+				end();
+				var values = instance.get().values;
+				expect(values).to.have.length(3);
+				expect(values[0].labels.method).to.equal('GET');
+				expect(values[0].labels.endpoint).to.equal('/test');
+				expect(values[0].labels.quantile).to.equal(0.9);
+				expect(values[0].value).to.equal(1);
+
+				expect(values[1].metricName).to.equal('summary_test_sum');
+				expect(values[1].labels.method).to.equal('GET');
+				expect(values[1].labels.endpoint).to.equal('/test');
+				expect(values[1].value).to.equal(1);
+
+				expect(values[2].metricName).to.equal('summary_test_count');
+				expect(values[2].labels.method).to.equal('GET');
+				expect(values[2].labels.endpoint).to.equal('/test');
+				expect(values[2].value).to.equal(1);
+
+				clock.restore();
+			});
+
+			it('should start a timer and set labels afterwards', function(){
+				var clock = sinon.useFakeTimers();
+				var end = instance.startTimer();
+				clock.tick(1000);
+				end({ 'method': 'GET', 'endpoint': '/test' });
+				var values = instance.get().values;
+				expect(values).to.have.length(3);
+				expect(values[0].labels.method).to.equal('GET');
+				expect(values[0].labels.endpoint).to.equal('/test');
+				expect(values[0].labels.quantile).to.equal(0.9);
+				expect(values[0].value).to.equal(1);
+
+				expect(values[1].metricName).to.equal('summary_test_sum');
+				expect(values[1].labels.method).to.equal('GET');
+				expect(values[1].labels.endpoint).to.equal('/test');
+				expect(values[1].value).to.equal(1);
+
+				expect(values[2].metricName).to.equal('summary_test_count');
+				expect(values[2].labels.method).to.equal('GET');
+				expect(values[2].labels.endpoint).to.equal('/test');
+				expect(values[2].value).to.equal(1);
+
+				clock.restore();
+			});
+
+			it('should allow labels before and after timers', function(){
+				var clock = sinon.useFakeTimers();
+				var end = instance.startTimer({ 'method': 'GET' });
+				clock.tick(1000);
+				end({ 'endpoint': '/test' });
+				var values = instance.get().values;
+				expect(values).to.have.length(3);
+				expect(values[0].labels.method).to.equal('GET');
+				expect(values[0].labels.endpoint).to.equal('/test');
+				expect(values[0].labels.quantile).to.equal(0.9);
+				expect(values[0].value).to.equal(1);
+
+				expect(values[1].metricName).to.equal('summary_test_sum');
+				expect(values[1].labels.method).to.equal('GET');
+				expect(values[1].labels.endpoint).to.equal('/test');
+				expect(values[1].value).to.equal(1);
+
+				expect(values[2].metricName).to.equal('summary_test_count');
+				expect(values[2].labels.method).to.equal('GET');
+				expect(values[2].labels.endpoint).to.equal('/test');
+				expect(values[2].value).to.equal(1);
+
+				clock.restore();
+			});
 		});
 	});
 });


### PR DESCRIPTION
As discussed in #100, it's been a mess to add new functionality to the metrics because of parameter bloat in the constructor for each metric.

This PR tries to address this, replacing the old 'one parameter for each parameter' with an object that can hold all parameters needed for the constructor. This will make it easier to add new functionality in the future.

This PR should be backwards compatible, but the old one should be deprecated from now on.

@SimenB @SkeLLLa @eljasala could anyone of you have a look?