### PR TITLE
Compatibility with pushgateway 0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 - Added registerMetric to definitions file
 ### Changed
+- Don't pass timestamps through to pushgateway by default
 
 ## [10.0.2] - 2017-07-07
 ### Changed

--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ const mergedRegistries = client.Registry.merge([registry, client.register]);
 
 You can get all metrics by running `register.metrics()`, which will output a string for prometheus to consume.
 
+`register.metrics()` takes an optional object with a `timestamps` field. Setting this to false will strip timestamps from the string.
+
 ##### Getting a single metric for Prometheus displaying
 
 If you need to output a single metric for Prometheus, you can use `register.getSingleMetricAsString(*name of metric*)`, it will output a string for Prometheus to consume.
@@ -281,6 +283,8 @@ You can remove all metrics by calling `register.clear()`. You can also remove a 
 #### Pushgateway
 
 It is possible to push metrics via a [Pushgateway](https://github.com/prometheus/pushgateway).
+
+Note that timestamps will be stripped before the metrics are pushed, since pushgateway >= 0.4 does not accept timestamps.
 
 ```js
 const client = require('prom-client');

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,13 +2,23 @@
 // Definitions by: Simon Nyberg http://twitter.com/siimon_nyberg
 
 /**
+ * Options pass to Registry.metrics()
+ */
+export interface MetricsOpts {
+	/**
+	 * Whether to include timestamps in the output, defaults to true
+	 */
+	timestamps?: boolean;
+}
+
+/**
  * Container for all registered metrics
  */
 export class Registry {
 	/**
 	 * Get string representation for all metrics
 	 */
-	metrics(): string;
+	metrics(opts?: MetricsOpts): string;
 
 	/**
 	 * Remove all metrics from the registry

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -71,7 +71,7 @@ function useGateway(method, job, groupings, callback) {
 	});
 
 	if (method !== 'DELETE') {
-		req.write(this.registry.metrics());
+		req.write(this.registry.metrics({ timestamps: false }));
 	}
 	req.end();
 }

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -10,6 +10,10 @@ function escapeLabelValue(str) {
 	return escapeString(str).replace(/"/g, '\\"');
 }
 
+const defaultMetricsOpts = {
+	timestamps: true
+};
+
 class Registry {
 	constructor() {
 		this._metrics = {};
@@ -20,7 +24,8 @@ class Registry {
 		return Object.keys(this._metrics).map(this.getSingleMetric, this);
 	}
 
-	getMetricAsPrometheusString(metric) {
+	getMetricAsPrometheusString(metric, conf) {
+		const opts = Object.assign({}, defaultMetricsOpts, conf);
 		const item = metric.get();
 		const name = escapeString(item.name);
 		let help = escapeString(item.help);
@@ -39,7 +44,11 @@ class Registry {
 				metricName += `{${labels.join(',')}}`;
 			}
 
-			valAcc += [metricName, val.value, val.timestamp].join(' ').trim();
+			const line = [metricName, val.value];
+			if (opts.timestamps) {
+				line.push(val.timestamp);
+			}
+			valAcc += line.join(' ').trim();
 			valAcc += '\n';
 			return valAcc;
 		}, '');
@@ -48,9 +57,9 @@ class Registry {
 		return acc;
 	}
 
-	metrics() {
+	metrics(opts) {
 		return this.getMetricsAsArray()
-			.map(this.getMetricAsPrometheusString, this)
+			.map(metric => this.getMetricAsPrometheusString.bind(this)(metric, opts))
 			.join('\n');
 	}
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -59,7 +59,7 @@ class Registry {
 
 	metrics(opts) {
 		return this.getMetricsAsArray()
-			.map(metric => this.getMetricAsPrometheusString.bind(this)(metric, opts))
+			.map(metric => this.getMetricAsPrometheusString(metric, opts))
 			.join('\n');
 	}
 

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -204,6 +204,16 @@ describe('register', () => {
 		expect(output).toEqual(metric);
 	});
 
+	it('should allow gettings metrics without timestamps', () => {
+		const metric = getMetric();
+		register.registerMetric(metric);
+		const metrics = register.metrics({ timestamps: false });
+
+		expect(metrics.split('\n')[3]).toEqual(
+			'test_metric{label="bye",code="404"} 34'
+		);
+	});
+
 	describe('merging', () => {
 		const Registry = require('../lib/registry');
 		let registryOne;


### PR DESCRIPTION
As of pushgateway 0.4, timestamps are no longer accepted when pushing.

See: https://github.com/prometheus/pushgateway/pull/119