### PR TITLE
Support exposing metrics as Protocol Buffer messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ A prometheus client for node.js that supports histogram, summaries, gauges and c
 
 ### Usage
 
-See example folder for a sample usage. The library does not bundle any web framework, to expose the metrics just return the metrics() function in the registry.
+See example folder for a sample usage. The library does not bundle any web framework, to expose the metrics just return the metrics() or metricsProtobuf() function in the registry.
 
 ### API
 
 #### Configuration
 
-All metric types has 2 mandatory parameters, name and help.
+All metric types have 2 mandatory parameters, name and help.
 
 #### Default metrics
 
@@ -226,7 +226,8 @@ counter.inc();
 
 #### Register
 
-You can get all metrics by running `register.metrics()`, which will output a string for prometheus to consume.
+You can get all metrics in text format by running `register.metrics()`, or in protobuf format by running `register.metricsProtobuf()`. Both are consumable by Prometheus.
+`register.metricsProtobuf()` returns a buffer which can be sent in the body of an HTTP response.
 
 ##### Geting a single metric for Prometheus displaying
 
@@ -285,3 +286,14 @@ The content-type prometheus expects is also exported as a constant, both on the 
 ### Garbage Collection
 
 To avoid dependencies in this module, GC stats are kept outside of it. If you want GC stats, you can use https://github.com/SimenB/node-prometheus-gc-stats
+
+### Run the tests in Docker
+
+This will install the NPM packages to the local `node_modules` directory. Beware these packages will need rebuilt if you plan to use them outside Docker, unless your system is Linux and has the same dependencies.
+```shell
+git clone git@github.com:siimon/prom-client.git
+cd prom-client
+rm -rf node_modules # Only if pre-existing AND your system is not Linux
+docker run -it --rm -v $(pwd):/code --workdir /code --entrypoint npm node:7.9.0 install
+docker run -it --rm -v $(pwd):/code --workdir /code --entrypoint npm node:7.9.0 test
+```

--- a/example/server.js
+++ b/example/server.js
@@ -2,16 +2,14 @@
 
 var express = require('express');
 var server = express();
-var register = require('../lib/register');
+var client = require('../index');
+var register = client.register;
 
-var Histogram = require('../').Histogram;
-var h = new Histogram({ name: 'test_histogram', help: 'Example of a histogram', labelNames: [ 'code' ] });
+var h = new client.Histogram({ name: 'test_histogram', help: 'Example of a histogram', labelNames: [ 'code' ] });
 
-var Counter = require('../').Counter;
-var c = new Counter({ name: 'test_counter', help: 'Example of a counter', labelNames: [ 'code' ] });
+var c = new client.Counter({ name: 'test_counter', help: 'Example of a counter', labelNames: [ 'code' ] });
 
-var Gauge = require('../').Gauge;
-var g = new Gauge({ name: 'test_gauge', help: 'Example of a gauge', labelNames: [ 'method', 'code' ] });
+var g = new client.Gauge({ name: 'test_gauge', help: 'Example of a gauge', labelNames: [ 'method', 'code' ] });
 
 setTimeout(function() {
 	h.labels('200').observe(Math.random());
@@ -45,6 +43,12 @@ server.get('/metrics', function(req, res) {
 server.get('/metrics/counter', function(req, res) {
 	res.set('Content-Type', register.contentType);
 	res.end(register.getSingleMetricAsString('test_counter'));
+});
+
+server.get('/metrics/protobuf', function(req, res) {
+	client.collectDefaultMetrics();
+	res.set('Content-Type', register.contentTypeProto);
+	res.end(register.metricsProtobuf());
 });
 
 console.log('Server listening to 3000, metrics exposed on /metrics endpoint'); //eslint-disable-line no-console

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@
 exports.register = require('./lib/register');
 exports.Registry = require('./lib/registry');
 exports.contentType = require('./lib/register').contentType;
+exports.contentTypeProto = require('./lib/register').contentTypeProto;
 
 exports.Counter = require('./lib/counter');
 exports.Gauge = require('./lib/gauge');

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -13,6 +13,7 @@ var validateMetricName = require('./validation').validateMetricName;
 var validateLabelNames = require('./validation').validateLabelName;
 var isObject = require('./util').isObject;
 var extend = require('util-extend');
+var convertLabelsToProto = require('./util').convertLabelsToProto;
 
 var getLabels = require('./util').getLabels;
 
@@ -93,6 +94,25 @@ Counter.prototype.get = function() {
 	};
 };
 
+Counter.prototype.getProtoCompliant = function() {
+	var metrics = [];
+	var properties = getProperties(this.hashMap);
+	var propertiesLength = properties.length;
+	for(var i = 0; i < propertiesLength; i++) {
+		metrics.push({
+			label: convertLabelsToProto(properties[i].labels),
+			counter: { value: properties[i].value },
+			timestampMs: properties[i].timestamp
+		});
+	}
+	return {
+		name: this.name,
+		help: this.help,
+		type: 0,
+		metric: metrics
+	};
+};
+
 Counter.prototype.labels = function() {
 	var labels = getLabels(this.labelNames, arguments) || {};
 	var hash = hashObject(labels);
@@ -131,5 +151,6 @@ function createValue(hashMap, value, timestamp, labels, hash) {
 	}
 	return hashMap;
 };
+
 
 module.exports = Counter;

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -18,6 +18,7 @@ var validateLabels = require('./validation').validateLabel;
 var validateLabelNames = require('./validation').validateLabelName;
 var isObject = require('./util').isObject;
 var extend = require('util-extend');
+var convertLabelsToProto = require('./util').convertLabelsToProto;
 
 /**
  * Gauge constructor
@@ -132,6 +133,25 @@ Gauge.prototype.get = function() {
 		name: this.name,
 		type: type,
 		values: getProperties(this.hashMap)
+	};
+};
+
+Gauge.prototype.getProtoCompliant = function() {
+	var metrics = [];
+	var properties = getProperties(this.hashMap);
+	var propertiesLength = properties.length;
+	for(var i = 0; i < propertiesLength; i++) {
+		metrics.push({
+			label: convertLabelsToProto(properties[i].labels),
+			gauge: { value: properties[i].value },
+			timestampMs: properties[i].timestamp
+		});
+	}
+	return {
+		name: this.name,
+		help: this.help,
+		type: 1,
+		metric: metrics
 	};
 };
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,5 +1,16 @@
 'use strict';
 
+var protobuf = require('protobufjs');
+var path = require('path');
+// TODO consider the possibility this gets loaded too late
+var MetricFamily;
+protobuf.load(path.resolve( __dirname, '../metrics.proto'), function(err, root) {
+	if(err !== null) {
+		throw err;
+	}
+	MetricFamily = root.lookupType('io.prometheus.client.MetricFamily');
+});
+
 function escapeString(str) {
 	return str.replace(/\n/g, '\\n').replace(/\\(?!n)/g, '\\\\');
 }
@@ -53,6 +64,21 @@ var registry = (function() {
 			.join('\n');
 	};
 
+	Registry.prototype.metricsProtobuf = function() {
+		var writer = new protobuf.Writer.create();
+		var metrics = this.getMetricsAsProtobufJSON();
+		var metricsLength = metrics.length;
+		for(var i = 0; i < metricsLength; i++) {
+			var message = MetricFamily.fromObject(metrics[i]);
+			var err = MetricFamily.verify(message);
+			if(err !== null) {
+				throw err;
+			}
+			MetricFamily.encode(message, writer.fork()).ldelim();
+		}
+		return writer.finish();
+	};
+
 	Registry.prototype.registerMetric = function(metricFn) {
 		if(_metrics[metricFn.name]) {
 			throw new Error('A metric with the name ' + metricFn.name + ' has already been registered.');
@@ -71,6 +97,12 @@ var registry = (function() {
 		});
 	};
 
+	Registry.prototype.getMetricsAsProtobufJSON = function() {
+		return getMetricsAsArray().map(function(metric) {
+			return metric.getProtoCompliant();
+		});
+	};
+
 	Registry.prototype.removeSingleMetric = function(name) {
 		delete _metrics[name];
 	};
@@ -84,6 +116,7 @@ var registry = (function() {
 	};
 
 	Registry.prototype.contentType = 'text/plain; version=0.0.4; charset=utf-8';
+	Registry.prototype.contentTypeProto = 'application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited';
 	return new Registry();
 });
 module.exports = registry;

--- a/lib/util.js
+++ b/lib/util.js
@@ -33,6 +33,16 @@ exports.getLabels = function(labelNames, args) {
 	}, {});
 };
 
+exports.convertLabelsToProto = function convertLabelsToProto(labels) {
+	var newLabels = [];
+	Object.keys(labels).forEach(function(key) {
+		if(labels[key] && labels[key].toString() !== null) {
+			newLabels.push({ 'name': key, 'value': labels[key].toString() });
+		}
+	});
+	return newLabels;
+};
+
 
 function hashObject(labels) {
 	// We don't actually need a hash here. We just need a string that

--- a/metrics.proto
+++ b/metrics.proto
@@ -1,0 +1,83 @@
+// FROM https://github.com/prometheus/client_model/blob/proto3/metrics.proto
+// Copyright 2013 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package io.prometheus.client;
+option java_package = "io.prometheus.client";
+
+message LabelPair {
+  string name  = 1;
+  string value = 2;
+}
+
+enum MetricType {
+  COUNTER    = 0;
+  GAUGE      = 1;
+  SUMMARY    = 2;
+  UNTYPED    = 3;
+  HISTOGRAM  = 4;
+}
+
+message Gauge {
+  double value = 1;
+}
+
+message Counter {
+  double value = 1;
+}
+
+message Quantile {
+  double quantile = 1;
+  double value    = 2;
+}
+
+message Summary {
+  uint64 sample_count         = 1;
+  double sample_sum           = 2;
+  repeated Quantile quantile  = 3;
+}
+
+message Untyped {
+  double value = 1;
+}
+
+message Histogram {
+  uint64 sample_count    = 1;
+  double sample_sum      = 2;
+  repeated Bucket bucket = 3; // Ordered in increasing order of upper_bound, +Inf bucket is optional.
+}
+
+message Bucket {
+  uint64 cumulative_count = 1; // Cumulative in increasing order.
+  double upper_bound      = 2;      // Inclusive.
+}
+
+message Metric {
+  repeated LabelPair label = 1;
+  Gauge     gauge          = 2;
+  Counter   counter        = 3;
+  Summary   summary        = 4;
+  Untyped   untyped        = 5;
+  Histogram histogram      = 7;
+  int64     timestamp_ms   = 6;
+}
+
+message MetricFamily {
+  string     name        = 1;
+  string     help        = 2;
+  MetricType type        = 3;
+  repeated Metric metric = 4;
+}
+

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "typescript": "^2.0.3"
   },
   "dependencies": {
+    "protobufjs": "^6.7.3",
     "tdigest": "^0.1.1",
     "util-extend": "^1.0.1"
   },

--- a/test/counterTest.js
+++ b/test/counterTest.js
@@ -95,6 +95,42 @@ describe('counter', function() {
 				});
 			});
 		});
+
+		describe('get as protobuf', function() {
+			beforeEach(function() {
+				instance = new Counter({ name: 'gauge_test', help: 'test', labelNames: [ 'method', 'endpoint'] });
+			});
+			afterEach(function() {
+				globalRegistry.clear();
+			});
+
+			it('should get as protobuf compliant object', function() {
+				instance.labels('GET', '/test').inc(1234, 1485392700000);
+				var validValue = {
+					name: 'gauge_test',
+					help: 'test',
+					type: 0,
+					metric: [{
+						label: [
+							{
+								name: 'method',
+								value: 'GET'
+							},
+							{
+								name: 'endpoint',
+								value: '/test'
+							}
+						],
+						timestampMs: 1485392700000,
+						counter: {
+							value: 1234
+						}
+					}]
+				};
+				var value = instance.getProtoCompliant();
+				expect(value).to.deep.equal(validValue);
+			});
+		});
 	});
 
 	describe('with params as object', function() {

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -290,6 +290,39 @@ describe('gauge', function() {
 				});
 			});
 		});
+
+		describe('get as protobuf', function() {
+			beforeEach(function() {
+				instance = new Gauge({ name: 'gauge_test', help: 'test', labelNames: [ 'method', 'endpoint'] });
+			});
+
+			it('should get as protobuf compliant object', function() {
+				instance.labels('GET', '/test').inc(1234, 1485392700000);
+				var validValue = {
+					name: 'gauge_test',
+					help: 'test',
+					type: 1,
+					metric: [{
+						label: [
+							{
+								name: 'method',
+								value: 'GET'
+							},
+							{
+								name: 'endpoint',
+								value: '/test'
+							}
+						],
+						timestampMs: 1485392700000,
+						gauge: {
+							value: 1234
+						}
+					}]
+				};
+				var value = instance.getProtoCompliant();
+				expect(value).to.deep.equal(validValue);
+			});
+		});
 	});
 	describe('without registry', function() {
 		afterEach(function() {


### PR DESCRIPTION
As discussed in [#96](https://github.com/siimon/prom-client/issues/96). This pull request is not finished or ready for merge, but I wanted to start the conversation and get feedback.

I've attempted to follow your styling, but some decisions had to be made. Let me know if you want things named, placed, or to work differently. I'm open to any and all feedback, I'm still getting the hang of Node. Also, you may or may not like my additions to `README.md`, I'm happy to remove them if you like.

Note, as my [comment here](https://github.com/snarlysodboxer/prom-client/blob/master/lib/registry.js#L5) states, I'm unsure if this could be a problem nor how to address if so, but it's technically possible for the `MetricFamily` variable to be accessed before it receives the results of the `protobuf.load` function. Any advice would be appreciated.

This commit adds [protobuf.js](https://github.com/dcodeIO/protobuf.js) as a dependency. It enables exposure of
the collected metrics in the protobuf format Prometheus expects.
Counter and Gauge are working, Histogram and Summary have yet to be
started. All tests pass.

NOTE: If you try to run the `example/server.js`, you'll get an error because histogram is unfinished, simply comment out the histogram portions of `server.js` and it will work.