### PR TITLE
Merge registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## Unreleased
 ### Added
+- Ability to merge registries
+
 ### Changed
 
 ## [9.0.0] - 2017-05-06

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ You can prevent this by setting last parameter when creating the metric to `fals
 Using non-global registries requires creating Registry instance and adding it inside `registers` inside the configuration object. Alternatively
 you can pass an empty `registers` array and register it manually.
 
-Each registry has a merge function that enables you to expose multiple registries on the same endpoint.
+Each registry has a merge function that enables you to expose multiple registries on the same endpoint. If the same metric name exists in both registries, an error will be thrown.
 
 ```js
 var client = require('prom-client');

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ You can prevent this by setting last parameter when creating the metric to `fals
 Using non-global registries requires creating Registry instance and adding it inside `registers` inside the configuration object. Alternatively
 you can pass an empty `registers` array and register it manually.
 
-Each registry has a merge function that enables you to expose multiple registries on the same endpoint. If the same metric name exists in both registries, an error will be thrown.
+Registry has a merge function that enables you to expose multiple registries on the same endpoint. If the same metric name exists in both registries, an error will be thrown.
 
 ```js
 var client = require('prom-client');
@@ -225,7 +225,7 @@ var histogram = new client.Histogram({name: 'metric_name', help: 'metric_help', 
 registry.registerMetric(histogram);
 counter.inc();
 
-var mergedRegistries = client.register.merge([registry]);
+var mergedRegistries = client.Registry.merge([registry, client.register]);
 ```
 
 #### Register

--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ You can prevent this by setting last parameter when creating the metric to `fals
 Using non-global registries requires creating Registry instance and adding it inside `registers` inside the configuration object. Alternatively
 you can pass an empty `registers` array and register it manually.
 
+Each registry has a merge function that enables you to expose multiple registries on the same endpoint.
+
 ```js
 var client = require('prom-client');
 var registry = new client.Registry();
@@ -222,6 +224,8 @@ var counter = new client.Counter({name: 'metric_name', help: 'metric_help', regi
 var histogram = new client.Histogram({name: 'metric_name', help: 'metric_help', registers: [ ]});
 registry.registerMetric(histogram);
 counter.inc();
+
+var mergedRegistries = client.register.merge([registry]);
 ```
 
 #### Register

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,11 @@ export class Registry {
 	 * @param name The name of the metric
 	 */
 	getSingleMetricAsString(name:string): string
+	/**
+	* Merge registers
+	* @param registers The registers you want to merge together
+	*/
+	merge(registers: Registry[]): Registry
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,8 +68,8 @@ interface labelValues {
 export interface CounterConfiguration {
 	name: string,
 	help: string,
-	labels: string [],
-	registers: Registry[]
+	labelNames?: string [],
+	registers?: Registry[]
 }
 
 /**
@@ -128,8 +128,8 @@ export namespace Counter {
 export interface GaugeConfiguration{
 	name: string,
 	help: string,
-	labels: string[],
-	registers: Registry[]
+	labelNames?: string[],
+	registers?: Registry[]
 }
 
 /**
@@ -254,9 +254,9 @@ export namespace Gauge {
 export interface HistogramConfiguration {
 	name: string,
 	help: string,
-	labels: string[],
-	buckets: number[],
-	registers: Registry[]
+	labelNames?: string[],
+	buckets?: number[],
+	registers?: Registry[]
 }
 
 /**
@@ -338,9 +338,9 @@ export namespace Histogram {
 export interface SummaryConfiguration{
 	name: string,
 	help: string,
-	labels: string[]
-	percentiles: number[],
-	registers: Registry[]
+	labelNames?: string[]
+	percentiles?: number[],
+	registers?: Registry[]
 }
 
 /**

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -93,7 +93,7 @@ var registry = (function() {
 
 		selfMetrics.concat(metricsToMerge).forEach(mergedRegistry.registerMetric);
 		return mergedRegistry;
-	}
+	};
 
 	Registry.prototype.contentType = 'text/plain; version=0.0.4; charset=utf-8';
 	return new Registry();

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -16,7 +16,7 @@ var registry = (function() {
 		self = this;
 	}
 
-	var getMetricsAsArray = function() {
+	Registry.prototype.getMetricsAsArray = function() {
 		return Object.keys(_metrics)
 			.map(self.getSingleMetric, self);
 	};
@@ -48,7 +48,7 @@ var registry = (function() {
 	};
 
 	Registry.prototype.metrics = function() {
-		return getMetricsAsArray()
+		return self.getMetricsAsArray()
 			.map(this.getMetricAsPrometheusString, this)
 			.join('\n');
 	};
@@ -66,7 +66,7 @@ var registry = (function() {
 	};
 
 	Registry.prototype.getMetricsAsJSON = function() {
-		return getMetricsAsArray().map(function(metric) {
+		return self.getMetricsAsArray().map(function(metric) {
 			return metric.get();
 		});
 	};
@@ -82,6 +82,18 @@ var registry = (function() {
 	Registry.prototype.getSingleMetric = function(name) {
 		return _metrics[name];
 	};
+
+	Registry.prototype.merge = function(registers) {
+		var mergedRegistry = new Registry();
+
+		var selfMetrics = self.getMetricsAsArray() || [];
+		var metricsToMerge = registers.reduce(function(acc, reg) {
+			return acc.concat(reg.getMetricsAsArray());
+		}, []);
+
+		selfMetrics.concat(metricsToMerge).forEach(mergedRegistry.registerMetric);
+		return mergedRegistry;
+	}
 
 	Registry.prototype.contentType = 'text/plain; version=0.0.4; charset=utf-8';
 	return new Registry();

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -54,7 +54,7 @@ var registry = (function() {
 	};
 
 	Registry.prototype.registerMetric = function(metricFn) {
-		if(_metrics[metricFn.name]) {
+		if(_metrics[metricFn.name] && _metrics[metricFn.name] !== metricFn) {
 			throw new Error('A metric with the name ' + metricFn.name + ' has already been registered.');
 		}
 
@@ -83,19 +83,19 @@ var registry = (function() {
 		return _metrics[name];
 	};
 
-	Registry.prototype.merge = function(registers) {
-		var mergedRegistry = new Registry();
-
-		var selfMetrics = self.getMetricsAsArray() || [];
-		var metricsToMerge = registers.reduce(function(acc, reg) {
-			return acc.concat(reg.getMetricsAsArray());
-		}, []);
-
-		selfMetrics.concat(metricsToMerge).forEach(mergedRegistry.registerMetric);
-		return mergedRegistry;
-	};
-
 	Registry.prototype.contentType = 'text/plain; version=0.0.4; charset=utf-8';
 	return new Registry();
 });
+
 module.exports = registry;
+
+registry.merge = function(registers) {
+	var mergedRegistry = new registry();
+
+	var metricsToMerge = registers.reduce(function(acc, reg) {
+		return acc.concat(reg.getMetricsAsArray());
+	}, []);
+
+	metricsToMerge.forEach(mergedRegistry.registerMetric);
+	return mergedRegistry;
+};

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -147,7 +147,7 @@ describe('register', function() {
 			registryOne.registerMetric(getMetric('one'));
 			registryTwo.registerMetric(getMetric('two'));
 
-			var merged = register.merge([registryOne, registryTwo]).getMetricsAsJSON();
+			var merged = Registry.merge([registryOne, registryTwo]).getMetricsAsJSON();
 			expect(merged).to.have.length(2);
 		});
 
@@ -156,7 +156,7 @@ describe('register', function() {
 			registryTwo.registerMetric(getMetric());
 
 			var fn = function() {
-				register.merge([registryOne, registryTwo]);
+				Registry.merge([registryOne, registryTwo]);
 			};
 
 			expect(fn).to.throw(Error);

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -133,6 +133,36 @@ describe('register', function() {
 		expect(output).to.equal(metric);
 	});
 
+	describe('merging', function() {
+		var Registry = require('../lib/registry');
+		var registryOne;
+		var registryTwo;
+
+		beforeEach(function() {
+			registryOne = new Registry();
+			registryTwo = new Registry();
+		});
+
+		it('should merge all provided registers', function() {
+			registryOne.registerMetric(getMetric('one'));
+			registryTwo.registerMetric(getMetric('two'));
+
+			var merged = register.merge([registryOne, registryTwo]).getMetricsAsJSON();
+			expect(merged).to.have.length(2);
+		});
+
+		it('should throw if same name exists on both registers', function() {
+			registryOne.registerMetric(getMetric());
+			registryTwo.registerMetric(getMetric());
+
+			var fn = function() {
+				register.merge([registryOne, registryTwo]);
+			};
+
+			expect(fn).to.throw(Error);
+		});
+	});
+
 	function getMetric(name) {
 		name = name || 'test_metric';
 		return {


### PR DESCRIPTION
Makes it possible to merge multiple registries - handy when you want to expose modules registers within your app for example.