### PR TITLE
Replace sinon with lolex

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "husky": "^0.13.4",
     "jest": "^20.0.4",
     "lint-staged": "^4.0.0",
+    "lolex": "^1.6.0",
     "prettier": "^1.4.4",
-    "sinon": "^2.0.0",
     "typescript": "^2.0.3"
   },
   "dependencies": {

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -4,7 +4,7 @@ describe('gauge', () => {
 	const Gauge = require('../index').Gauge;
 	const Registry = require('../index').Registry;
 	const globalRegistry = require('../index').register;
-	const sinon = require('sinon');
+	const lolex = require('lolex');
 	let instance;
 
 	describe('global registry', () => {
@@ -42,19 +42,19 @@ describe('gauge', () => {
 			});
 
 			it('should start a timer and set a gauge to elapsed in seconds', () => {
-				const clock = sinon.useFakeTimers();
+				const clock = lolex.install();
 				const doneFn = instance.startTimer();
 				clock.tick(500);
 				doneFn();
 				expectValue(0.5);
-				clock.restore();
+				clock.uninstall();
 			});
 
 			it('should set to current time', () => {
-				const clock = sinon.useFakeTimers();
+				const clock = lolex.install();
 				instance.setToCurrentTime();
 				expectValue(Date.now());
-				clock.restore();
+				clock.uninstall();
 			});
 
 			it('should not allow non numbers', () => {
@@ -82,35 +82,35 @@ describe('gauge', () => {
 					expectValue(500);
 				});
 				it('should be able to set value to current time', () => {
-					const clock = sinon.useFakeTimers();
+					const clock = lolex.install();
 					instance.labels('200').setToCurrentTime();
 					expectValue(Date.now());
-					clock.restore();
+					clock.uninstall();
 				});
 				it('should be able to start a timer', () => {
-					const clock = sinon.useFakeTimers();
+					const clock = lolex.install();
 					const end = instance.labels('200').startTimer();
 					clock.tick(1000);
 					end();
 					expectValue(1);
-					clock.restore();
+					clock.uninstall();
 				});
 				it('should be able to start a timer and set labels afterwards', () => {
-					const clock = sinon.useFakeTimers();
+					const clock = lolex.install();
 					const end = instance.startTimer();
 					clock.tick(1000);
 					end({ code: 200 });
 					expectValue(1);
-					clock.restore();
+					clock.uninstall();
 				});
 				it('should allow labels before and after timers', () => {
 					instance = new Gauge('name_2', 'help', ['code', 'success']);
-					const clock = sinon.useFakeTimers();
+					const clock = lolex.install();
 					const end = instance.startTimer({ code: 200 });
 					clock.tick(1000);
 					end({ success: 'SUCCESS' });
 					expectValue(1);
-					clock.restore();
+					clock.uninstall();
 				});
 			});
 
@@ -181,19 +181,19 @@ describe('gauge', () => {
 			});
 
 			it('should start a timer and set a gauge to elapsed in seconds', () => {
-				const clock = sinon.useFakeTimers();
+				const clock = lolex.install();
 				const doneFn = instance.startTimer();
 				clock.tick(500);
 				doneFn();
 				expectValue(0.5);
-				clock.restore();
+				clock.uninstall();
 			});
 
 			it('should set to current time', () => {
-				const clock = sinon.useFakeTimers();
+				const clock = lolex.install();
 				instance.setToCurrentTime();
 				expectValue(Date.now());
-				clock.restore();
+				clock.uninstall();
 			});
 
 			it('should not allow non numbers', () => {
@@ -225,26 +225,26 @@ describe('gauge', () => {
 					expectValue(500);
 				});
 				it('should be able to set value to current time', () => {
-					const clock = sinon.useFakeTimers();
+					const clock = lolex.install();
 					instance.labels('200').setToCurrentTime();
 					expectValue(Date.now());
-					clock.restore();
+					clock.uninstall();
 				});
 				it('should be able to start a timer', () => {
-					const clock = sinon.useFakeTimers();
+					const clock = lolex.install();
 					const end = instance.labels('200').startTimer();
 					clock.tick(1000);
 					end();
 					expectValue(1);
-					clock.restore();
+					clock.uninstall();
 				});
 				it('should be able to start a timer and set labels afterwards', () => {
-					const clock = sinon.useFakeTimers();
+					const clock = lolex.install();
 					const end = instance.startTimer();
 					clock.tick(1000);
 					end({ code: 200 });
 					expectValue(1);
-					clock.restore();
+					clock.uninstall();
 				});
 				it('should allow labels before and after timers', () => {
 					instance = new Gauge({
@@ -252,12 +252,12 @@ describe('gauge', () => {
 						help: 'help',
 						labelNames: ['code', 'success']
 					});
-					const clock = sinon.useFakeTimers();
+					const clock = lolex.install();
 					const end = instance.startTimer({ code: 200 });
 					clock.tick(1000);
 					end({ success: 'SUCCESS' });
 					expectValue(1);
-					clock.restore();
+					clock.uninstall();
 				});
 			});
 

--- a/test/histogramTest.js
+++ b/test/histogramTest.js
@@ -4,7 +4,7 @@ describe('histogram', () => {
 	const Histogram = require('../index').Histogram;
 	const Registry = require('../index').Registry;
 	const globalRegistry = require('../index').register;
-	const sinon = require('sinon');
+	const lolex = require('lolex');
 	let instance;
 
 	afterEach(() => {
@@ -83,13 +83,13 @@ describe('histogram', () => {
 		});
 
 		it('should time requests', () => {
-			const clock = sinon.useFakeTimers();
+			const clock = lolex.install();
 			const doneFn = instance.startTimer();
 			clock.tick(500);
 			doneFn();
 			const valuePair = getValueByLabel(0.5, instance.get().values);
 			expect(valuePair.value).toEqual(1);
-			clock.restore();
+			clock.uninstall();
 		});
 
 		it('should not allow non numbers', () => {
@@ -160,7 +160,7 @@ describe('histogram', () => {
 			});
 
 			it('should start a timer', () => {
-				const clock = sinon.useFakeTimers();
+				const clock = lolex.install();
 				const end = instance.labels('get').startTimer();
 				clock.tick(500);
 				end();
@@ -171,11 +171,11 @@ describe('histogram', () => {
 					instance.get().values
 				);
 				expect(res.value).toEqual(1);
-				clock.restore();
+				clock.uninstall();
 			});
 
 			it('should start a timer and set labels afterwards', () => {
-				const clock = sinon.useFakeTimers();
+				const clock = lolex.install();
 				const end = instance.startTimer();
 				clock.tick(500);
 				end({ method: 'get' });
@@ -186,7 +186,7 @@ describe('histogram', () => {
 					instance.get().values
 				);
 				expect(res.value).toEqual(1);
-				clock.restore();
+				clock.uninstall();
 			});
 
 			it('should allow labels before and after timers', () => {
@@ -195,7 +195,7 @@ describe('histogram', () => {
 					'Histogram with labels fn',
 					['method', 'success']
 				);
-				const clock = sinon.useFakeTimers();
+				const clock = lolex.install();
 				const end = instance.startTimer({ method: 'get' });
 				clock.tick(500);
 				end({ success: 'SUCCESS' });
@@ -213,7 +213,7 @@ describe('histogram', () => {
 				);
 				expect(res1.value).toEqual(1);
 				expect(res2.value).toEqual(1);
-				clock.restore();
+				clock.uninstall();
 			});
 		});
 	});
@@ -296,13 +296,13 @@ describe('histogram', () => {
 			});
 
 			it('should time requests', () => {
-				const clock = sinon.useFakeTimers();
+				const clock = lolex.install();
 				const doneFn = instance.startTimer();
 				clock.tick(500);
 				doneFn();
 				const valuePair = getValueByLabel(0.5, instance.get().values);
 				expect(valuePair.value).toEqual(1);
-				clock.restore();
+				clock.uninstall();
 			});
 
 			it('should not allow non numbers', () => {
@@ -380,7 +380,7 @@ describe('histogram', () => {
 				});
 
 				it('should start a timer', () => {
-					const clock = sinon.useFakeTimers();
+					const clock = lolex.install();
 					const end = instance.labels('get').startTimer();
 					clock.tick(500);
 					end();
@@ -391,11 +391,11 @@ describe('histogram', () => {
 						instance.get().values
 					);
 					expect(res.value).toEqual(1);
-					clock.restore();
+					clock.uninstall();
 				});
 
 				it('should start a timer and set labels afterwards', () => {
-					const clock = sinon.useFakeTimers();
+					const clock = lolex.install();
 					const end = instance.startTimer();
 					clock.tick(500);
 					end({ method: 'get' });
@@ -406,7 +406,7 @@ describe('histogram', () => {
 						instance.get().values
 					);
 					expect(res.value).toEqual(1);
-					clock.restore();
+					clock.uninstall();
 				});
 
 				it('should allow labels before and after timers', () => {
@@ -415,7 +415,7 @@ describe('histogram', () => {
 						help: 'Histogram with labels fn',
 						labelNames: ['method', 'success']
 					});
-					const clock = sinon.useFakeTimers();
+					const clock = lolex.install();
 					const end = instance.startTimer({ method: 'get' });
 					clock.tick(500);
 					end({ success: 'SUCCESS' });
@@ -433,7 +433,7 @@ describe('histogram', () => {
 					);
 					expect(res1.value).toEqual(1);
 					expect(res2.value).toEqual(1);
-					clock.restore();
+					clock.uninstall();
 				});
 			});
 		});

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -4,7 +4,7 @@ describe('summary', () => {
 	const Summary = require('../index').Summary;
 	const Registry = require('../index').Registry;
 	const globalRegistry = require('../index').register;
-	const sinon = require('sinon');
+	const lolex = require('lolex');
 	let instance;
 
 	describe('global registry', () => {
@@ -186,7 +186,7 @@ describe('summary', () => {
 				});
 
 				it('should start a timer', () => {
-					const clock = sinon.useFakeTimers();
+					const clock = lolex.install();
 					const end = instance.labels('GET', '/test').startTimer();
 					clock.tick(1000);
 					end();
@@ -207,11 +207,11 @@ describe('summary', () => {
 					expect(values[2].labels.endpoint).toEqual('/test');
 					expect(values[2].value).toEqual(1);
 
-					clock.restore();
+					clock.uninstall();
 				});
 
 				it('should start a timer and set labels afterwards', () => {
-					const clock = sinon.useFakeTimers();
+					const clock = lolex.install();
 					const end = instance.startTimer();
 					clock.tick(1000);
 					end({ method: 'GET', endpoint: '/test' });
@@ -232,11 +232,11 @@ describe('summary', () => {
 					expect(values[2].labels.endpoint).toEqual('/test');
 					expect(values[2].value).toEqual(1);
 
-					clock.restore();
+					clock.uninstall();
 				});
 
 				it('should allow labels before and after timers', () => {
-					const clock = sinon.useFakeTimers();
+					const clock = lolex.install();
 					const end = instance.startTimer({ method: 'GET' });
 					clock.tick(1000);
 					end({ endpoint: '/test' });
@@ -257,7 +257,7 @@ describe('summary', () => {
 					expect(values[2].labels.endpoint).toEqual('/test');
 					expect(values[2].value).toEqual(1);
 
-					clock.restore();
+					clock.uninstall();
 				});
 			});
 		});
@@ -442,7 +442,7 @@ describe('summary', () => {
 				});
 
 				it('should start a timer', () => {
-					const clock = sinon.useFakeTimers();
+					const clock = lolex.install();
 					const end = instance.labels('GET', '/test').startTimer();
 					clock.tick(1000);
 					end();
@@ -463,11 +463,11 @@ describe('summary', () => {
 					expect(values[2].labels.endpoint).toEqual('/test');
 					expect(values[2].value).toEqual(1);
 
-					clock.restore();
+					clock.uninstall();
 				});
 
 				it('should start a timer and set labels afterwards', () => {
-					const clock = sinon.useFakeTimers();
+					const clock = lolex.install();
 					const end = instance.startTimer();
 					clock.tick(1000);
 					end({ method: 'GET', endpoint: '/test' });
@@ -488,11 +488,11 @@ describe('summary', () => {
 					expect(values[2].labels.endpoint).toEqual('/test');
 					expect(values[2].value).toEqual(1);
 
-					clock.restore();
+					clock.uninstall();
 				});
 
 				it('should allow labels before and after timers', () => {
-					const clock = sinon.useFakeTimers();
+					const clock = lolex.install();
 					const end = instance.startTimer({ method: 'GET' });
 					clock.tick(1000);
 					end({ endpoint: '/test' });
@@ -513,7 +513,7 @@ describe('summary', () => {
 					expect(values[2].labels.endpoint).toEqual('/test');
 					expect(values[2].value).toEqual(1);
 
-					clock.restore();
+					clock.uninstall();
 				});
 			});
 		});


### PR DESCRIPTION
Since we only use sinon for time now that jest is used for tests, we can use lolex directly (it's what sinon uses under the hood for time stuff).