### PR TITLE
Use object constructor for built in metrics

### DIFF
--- a/lib/metrics/eventLoopLag.js
+++ b/lib/metrics/eventLoopLag.js
@@ -13,7 +13,7 @@ function reportEventloopLag(start, gauge) {
 }
 
 module.exports = function() {
-	var gauge = new Gauge(NODEJS_EVENTLOOP_LAG, 'Lag of event loop in seconds.');
+	var gauge = new Gauge({ name: NODEJS_EVENTLOOP_LAG, help: 'Lag of event loop in seconds.' });
 
 	return function() {
 		var start = process.hrtime();

--- a/lib/metrics/heapSizeAndUsed.js
+++ b/lib/metrics/heapSizeAndUsed.js
@@ -13,16 +13,22 @@ module.exports = function() {
 		};
 	}
 
-	var heapSizeTotal = new Gauge(NODEJS_HEAP_SIZE_TOTAL, 'Process heap size from node.js in bytes.');
-	var heapSizeUsed = new Gauge(NODEJS_HEAP_SIZE_USED, 'Process heap size used from node.js in bytes.');
+	var heapSizeTotal = new Gauge({ name: NODEJS_HEAP_SIZE_TOTAL, help: 'Process heap size from node.js in bytes.' });
+	var heapSizeUsed = new Gauge({
+		name: NODEJS_HEAP_SIZE_USED,
+		help: 'Process heap size used from node.js in bytes.'
+	});
 
 	var usage = safeMemoryUsage();
 	if(usage && usage.external) {
-		var externalMemUsed = new Gauge(NODEJS_EXTERNAL_MEMORY, 'Nodejs external memory size in bytes.');
+		var externalMemUsed = new Gauge({
+			name: NODEJS_EXTERNAL_MEMORY,
+			help: 'Nodejs external memory size in bytes.'
+		});
 	}
 
 	return function() {
-    	// process.memoryUsage() can throw EMFILE errors, see #67
+		// process.memoryUsage() can throw EMFILE errors, see #67
 		var memUsage = safeMemoryUsage();
 		if(memUsage) {
 			var now = Date.now();
@@ -33,7 +39,7 @@ module.exports = function() {
 			}
 		}
 
-		return {total: heapSizeTotal, used: heapSizeUsed, external: externalMemUsed};
+		return { total: heapSizeTotal, used: heapSizeUsed, external: externalMemUsed };
 	};
 };
 

--- a/lib/metrics/heapSpacesSizeAndUsed.js
+++ b/lib/metrics/heapSpacesSizeAndUsed.js
@@ -22,7 +22,6 @@ METRICS.forEach(function(metricType) {
 	NODEJS_HEAP_SIZE[metricType] = 'nodejs_heap_space_size_' + metricType + '_bytes';
 });
 
-
 module.exports = function() {
 	if(typeof v8 === 'undefined' || typeof v8.getHeapSpaceStatistics !== 'function') {
 		return function() {
@@ -32,11 +31,11 @@ module.exports = function() {
 	var gauges = {};
 
 	METRICS.forEach(function(metricType) {
-		gauges[metricType] = new Gauge(
-			NODEJS_HEAP_SIZE[metricType],
-			'Process heap space size ' + metricType + ' from node.js in bytes.',
-			['space']
-		);
+		gauges[metricType] = new Gauge({
+			name: NODEJS_HEAP_SIZE[metricType],
+			help: 'Process heap space size ' + metricType + ' from node.js in bytes.',
+			labelNames: ['space']
+		});
 	});
 
 	return function() {
@@ -54,9 +53,9 @@ module.exports = function() {
 			data.used[spaceName] = space.space_used_size;
 			data.available[spaceName] = space.space_available_size;
 
-			gauges.total.set({space: spaceName}, space.space_size, now);
-			gauges.used.set({space: spaceName}, space.space_used_size, now);
-			gauges.available.set({space: spaceName}, space.space_available_size, now);
+			gauges.total.set({ space: spaceName }, space.space_size, now);
+			gauges.used.set({ space: spaceName }, space.space_used_size, now);
+			gauges.available.set({ space: spaceName }, space.space_available_size, now);
 		});
 
 		return data;

--- a/lib/metrics/osMemoryHeap.js
+++ b/lib/metrics/osMemoryHeap.js
@@ -7,7 +7,7 @@ var safeMemoryUsage = require('./helpers/safeMemoryUsage');
 var PROCESS_RESIDENT_MEMORY = 'process_resident_memory_bytes';
 
 var notLinuxVariant = function() {
-	var residentMemGauge = new Gauge(PROCESS_RESIDENT_MEMORY, 'Resident memory size in bytes.');
+	var residentMemGauge = new Gauge({ name: PROCESS_RESIDENT_MEMORY, help: 'Resident memory size in bytes.' });
 
 	return function() {
 		var memUsage = safeMemoryUsage();

--- a/lib/metrics/osMemoryHeapLinux.js
+++ b/lib/metrics/osMemoryHeapLinux.js
@@ -35,9 +35,9 @@ function structureOutput(input) {
 }
 
 module.exports = function() {
-	var residentMemGauge = new Gauge(PROCESS_RESIDENT_MEMORY, 'Resident memory size in bytes.');
-	var virtualMemGauge = new Gauge(PROCESS_VIRTUAL_MEMORY, 'Virtual memory size in bytes.');
-	var heapSizeMemGauge = new Gauge(PROCESS_HEAP , 'Process heap size in bytes.');
+	var residentMemGauge = new Gauge({ name: PROCESS_RESIDENT_MEMORY, help: 'Resident memory size in bytes.' });
+	var virtualMemGauge = new Gauge({ name: PROCESS_VIRTUAL_MEMORY, help: 'Virtual memory size in bytes.' });
+	var heapSizeMemGauge = new Gauge({ name: PROCESS_HEAP, help: 'Process heap size in bytes.' });
 
 	return function() {
 		fs.readFile('/proc/self/status', 'utf8', function(err, status) {

--- a/lib/metrics/processCpuTotal.js
+++ b/lib/metrics/processCpuTotal.js
@@ -12,12 +12,18 @@ module.exports = function() {
 		};
 	}
 
-	var cpuUserUsageCounter = new Counter(PROCESS_CPU_USER_SECONDS,
-		'Total user CPU time spent in seconds.');
-	var cpuSystemUsageCounter = new Counter(PROCESS_CPU_SYSTEM_SECONDS,
-		'Total system CPU time spent in seconds.');
-	var cpuUsageCounter = new Counter(PROCESS_CPU_SECONDS,
-		'Total user and system CPU time spent in seconds.');
+	var cpuUserUsageCounter = new Counter({
+		name: PROCESS_CPU_USER_SECONDS,
+		help: 'Total user CPU time spent in seconds.'
+	});
+	var cpuSystemUsageCounter = new Counter({
+		name: PROCESS_CPU_SYSTEM_SECONDS,
+		help: 'Total system CPU time spent in seconds.'
+	});
+	var cpuUsageCounter = new Counter({
+		name: PROCESS_CPU_SECONDS,
+		help: 'Total user and system CPU time spent in seconds.'
+	});
 
 	var lastCpuUsage = process.cpuUsage();
 

--- a/lib/metrics/processHandles.js
+++ b/lib/metrics/processHandles.js
@@ -11,7 +11,7 @@ module.exports = function() {
 		};
 	}
 
-	var gauge = new Gauge(NODEJS_ACTIVE_HANDLES, 'Number of active handles.');
+	var gauge = new Gauge({ name: NODEJS_ACTIVE_HANDLES, help: 'Number of active handles.' });
 
 	return function() {
 		gauge.set(process._getActiveHandles().length, Date.now());

--- a/lib/metrics/processMaxFileDescriptors.js
+++ b/lib/metrics/processMaxFileDescriptors.js
@@ -13,7 +13,7 @@ module.exports = function() {
 		};
 	}
 
-	var fileDescriptorsGauge = new Gauge(PROCESS_MAX_FDS, 'Maximum number of open file descriptors.');
+	var fileDescriptorsGauge = new Gauge({ name: PROCESS_MAX_FDS, help: 'Maximum number of open file descriptors.' });
 
 	return function() {
 		if(isSet) {

--- a/lib/metrics/processOpenFileDescriptors.js
+++ b/lib/metrics/processOpenFileDescriptors.js
@@ -11,7 +11,7 @@ module.exports = function() {
 		};
 	}
 
-	var fileDescriptorsGauge = new Gauge(PROCESS_OPEN_FDS, 'Number of open file descriptors.');
+	var fileDescriptorsGauge = new Gauge({ name: PROCESS_OPEN_FDS, help: 'Number of open file descriptors.' });
 
 	return function() {
 		fs.readdir('/proc/self/fd', function(err, list) {

--- a/lib/metrics/processRequests.js
+++ b/lib/metrics/processRequests.js
@@ -11,7 +11,7 @@ module.exports = function() {
 		};
 	}
 
-	var gauge = new Gauge(NODEJS_ACTIVE_REQUESTS, 'Number of active requests.');
+	var gauge = new Gauge({ name: NODEJS_ACTIVE_REQUESTS, help: 'Number of active requests.' });
 
 	return function() {
 		gauge.set(process._getActiveRequests().length, Date.now());

--- a/lib/metrics/processStartTime.js
+++ b/lib/metrics/processStartTime.js
@@ -6,7 +6,10 @@ var nowInSeconds = Math.round(Date.now() / 1000 - process.uptime());
 var PROCESS_START_TIME = 'process_start_time_seconds';
 
 module.exports = function() {
-	var cpuUserGauge = new Gauge(PROCESS_START_TIME, 'Start time of the process since unix epoch in seconds.');
+	var cpuUserGauge = new Gauge({
+		name: PROCESS_START_TIME,
+		help: 'Start time of the process since unix epoch in seconds.'
+	});
 	var isSet = false;
 
 	return function() {

--- a/lib/metrics/version.js
+++ b/lib/metrics/version.js
@@ -7,7 +7,11 @@ var versionSegments = version.slice(1).split('.').map(Number);
 var NODE_VERSION_INFO = 'nodejs_version_info';
 
 module.exports = function() {
-	var nodeVersionGauge = new Gauge(NODE_VERSION_INFO, 'Node.js version info.', ['version', 'major', 'minor', 'patch']);
+	var nodeVersionGauge = new Gauge({
+		name: NODE_VERSION_INFO,
+		help: 'Node.js version info.',
+		labelNames: ['version', 'major', 'minor', 'patch']
+	});
 	var isSet = false;
 
 	return function() {


### PR DESCRIPTION
Seeing as the non-object constructors are soft deprecated, we should not use them ourselves.