### PR TITLE
Add support for default labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Added
+- Ability to set default labels by registry
 ### Changed
 - Convert code base to ES2015 code (node 4)
   - add engines field to package.json
@@ -13,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   - Arrow functions over binding or putting `this` in a variable
   - Use template strings
   - `prototype` -> `class`
+
 
 ## [9.1.1] - 2017-06-17
 ### Changed

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ This will output metrics in the following way:
 process_resident_memory_bytes{serviceName="api-v1"} 33853440 1498510040309
 ```
 
-Default metrics will be overridden if there is a name conflict.
+Default labels will be overridden if there is a name conflict.
 
 `register.clear()` will clear default labels.
 

--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ xhrRequest(function(err, res) {
 
 Static labels may be applied to every metric emitted by a registry:
 ```js
-var client = require('prom-client');
-var defaultLabels = { serviceName: "api-v1"};
+const client = require('prom-client');
+const defaultLabels = { serviceName: "api-v1" };
 client.register.setDefaultLabels(defaultLabels);
 ```
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,9 @@ This will output metrics in the following way:
 process_resident_memory_bytes{serviceName="api-v1"} 33853440 1498510040309
 ```
 
-Note: `register.clear()` will clear default labels.
+Default metrics will be overridden if there is a name conflict.
+
+`register.clear()` will clear default labels.
 
 #### Timestamps
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,24 @@ xhrRequest(function(err, res) {
 });
 ```
 
+##### Default Labels (segmented by registry)
+
+Static labels may be applied to every metric emitted by a registry:
+```js
+var client = require('prom-client');
+var defaultLabels = { serviceName: "api-v1"};
+client.register.setDefaultLabels(defaultLabels);
+```
+
+This will output metrics in the following way:
+```
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes{serviceName="api-v1"} 33853440 1498510040309
+```
+
+Note: `register.clear()` will clear default labels.
+
 #### Timestamps
 
 Counter and gauge metrics can take a timestamp argument after the value argument.

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,10 +33,10 @@ export class Registry {
 	getSingleMetric(name: string): Metric;
 
 	/**
-   * Set static labels to every metric emitted by this registry
-   * @param object of name/value pairs:
-   * { defaultLabel: "value", anotherLabel: "value 2" }
-   */
+	 * Set static labels to every metric emitted by this registry
+	 * @param object of name/value pairs:
+	 * { defaultLabel: "value", anotherLabel: "value 2" }
+	 */
 	setDefaultLabels(labels: Object): void;
 
 	/**

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,13 @@ export class Registry {
 	getSingleMetric(name: string): Metric;
 
 	/**
+   * Set static labels to every metric emitted by this registry
+   * @param object of name/value pairs:
+   * { defaultLabel: "value", anotherLabel: "value 2" }
+   */
+	setDefaultLabels(labels: Object): void;
+
+	/**
 	 * Get a string representation of a single metric by name
 	 * @param name The name of the metric
 	 */

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -9,20 +9,11 @@ function escapeLabelValue(str) {
 	}
 	return escapeString(str).replace(/"/g, '\\"');
 }
-<<<<<<< HEAD
 
 class Registry {
 	constructor() {
 		this._metrics = {};
 		this._defaultLabels = {};
-=======
-var registry = (function() {
-	var _metrics = {};
-	var _defaultLabels = [];
-	var self;
-	function Registry() {
-		self = this;
->>>>>>> default metrics will be overridden
 	}
 
 	getMetricsAsArray() {
@@ -36,23 +27,15 @@ var registry = (function() {
 		help = ['#', 'HELP', name, help].join(' ');
 		const type = ['#', 'TYPE', name, item.type].join(' ');
 
-<<<<<<< HEAD
 		const values = (item.values || []).reduce((valAcc, val) => {
 			const labels = Object.keys(val.labels || {}).map(
 				key => `${key}="${escapeLabelValue(val.labels[key])}"`
 			);
 
-<<<<<<< HEAD
 			labels = Object.assign(labels, this._defaultLabels);
-=======
-			labels = Object.assign(labels, _defaultLabels);
->>>>>>> onetime processing of default labels
-=======
-			labels = Object.assign(_defaultLabels, labels);
->>>>>>> default metrics will be overridden
 
 			let metricName = val.metricName || item.name;
-			if(labels.length) {
+			if (labels.length) {
 				metricName += `{${labels.join(',')}}`;
 			}
 
@@ -106,9 +89,9 @@ var registry = (function() {
 	}
 
 	setDefaultLabels(labels) {
-		this._defaultLabels = Object.keys(_defaultLabels).map(function(key) {
-			return key + '="' + escapeLabelValue(_defaultLabels[key]) + '"';
-		});
+		this._defaultLabels = Object.keys(labels).map(
+			key => `${key}="${escapeLabelValue(labels[key])}"`
+		);
 	}
 
 	get contentType() {

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -13,7 +13,7 @@ function escapeLabelValue(str) {
 class Registry {
 	constructor() {
 		this._metrics = {};
-		this._defaultLabels = {};
+		this._defaultLabels = [];
 	}
 
 	getMetricsAsArray() {
@@ -28,11 +28,11 @@ class Registry {
 		const type = ['#', 'TYPE', name, item.type].join(' ');
 
 		const values = (item.values || []).reduce((valAcc, val) => {
-			const labels = Object.keys(val.labels || {}).map(
+			let labels = Object.keys(val.labels || {}).map(
 				key => `${key}="${escapeLabelValue(val.labels[key])}"`
 			);
 
-			labels = Object.assign(labels, this._defaultLabels);
+			labels = Object.assign(this._defaultLabels, labels);
 
 			let metricName = val.metricName || item.name;
 			if (labels.length) {
@@ -69,7 +69,7 @@ class Registry {
 
 	clear() {
 		this._metrics = {};
-		this._defaultLabels = {};
+		this._defaultLabels = [];
 	}
 
 	getMetricsAsJSON() {

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -13,7 +13,7 @@ function escapeLabelValue(str) {
 class Registry {
 	constructor() {
 		this._metrics = {};
-		this._defaultLabels = [];
+		this._defaultLabels = {};
 	}
 
 	getMetricsAsArray() {
@@ -28,11 +28,11 @@ class Registry {
 		const type = ['#', 'TYPE', name, item.type].join(' ');
 
 		const values = (item.values || []).reduce((valAcc, val) => {
-			let labels = Object.keys(val.labels || {}).map(
-				key => `${key}="${escapeLabelValue(val.labels[key])}"`
-			);
+			const merged = Object.assign({}, this._defaultLabels, val.labels);
 
-			labels = Object.assign(this._defaultLabels, labels);
+			const labels = Object.keys(merged).map(
+				key => `${key}="${escapeLabelValue(merged[key])}"`
+			);
 
 			let metricName = val.metricName || item.name;
 			if (labels.length) {
@@ -69,7 +69,7 @@ class Registry {
 
 	clear() {
 		this._metrics = {};
-		this._defaultLabels = [];
+		this._defaultLabels = {};
 	}
 
 	getMetricsAsJSON() {
@@ -89,9 +89,7 @@ class Registry {
 	}
 
 	setDefaultLabels(labels) {
-		this._defaultLabels = Object.keys(labels).map(
-			key => `${key}="${escapeLabelValue(labels[key])}"`
-		);
+		this._defaultLabels = labels;
 	}
 
 	get contentType() {

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -9,11 +9,20 @@ function escapeLabelValue(str) {
 	}
 	return escapeString(str).replace(/"/g, '\\"');
 }
+<<<<<<< HEAD
 
 class Registry {
 	constructor() {
 		this._metrics = {};
 		this._defaultLabels = {};
+=======
+var registry = (function() {
+	var _metrics = {};
+	var _defaultLabels = [];
+	var self;
+	function Registry() {
+		self = this;
+>>>>>>> default metrics will be overridden
 	}
 
 	getMetricsAsArray() {
@@ -33,10 +42,14 @@ class Registry {
 				key => `${key}="${escapeLabelValue(val.labels[key])}"`
 			);
 
+<<<<<<< HEAD
 			labels = Object.assign(labels, this._defaultLabels);
 =======
 			labels = Object.assign(labels, _defaultLabels);
 >>>>>>> onetime processing of default labels
+=======
+			labels = Object.assign(_defaultLabels, labels);
+>>>>>>> default metrics will be overridden
 
 			let metricName = val.metricName || item.name;
 			if(labels.length) {

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -13,6 +13,7 @@ function escapeLabelValue(str) {
 class Registry {
 	constructor() {
 		this._metrics = {};
+		this._defaultLabels = {};
 	}
 
 	getMetricsAsArray() {
@@ -31,8 +32,10 @@ class Registry {
 				key => `${key}="${escapeLabelValue(val.labels[key])}"`
 			);
 
+			labels = Object.assign(labels, this._defaultLabels);
+
 			let metricName = val.metricName || item.name;
-			if (labels.length) {
+			if(labels.length) {
 				metricName += `{${labels.join(',')}}`;
 			}
 
@@ -66,6 +69,7 @@ class Registry {
 
 	clear() {
 		this._metrics = {};
+		this._defaultLabels = {};
 	}
 
 	getMetricsAsJSON() {
@@ -82,6 +86,12 @@ class Registry {
 
 	getSingleMetric(name) {
 		return this._metrics[name];
+	}
+
+	setDefaultLabels(labels) {
+		this._defaultLabels = Object.keys(_defaultLabels).map(function(key) {
+			return key + '="' + escapeLabelValue(_defaultLabels[key]) + '"';
+		});
 	}
 
 	get contentType() {

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -27,12 +27,16 @@ class Registry {
 		help = ['#', 'HELP', name, help].join(' ');
 		const type = ['#', 'TYPE', name, item.type].join(' ');
 
+<<<<<<< HEAD
 		const values = (item.values || []).reduce((valAcc, val) => {
 			const labels = Object.keys(val.labels || {}).map(
 				key => `${key}="${escapeLabelValue(val.labels[key])}"`
 			);
 
 			labels = Object.assign(labels, this._defaultLabels);
+=======
+			labels = Object.assign(labels, _defaultLabels);
+>>>>>>> onetime processing of default labels
 
 			let metricName = val.metricName || item.name;
 			if(labels.length) {

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -55,55 +55,55 @@ describe('register', () => {
 				};
 			}
 		});
-		const actual = register.metrics().split('\n');
-		expect(actual).toHaveLength(4);
+		expect(register.metrics().split('\n')).toHaveLength(4);
 	});
 
-	it('should handle a metric with default labels', function() {
-		register.setDefaultLabels({'testLabel':'testValue'});
+	it('should handle a metric with default labels', () => {
+		register.setDefaultLabels({ testLabel: 'testValue' });
 		register.registerMetric({
-			get: function() {
+			get() {
 				return {
 					name: 'test_metric',
 					type: 'counter',
 					help: 'A test metric',
-					values: [ {
-						value: 1
-					}]
+					values: [{ value: 1 }]
 				};
 			}
 		});
 
-		var output = register.metrics().split('\n');
-		expect(output[2]).to.equal('test_metric{testLabel="testValue"} 1');
+		const output = register.metrics().split('\n')[2];
+		expect(output).toEqual('test_metric{testLabel="testValue"} 1');
 	});
 
-	it('labeled metrics should take precidence over defaulted', function() {
-		register.setDefaultLabels({'testLabel':'testValue'});
+	it('labeled metrics should take precidence over defaulted', () => {
+		register.setDefaultLabels({ testLabel: 'testValue' });
 		register.registerMetric({
-			get: function() {
+			get() {
 				return {
 					name: 'test_metric',
 					type: 'counter',
 					help: 'A test metric',
-					values: [ {
-						value: 1,
-						labels: {
-							testLabel:'overlapped',
-							anotherLabel:'value123'
+					values: [
+						{
+							value: 1,
+							labels: {
+								testLabel: 'overlapped',
+								anotherLabel: 'value123'
+							}
 						}
-					}]
+					]
 				};
 			}
 		});
 
-		var output = register.metrics().split('\n');
-		expect(output[2]).to.equal('test_metric{testLabel="overlapped",anotherLabel="value123"} 1');
+		expect(register.metrics().split('\n')[2]).toEqual(
+			'test_metric{testLabel="overlapped",anotherLabel="value123"} 1'
+		);
 	});
 
-	describe('should escape', function() {
-		var escapedResult;
-		beforeEach(function() {
+	describe('should escape', () => {
+		let escapedResult;
+		beforeEach(() => {
 			register.registerMetric({
 				get() {
 					return {

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -59,9 +59,27 @@ describe('register', () => {
 		expect(actual).toHaveLength(4);
 	});
 
-	describe('should escape', () => {
-		let escapedResult;
-		beforeEach(() => {
+	it('should handle a metric with default labels', function() {
+		register.setDefaultLabels({'testLabel':'testValue'});
+		register.registerMetric({
+			get: function() {
+				return {
+					name: 'test_metric',
+					type: 'counter',
+					help: 'A test metric',
+					values: [ {
+						value: 1
+					}]
+				};
+			}
+		});
+		var actual = register.metrics().split('\n');
+		expect(actual).to.have.length(4);
+	});
+
+	describe('should escape', function() {
+		var escapedResult;
+		beforeEach(function() {
 			register.registerMetric({
 				get() {
 					return {

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -73,8 +73,9 @@ describe('register', () => {
 				};
 			}
 		});
-		var actual = register.metrics().split('\n');
-		expect(actual).to.have.length(4);
+
+		var output = register.metrics().split('\n');
+		expect(output[2]).to.equal('test_metric{testLabel="testValue"} 1');
 	});
 
 	describe('should escape', function() {

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -78,6 +78,29 @@ describe('register', () => {
 		expect(output[2]).to.equal('test_metric{testLabel="testValue"} 1');
 	});
 
+	it('labeled metrics should take precidence over defaulted', function() {
+		register.setDefaultLabels({'testLabel':'testValue'});
+		register.registerMetric({
+			get: function() {
+				return {
+					name: 'test_metric',
+					type: 'counter',
+					help: 'A test metric',
+					values: [ {
+						value: 1,
+						labels: {
+							testLabel:'overlapped',
+							anotherLabel:'value123'
+						}
+					}]
+				};
+			}
+		});
+
+		var output = register.metrics().split('\n');
+		expect(output[2]).to.equal('test_metric{testLabel="overlapped",anotherLabel="value123"} 1');
+	});
+
 	describe('should escape', function() {
 		var escapedResult;
 		beforeEach(function() {


### PR DESCRIPTION
I believe this is a pretty good solution for #83 

It's simple, doesn't break any APIs, allows you to configure static labels per registry, and defaulted values can be overridden.

Let me know if this wasn't what you were thinking about this, or if there are any styling considerations I should be changing.

Thanks!