### PR TITLE
Include name of unknown label in error

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,15 +1,19 @@
 'use strict';
 
+var util = require('util');
+
+// These are from https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+var metricRegexp = /^[a-zA-Z_:][a-zA-Z0-9_:]*$/;
+var labelRegexp = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
 exports.validateMetricName = function(name) {
-	var regexp = new RegExp('^[a-zA-Z_:][a-zA-Z0-9_:]*$');
-	return regexp.test(name);
+	return metricRegexp.test(name);
 };
 
 exports.validateLabelName = function(names) {
 	var valid = true;
-	var regexp = new RegExp('^[a-zA-Z_][a-zA-Z0-9_]*$');
 	(names || []).forEach(function(name) {
-		if(!regexp.test(name)) {
+		if(!labelRegexp.test(name)) {
 			valid = false;
 		}
 	});
@@ -19,7 +23,7 @@ exports.validateLabelName = function(names) {
 exports.validateLabel = function validateLabel(savedLabels, labels) {
 	Object.keys(labels).forEach(function(label) {
 		if(savedLabels.indexOf(label) === -1) {
-			throw new Error('Added label is not included in initial labelset');
+			throw new Error('Added label "' + label + '" is not included in initial labelset: ' + util.inspect(savedLabels));
 		}
 	});
 };

--- a/test/validationTest.js
+++ b/test/validationTest.js
@@ -1,0 +1,21 @@
+'use strict';
+
+describe('validation', function() {
+	var expect = require('chai').expect;
+
+	describe('validateLabel', function() {
+		var validateLabel = require('../lib/validation').validateLabel;
+
+		it('should not throw on known label', function() {
+			expect(function() {
+				validateLabel(['exists'], {exists: null});
+			}).not.to.throw();
+		});
+
+		it('should throw on unknown label', function() {
+			expect(function() {
+				validateLabel(['exists'], {somethingElse: null});
+			}).to.throw('Added label "somethingElse" is not included in initial labelset: [ \'exists\' ]');
+		});
+	});
+});


### PR DESCRIPTION
I had a typo when using the object form of labels. Would be nice if it the error included info about what label I used, and which were available