### PR TITLE
Allow registering default metrics to other registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Print deprecation warning when metrics are constructed using non-objects
 ### Added
 - Ability to set default labels by registry
+- Allow passing in `registry` as second argument to `collectDefaultMetrics` to use that instead of the default registry
 ### Changed
 - Convert code base to ES2015 code (node 4)
   - add engines field to package.json
@@ -16,7 +17,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   - Arrow functions over binding or putting `this` in a variable
   - Use template strings
   - `prototype` -> `class`
-
 
 ## [9.1.1] - 2017-06-17
 ### Changed

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ NOTE: Some of the metrics, concerning File Descriptors and Memory, are only avai
 In addition, some Node-specific metrics are included, such as event loop lag, active handles and Node.js version. See what metrics there are in
 [lib/metrics](lib/metrics).
 
-The function returned from `collectDefaultMetrics` takes 1 option, a timeout for how often the probe should
-be fired. By default probes are launched every 10 seconds, but this can be modified like this:
+`collectDefaultMetrics` takes 1 options object with 2 entries, a timeout for how often the probe should be fired and a
+registry to which metrics should be registered. By default probes are launched every 10 seconds, but this can be
+modified like this:
 
 ```js
 const client = require('prom-client');
@@ -32,7 +33,19 @@ const client = require('prom-client');
 const collectDefaultMetrics = client.collectDefaultMetrics;
 
 // Probe every 5th second.
-collectDefaultMetrics(5000);
+collectDefaultMetrics({ timeout: 5000 });
+````
+
+To register metrics to another registry, pass it in as `register`:
+
+```js
+const client = require('prom-client');
+
+const collectDefaultMetrics = client.collectDefaultMetrics;
+const Registry = client.Registry;
+const register = new Registry();
+
+collectDefaultMetrics({ register });
 ````
 
 You can get the full list of metrics by inspecting `client.collectDefaultMetrics.metricsList`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -532,18 +532,27 @@ export function exponentialBuckets(
 	count: number
 ): number[];
 
-/**
- * Configure default metrics
- * @param interval The interval how often the default metrics should be probed
- * @return The setInterval number
- */
-export function collectDefaultMetrics(interval: number): number;
+export interface DefaultMetricsCollectorConfiguration {
+	interval?: number;
+	registry?: Registry;
+}
 
 /**
  * Configure default metrics
+ * @param config Configuration object for default metrics collector
  * @return The setInterval number
  */
-export function collectDefaultMetrics(): number;
+export function collectDefaultMetrics(
+	config?: DefaultMetricsCollectorConfiguration
+): number;
+
+/**
+ * Configure default metrics
+ * @param interval The interval how often the default metrics should be probed
+ * @deprecated
+ * @return The setInterval number
+ */
+export function collectDefaultMetrics(interval: number): number;
 
 export interface defaultMetrics {
 	/**

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -29,11 +29,14 @@ class Counter {
 		if (isObject(name)) {
 			config = Object.assign(
 				{
-					labelNames: [],
-					registers: [globalRegistry]
+					labelNames: []
 				},
 				name
 			);
+
+			if (!config.registers) {
+				config.registers = [globalRegistry];
+			}
 		} else {
 			printDeprecationObjectConstructor();
 

--- a/lib/defaultMetrics.js
+++ b/lib/defaultMetrics.js
@@ -33,12 +33,30 @@ let existingInterval = null;
 // We might want to consider not supporting running the default metrics function more than once
 let init = true;
 
-module.exports = function startDefaultMetrics(interval) {
+module.exports = function startDefaultMetrics(config) {
+	if (typeof config === 'number') {
+		const deprecationWarning = new Error(
+			`A number to defaultMetrics is deprecated, please use \`collectDefaultMetrics({ timeout: ${config} })\`.`
+		);
+
+		deprecationWarning.name = 'DeprecationWarning';
+
+		// Check can be removed when we only support node@>=6
+		if (process.emitWarning) {
+			process.emitWarning(deprecationWarning);
+		} else {
+			// eslint-disable-next-line no-console
+			console.error(deprecationWarning);
+		}
+
+		config = { timeout: config };
+	}
+
+	config = Object.assign({ timeout: 10000 }, config);
+
 	if (existingInterval !== null) {
 		clearInterval(existingInterval);
 	}
-
-	interval = interval || 10000;
 
 	const initialisedMetrics = metricsList.map(metric => {
 		const defaultMetric = metrics[metric];
@@ -49,7 +67,7 @@ module.exports = function startDefaultMetrics(interval) {
 			);
 		}
 
-		return defaultMetric();
+		return defaultMetric(config.register);
 	});
 
 	function updateAllMetrics() {
@@ -60,7 +78,7 @@ module.exports = function startDefaultMetrics(interval) {
 
 	updateAllMetrics();
 
-	existingInterval = setInterval(updateAllMetrics, interval).unref();
+	existingInterval = setInterval(updateAllMetrics, config.interval).unref();
 
 	init = false;
 

--- a/lib/defaultMetrics.js
+++ b/lib/defaultMetrics.js
@@ -34,6 +34,7 @@ let existingInterval = null;
 let init = true;
 
 module.exports = function startDefaultMetrics(config) {
+	let normalizedConfig = config;
 	if (typeof config === 'number') {
 		const deprecationWarning = new Error(
 			`A number to defaultMetrics is deprecated, please use \`collectDefaultMetrics({ timeout: ${config} })\`.`
@@ -49,10 +50,10 @@ module.exports = function startDefaultMetrics(config) {
 			console.error(deprecationWarning);
 		}
 
-		config = { timeout: config };
+		normalizedConfig = { timeout: config };
 	}
 
-	config = Object.assign({ timeout: 10000 }, config);
+	normalizedConfig = Object.assign({ timeout: 10000 }, normalizedConfig);
 
 	if (existingInterval !== null) {
 		clearInterval(existingInterval);
@@ -67,18 +68,19 @@ module.exports = function startDefaultMetrics(config) {
 			);
 		}
 
-		return defaultMetric(config.register);
+		return defaultMetric(normalizedConfig.register);
 	});
 
 	function updateAllMetrics() {
-		initialisedMetrics.forEach(metric => {
-			metric.call();
-		});
+		initialisedMetrics.forEach(metric => metric.call());
 	}
 
 	updateAllMetrics();
 
-	existingInterval = setInterval(updateAllMetrics, config.interval).unref();
+	existingInterval = setInterval(
+		updateAllMetrics,
+		normalizedConfig.interval
+	).unref();
 
 	init = false;
 

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -31,11 +31,14 @@ class Gauge {
 		if (isObject(name)) {
 			config = Object.assign(
 				{
-					labelNames: [],
-					registers: [globalRegistry]
+					labelNames: []
 				},
 				name
 			);
+
+			if (!config.registers) {
+				config.registers = [globalRegistry];
+			}
 		} else {
 			printDeprecationObjectConstructor();
 			config = {

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -31,11 +31,14 @@ class Histogram {
 			config = Object.assign(
 				{
 					buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
-					labelNames: [],
-					registers: [globalRegistry]
+					labelNames: []
 				},
 				name
 			);
+
+			if (!config.registers) {
+				config.registers = [globalRegistry];
+			}
 		} else {
 			let obj;
 			let labels = [];

--- a/lib/metrics/eventLoopLag.js
+++ b/lib/metrics/eventLoopLag.js
@@ -12,10 +12,11 @@ function reportEventloopLag(start, gauge) {
 	gauge.set(seconds, Date.now());
 }
 
-module.exports = () => {
+module.exports = registry => {
 	const gauge = new Gauge({
 		name: NODEJS_EVENTLOOP_LAG,
-		help: 'Lag of event loop in seconds.'
+		help: 'Lag of event loop in seconds.',
+		registers: registry ? [registry] : undefined
 	});
 
 	return () => {

--- a/lib/metrics/heapSizeAndUsed.js
+++ b/lib/metrics/heapSizeAndUsed.js
@@ -7,18 +7,22 @@ const NODEJS_HEAP_SIZE_TOTAL = 'nodejs_heap_size_total_bytes';
 const NODEJS_HEAP_SIZE_USED = 'nodejs_heap_size_used_bytes';
 const NODEJS_EXTERNAL_MEMORY = 'nodejs_external_memory_bytes';
 
-module.exports = () => {
+module.exports = registry => {
 	if (typeof process.memoryUsage !== 'function') {
 		return () => {};
 	}
 
+	const registers = registry ? [registry] : undefined;
+
 	const heapSizeTotal = new Gauge({
 		name: NODEJS_HEAP_SIZE_TOTAL,
-		help: 'Process heap size from node.js in bytes.'
+		help: 'Process heap size from node.js in bytes.',
+		registers
 	});
 	const heapSizeUsed = new Gauge({
 		name: NODEJS_HEAP_SIZE_USED,
-		help: 'Process heap size used from node.js in bytes.'
+		help: 'Process heap size used from node.js in bytes.',
+		registers
 	});
 	let externalMemUsed;
 
@@ -26,7 +30,8 @@ module.exports = () => {
 	if (usage && usage.external) {
 		externalMemUsed = new Gauge({
 			name: NODEJS_EXTERNAL_MEMORY,
-			help: 'Nodejs external memory size in bytes.'
+			help: 'Nodejs external memory size in bytes.',
+			registers
 		});
 	}
 

--- a/lib/metrics/heapSpacesSizeAndUsed.js
+++ b/lib/metrics/heapSpacesSizeAndUsed.js
@@ -18,7 +18,7 @@ METRICS.forEach(metricType => {
 	NODEJS_HEAP_SIZE[metricType] = `nodejs_heap_space_size_${metricType}_bytes`;
 });
 
-module.exports = () => {
+module.exports = registry => {
 	if (
 		typeof v8 === 'undefined' ||
 		typeof v8.getHeapSpaceStatistics !== 'function'
@@ -26,13 +26,16 @@ module.exports = () => {
 		return () => {};
 	}
 
+	const registers = registry ? [registry] : undefined;
+
 	const gauges = {};
 
 	METRICS.forEach(metricType => {
 		gauges[metricType] = new Gauge({
 			name: NODEJS_HEAP_SIZE[metricType],
 			help: `Process heap space size ${metricType} from node.js in bytes.`,
-			labelNames: ['space']
+			labelNames: ['space'],
+			registers
 		});
 	});
 

--- a/lib/metrics/osMemoryHeap.js
+++ b/lib/metrics/osMemoryHeap.js
@@ -6,10 +6,11 @@ const safeMemoryUsage = require('./helpers/safeMemoryUsage');
 
 const PROCESS_RESIDENT_MEMORY = 'process_resident_memory_bytes';
 
-const notLinuxVariant = function() {
+function notLinuxVariant(registry) {
 	const residentMemGauge = new Gauge({
 		name: PROCESS_RESIDENT_MEMORY,
-		help: 'Resident memory size in bytes.'
+		help: 'Resident memory size in bytes.',
+		registers: registry ? [registry] : undefined
 	});
 
 	return () => {
@@ -20,10 +21,12 @@ const notLinuxVariant = function() {
 			residentMemGauge.set(memUsage.rss, Date.now());
 		}
 	};
-};
+}
 
-module.exports = () =>
-	process.platform === 'linux' ? linuxVariant() : notLinuxVariant();
+module.exports = registry =>
+	process.platform === 'linux'
+		? linuxVariant(registry)
+		: notLinuxVariant(registry);
 
 module.exports.metricNames =
 	process.platform === 'linux'

--- a/lib/metrics/osMemoryHeapLinux.js
+++ b/lib/metrics/osMemoryHeapLinux.js
@@ -31,18 +31,22 @@ function structureOutput(input) {
 	return returnValue;
 }
 
-module.exports = () => {
+module.exports = registry => {
+	const registers = registry ? [registry] : undefined;
 	const residentMemGauge = new Gauge({
 		name: PROCESS_RESIDENT_MEMORY,
-		help: 'Resident memory size in bytes.'
+		help: 'Resident memory size in bytes.',
+		registers
 	});
 	const virtualMemGauge = new Gauge({
 		name: PROCESS_VIRTUAL_MEMORY,
-		help: 'Virtual memory size in bytes.'
+		help: 'Virtual memory size in bytes.',
+		registers
 	});
 	const heapSizeMemGauge = new Gauge({
 		name: PROCESS_HEAP,
-		help: 'Process heap size in bytes.'
+		help: 'Process heap size in bytes.',
+		registers
 	});
 
 	return () => {

--- a/lib/metrics/processCpuTotal.js
+++ b/lib/metrics/processCpuTotal.js
@@ -5,23 +5,28 @@ const PROCESS_CPU_USER_SECONDS = 'process_cpu_user_seconds_total';
 const PROCESS_CPU_SYSTEM_SECONDS = 'process_cpu_system_seconds_total';
 const PROCESS_CPU_SECONDS = 'process_cpu_seconds_total';
 
-module.exports = () => {
+module.exports = registry => {
 	// Don't do anything if the function doesn't exist (introduced in node@6.1.0)
 	if (typeof process.cpuUsage !== 'function') {
 		return () => {};
 	}
 
+	const registers = registry ? [registry] : undefined;
+
 	const cpuUserUsageCounter = new Counter({
 		name: PROCESS_CPU_USER_SECONDS,
-		help: 'Total user CPU time spent in seconds.'
+		help: 'Total user CPU time spent in seconds.',
+		registers
 	});
 	const cpuSystemUsageCounter = new Counter({
 		name: PROCESS_CPU_SYSTEM_SECONDS,
-		help: 'Total system CPU time spent in seconds.'
+		help: 'Total system CPU time spent in seconds.',
+		registers
 	});
 	const cpuUsageCounter = new Counter({
 		name: PROCESS_CPU_SECONDS,
-		help: 'Total user and system CPU time spent in seconds.'
+		help: 'Total user and system CPU time spent in seconds.',
+		registers
 	});
 
 	let lastCpuUsage = process.cpuUsage();

--- a/lib/metrics/processHandles.js
+++ b/lib/metrics/processHandles.js
@@ -4,7 +4,7 @@ const Gauge = require('../gauge');
 
 const NODEJS_ACTIVE_HANDLES = 'nodejs_active_handles_total';
 
-module.exports = () => {
+module.exports = registry => {
 	// Don't do anything if the function is removed in later nodes (exists in node@6)
 	if (typeof process._getActiveHandles !== 'function') {
 		return () => {};
@@ -12,7 +12,8 @@ module.exports = () => {
 
 	const gauge = new Gauge({
 		name: NODEJS_ACTIVE_HANDLES,
-		help: 'Number of active handles.'
+		help: 'Number of active handles.',
+		registers: registry ? [registry] : undefined
 	});
 
 	return () => {

--- a/lib/metrics/processMaxFileDescriptors.js
+++ b/lib/metrics/processMaxFileDescriptors.js
@@ -5,16 +5,16 @@ const fs = require('fs');
 
 const PROCESS_MAX_FDS = 'process_max_fds';
 
-module.exports = () => {
+module.exports = registry => {
 	let isSet = false;
 
 	if (process.platform !== 'linux') {
 		return () => {};
 	}
-
 	const fileDescriptorsGauge = new Gauge({
 		name: PROCESS_MAX_FDS,
-		help: 'Maximum number of open file descriptors.'
+		help: 'Maximum number of open file descriptors.',
+		registers: registry ? [registry] : undefined
 	});
 
 	return () => {

--- a/lib/metrics/processOpenFileDescriptors.js
+++ b/lib/metrics/processOpenFileDescriptors.js
@@ -5,14 +5,15 @@ const fs = require('fs');
 
 const PROCESS_OPEN_FDS = 'process_open_fds';
 
-module.exports = () => {
+module.exports = registry => {
 	if (process.platform !== 'linux') {
 		return () => {};
 	}
 
 	const fileDescriptorsGauge = new Gauge({
 		name: PROCESS_OPEN_FDS,
-		help: 'Number of open file descriptors.'
+		help: 'Number of open file descriptors.',
+		registers: registry ? [registry] : undefined
 	});
 
 	return () => {

--- a/lib/metrics/processRequests.js
+++ b/lib/metrics/processRequests.js
@@ -4,7 +4,7 @@ const Gauge = require('../gauge');
 
 const NODEJS_ACTIVE_REQUESTS = 'nodejs_active_requests_total';
 
-module.exports = () => {
+module.exports = registry => {
 	// Don't do anything if the function is removed in later nodes (exists in node@6)
 	if (typeof process._getActiveRequests !== 'function') {
 		return () => {};
@@ -12,7 +12,8 @@ module.exports = () => {
 
 	const gauge = new Gauge({
 		name: NODEJS_ACTIVE_REQUESTS,
-		help: 'Number of active requests.'
+		help: 'Number of active requests.',
+		registers: registry ? [registry] : undefined
 	});
 
 	return () => {

--- a/lib/metrics/processStartTime.js
+++ b/lib/metrics/processStartTime.js
@@ -5,10 +5,11 @@ const nowInSeconds = Math.round(Date.now() / 1000 - process.uptime());
 
 const PROCESS_START_TIME = 'process_start_time_seconds';
 
-module.exports = () => {
+module.exports = registry => {
 	const cpuUserGauge = new Gauge({
 		name: PROCESS_START_TIME,
-		help: 'Start time of the process since unix epoch in seconds.'
+		help: 'Start time of the process since unix epoch in seconds.',
+		registers: registry ? [registry] : undefined
 	});
 	let isSet = false;
 

--- a/lib/metrics/version.js
+++ b/lib/metrics/version.js
@@ -6,11 +6,12 @@ const versionSegments = version.slice(1).split('.').map(Number);
 
 const NODE_VERSION_INFO = 'nodejs_version_info';
 
-module.exports = () => {
+module.exports = registry => {
 	const nodeVersionGauge = new Gauge({
 		name: NODE_VERSION_INFO,
 		help: 'Node.js version info.',
-		labelNames: ['version', 'major', 'minor', 'patch']
+		labelNames: ['version', 'major', 'minor', 'patch'],
+		registers: registry ? [registry] : undefined
 	});
 	let isSet = false;
 

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -31,11 +31,14 @@ class Summary {
 			config = Object.assign(
 				{
 					percentiles: [0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999],
-					labelNames: [],
-					registers: [globalRegistry]
+					labelNames: []
 				},
 				name
 			);
+
+			if (!config.registers) {
+				config.registers = [globalRegistry];
+			}
 		} else {
 			let obj;
 			let labels = [];

--- a/test/defaultMetricsTest.js
+++ b/test/defaultMetricsTest.js
@@ -2,6 +2,7 @@
 
 describe('collectDefaultMetrics', () => {
 	const register = require('../index').register;
+	const Registry = require('../index').Registry;
 	const collectDefaultMetrics = require('../index').collectDefaultMetrics;
 	let platform;
 	let cpuUsage;
@@ -72,6 +73,20 @@ describe('collectDefaultMetrics', () => {
 			};
 
 			expect(fn).not.toThrowError(Error);
+		});
+	});
+
+	describe('custom registry', () => {
+		it('should allow to register metrics to custom registry', () => {
+			const registry = new Registry();
+
+			expect(register.getMetricsAsJSON()).toHaveLength(0);
+			expect(registry.getMetricsAsJSON()).toHaveLength(0);
+
+			interval = collectDefaultMetrics({ register: registry });
+
+			expect(register.getMetricsAsJSON()).toHaveLength(0);
+			expect(registry.getMetricsAsJSON()).not.toHaveLength(0);
 		});
 	});
 });


### PR DESCRIPTION
Maybe take an object to `collectDefaultMetrics`? I'm going to tackle custom labels for the default metrics now, yet another option and it gets quite hairy