### PR TITLE
Cluster support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@
   "plugins": ["prettier"],
   "extends": "eslint:recommended",
   "env": {
-	"node": true
+	"node": true,
+	"es6": true
   },
   "parserOptions": {
 	"ecmaVersion": 2015
@@ -55,6 +56,12 @@
 		"no-shadow": "off",
 		"no-unused-expressions": "off"
 	  }
+	},
+	{
+		"files": ["example/**/*.js"],
+		"rules": {
+			"no-console": "off"
+		}
 	}
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Breaking
 ### Added
+- Support aggregating metrics across workers in a Node.js cluster.
 ### Changed
 
 ## [10.0.4] - 2017-08-22

--- a/example/cluster.js
+++ b/example/cluster.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const cluster = require('cluster');
+const express = require('express');
+const metricsServer = express();
+const AggregatorRegistry = require('../').AggregatorRegistry;
+const aggregatorRegistry = new AggregatorRegistry();
+
+if (cluster.isMaster) {
+	for (let i = 0; i < 4; i++) {
+		cluster.fork();
+	}
+
+	metricsServer.get('/cluster_metrics', (req, res) => {
+		aggregatorRegistry.clusterMetrics((err, metrics) => {
+			if (err) console.log(err);
+			res.set('Content-Type', aggregatorRegistry.contentType);
+			res.send(metrics);
+		});
+	});
+
+	metricsServer.listen(3001);
+	console.log(
+		'Cluster metrics server listening to 3001, metrics exposed on /cluster_metrics'
+	);
+} else {
+	require('./server.js');
+}

--- a/example/server.js
+++ b/example/server.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const express = require('express');
+const cluster = require('cluster');
 const server = express();
 const register = require('../').register;
 
@@ -48,6 +49,13 @@ setInterval(() => {
 	g.labels('post', '300').inc();
 }, 100);
 
+if (cluster.isWorker) {
+	// Expose some worker-specific metric as an example
+	setInterval(() => {
+		c.inc({ code: `worker_${cluster.worker.id}` });
+	}, 2000);
+}
+
 server.get('/metrics', (req, res) => {
 	res.set('Content-Type', register.contentType);
 	res.end(register.metrics());
@@ -61,6 +69,5 @@ server.get('/metrics/counter', (req, res) => {
 //Enable collection of default metrics
 require('../').collectDefaultMetrics();
 
-//eslint-disable-next-line no-console
 console.log('Server listening to 3000, metrics exposed on /metrics endpoint');
 server.listen(3000);

--- a/index.d.ts
+++ b/index.d.ts
@@ -73,10 +73,48 @@ export class Registry {
  */
 export const register: Registry;
 
+export class AggregatorRegistry extends Registry {
+	/**
+	 * Gets aggregated metrics for all workers. The optional callback and
+	 * returned Promise resolve with the same value; either may be used.
+	 * @param {Function?} callback (err, metrics) => any
+	 * @return {Promise<string>} Promise that resolves with the aggregated
+	 *   metrics.
+	 */
+	clusterMetrics(
+		cb?: (err: Error | null, metrics?: string) => any
+	): Promise<string>;
+
+	/**
+	 * Creates a new Registry instance from an array of metrics that were
+	 * created by `registry.getMetricsAsJSON()`. Metrics are aggregated using
+	 * the method specified by their `aggregator` property, or by summation if
+	 * `aggregator` is undefined.
+	 * @param {Array} metricsArr Array of metrics, each of which created by
+	 *   `registry.getMetricsAsJSON()`.
+	 * @return {Registry} aggregated registry.
+	 */
+	static aggregate(metricsArr: Array<Object>): Registry;
+
+	/**
+	 * Sets the registry or registries to be aggregated. Call from workers to
+	 * use a registry/registries other than the default global registry.
+	 * @param {Array<Registry>|Registry} regs Registry or registries to be
+	 *   aggregated.
+	 * @return {void}
+	 */
+	static setRegistries(regs: Array<Registry> | Registry): void;
+}
+
 /**
  * General metric type
  */
 export type Metric = Counter | Gauge | Summary | Histogram;
+
+/**
+ * Aggregation methods, used for aggregating metrics in a Node.js cluster.
+ */
+export type Aggregator = 'omit' | 'sum' | 'first' | 'min' | 'max' | 'average';
 
 export enum MetricType {
 	Counter,
@@ -89,6 +127,7 @@ interface metric {
 	name: string;
 	help: string;
 	type: MetricType;
+	aggregator: Aggregator;
 }
 
 interface labelValues {
@@ -100,6 +139,7 @@ export interface CounterConfiguration {
 	help: string;
 	labelNames?: string[];
 	registers?: Registry[];
+	aggregator?: Aggregator;
 }
 
 /**
@@ -158,6 +198,7 @@ export interface GaugeConfiguration {
 	help: string;
 	labelNames?: string[];
 	registers?: Registry[];
+	aggregator?: Aggregator;
 }
 
 /**
@@ -285,6 +326,7 @@ export interface HistogramConfiguration {
 	labelNames?: string[];
 	buckets?: number[];
 	registers?: Registry[];
+	aggregator?: Aggregator;
 }
 
 /**
@@ -378,6 +420,7 @@ export interface SummaryConfiguration {
 	labelNames?: string[];
 	percentiles?: number[];
 	registers?: Registry[];
+	aggregator?: Aggregator;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -19,3 +19,6 @@ exports.linearBuckets = require('./lib/bucketGenerators').linearBuckets;
 exports.exponentialBuckets = require('./lib/bucketGenerators').exponentialBuckets;
 
 exports.collectDefaultMetrics = require('./lib/defaultMetrics');
+
+exports.aggregators = require('./lib/metricAggregators').aggregators;
+exports.AggregatorRegistry = require('./lib/cluster');

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -1,0 +1,172 @@
+'use strict';
+
+/**
+ * Extends the Registry class with a `clusterMetrics` method that returns
+ * aggregated metrics for all workers.
+ *
+ * In cluster workers, listens for and responds to requests for metrics by the
+ * cluster master.
+ */
+
+const cluster = require('cluster');
+const Registry = require('./registry');
+const util = require('./util');
+const aggregators = require('./metricAggregators').aggregators;
+
+const GET_METRICS_REQ = 'prom-client:getMetricsReq';
+const GET_METRICS_RES = 'prom-client:getMetricsRes';
+
+let registries = [Registry.globalRegistry];
+let requestCtr = 0; // Concurrency control
+const requests = new Map(); // Pending requests for workers' local metrics.
+
+class AggregatorRegistry extends Registry {
+	/**
+	 * Gets aggregated metrics for all workers. The optional callback and
+	 * returned Promise resolve with the same value; either may be used.
+	 * @param {Function?} callback (err, metrics) => any
+	 * @return {Promise<string>} Promise that resolves with the aggregated
+	 *   metrics.
+	 */
+	clusterMetrics(callback) {
+		const requestId = requestCtr++;
+
+		callback = callback || function() {};
+
+		return new Promise((resolve, reject) => {
+			const nWorkers = Object.keys(cluster.workers).length;
+
+			if (nWorkers === 0) {
+				return process.nextTick(() => {
+					callback(null, '');
+					resolve('');
+				});
+			}
+
+			const request = {
+				responses: [],
+				pending: nWorkers,
+				callback,
+				resolve,
+				reject,
+				errorTimeout: setTimeout(() => {
+					request.failed = true;
+					const err = new Error('Operation timed out.');
+					request.callback(err);
+					reject(err);
+				}, 5000),
+				failed: false
+			};
+			requests.set(requestId, request);
+
+			const message = {
+				type: GET_METRICS_REQ,
+				requestId
+			};
+			for (const id in cluster.workers) cluster.workers[id].send(message);
+		});
+	}
+
+	/**
+	 * Creates a new Registry instance from an array of metrics that were
+	 * created by `registry.getMetricsAsJSON()`. Metrics are aggregated using
+	 * the method specified by their `aggregator` property, or by summation if
+	 * `aggregator` is undefined.
+	 * @param {Array} metricsArr Array of metrics, each of which created by
+	 *   `registry.getMetricsAsJSON()`.
+	 * @return {Registry} aggregated registry.
+	 */
+	static aggregate(metricsArr) {
+		const aggregatedRegistry = new Registry();
+		const metricsByName = new util.Grouper();
+
+		// Gather by name
+		metricsArr.forEach(metrics => {
+			metrics.forEach(metric => {
+				metricsByName.add(metric.name, metric);
+			});
+		});
+
+		// Aggregate gathered metrics.
+		metricsByName.forEach(metrics => {
+			const aggregatorName = metrics[0].aggregator;
+			const aggregatorFn = aggregators[aggregatorName];
+			if (typeof aggregatorFn !== 'function') {
+				throw new Error(`'${aggregatorName}' is not a defined aggregator.`);
+			}
+			const aggregatedMetric = aggregatorFn(metrics);
+			// NB: The 'omit' aggregator returns undefined.
+			if (aggregatedMetric) {
+				const aggregatedMetricWrapper = Object.assign(
+					{
+						get: () => aggregatedMetric
+					},
+					aggregatedMetric
+				);
+				aggregatedRegistry.registerMetric(aggregatedMetricWrapper);
+			}
+		});
+
+		return aggregatedRegistry;
+	}
+
+	/**
+	 * Sets the registry or registries to be aggregated. Call from workers to
+	 * use a registry/registries other than the default global registry.
+	 * @param {Array<Registry>|Registry} regs Registry or registries to be
+	 *   aggregated.
+	 * @return {void}
+	 */
+	static setRegistries(regs) {
+		if (!Array.isArray(regs)) regs = [regs];
+		regs.forEach(reg => {
+			if (!(reg instanceof Registry)) {
+				throw new TypeError(`Expected Registry, got ${typeof reg}`);
+			}
+		});
+		registries = regs;
+	}
+}
+
+if (cluster.isMaster) {
+	// Listen for worker responses to requests for local metrics
+	cluster.on('message', (worker, message) => {
+		if (arguments.length === 2) {
+			// pre-Node.js v6.0
+			message = worker;
+			worker = undefined;
+		}
+
+		if (message.type === GET_METRICS_RES) {
+			const request = requests.get(message.requestId);
+			message.metrics.forEach(registry => request.responses.push(registry));
+			request.pending--;
+
+			if (request.pending === 0) {
+				// finalize
+				requests.delete(message.requestId);
+				clearTimeout(request.errorTimeout);
+
+				if (request.failed) return; // Callback already run with Error.
+
+				const registry = AggregatorRegistry.aggregate(request.responses);
+				const promString = registry.metrics();
+				request.callback(null, promString);
+				request.resolve(promString);
+			}
+		}
+	});
+} else if (cluster.isWorker) {
+	// Respond to master's requests for worker's local metrics.
+	process.on('message', message => {
+		if (message.type === GET_METRICS_REQ) {
+			process.send({
+				type: GET_METRICS_RES,
+				requestId: message.requestId,
+				metrics: registries.map(r => r.getMetricsAsJSON())
+			});
+		}
+	});
+}
+
+module.exports = AggregatorRegistry;

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -73,6 +73,7 @@ class Counter {
 		}
 
 		this.help = config.help;
+		this.aggregator = config.aggregator || 'sum';
 
 		config.registers.forEach(registryInstance =>
 			registryInstance.registerMetric(this)
@@ -100,7 +101,8 @@ class Counter {
 			help: this.help,
 			name: this.name,
 			type,
-			values: getProperties(this.hashMap)
+			values: getProperties(this.hashMap),
+			aggregator: this.aggregator
 		};
 	}
 

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -69,6 +69,7 @@ class Gauge {
 			this.hashMap = createValue({}, 0, {});
 		}
 		this.help = config.help;
+		this.aggregator = config.aggregator || 'sum';
 
 		config.registers.forEach(registryInstance =>
 			registryInstance.registerMetric(this)
@@ -90,24 +91,23 @@ class Gauge {
 	}
 
 	/**
- * Increment a gauge value
- * @param {object} labels - Object with labels where key is the label key and value is label value. Can only be one level deep
- * @param {Number} value - Value to increment - if omitted, increment with 1
- * @param {(Number|Date)} timestamp - Timestamp to set the gauge to
- * @returns {void}
- */
+	 * Increment a gauge value
+	 * @param {object} labels - Object with labels where key is the label key and value is label value. Can only be one level deep
+	 * @param {Number} value - Value to increment - if omitted, increment with 1
+	 * @param {(Number|Date)} timestamp - Timestamp to set the gauge to
+	 * @returns {void}
+	 */
 	inc(labels, value, timestamp) {
 		inc.call(this, labels)(value, timestamp);
 	}
 
 	/**
-
- * Decrement a gauge value
- * @param {object} labels - Object with labels where key is the label key and value is label value. Can only be one level deep
- * @param {Number} value - Value to decrement - if omitted, decrement with 1
- * @param {(Number|Date)} timestamp - Timestamp to set the gauge to
- * @returns {void}
- */
+	 * Decrement a gauge value
+	 * @param {object} labels - Object with labels where key is the label key and value is label value. Can only be one level deep
+	 * @param {Number} value - Value to decrement - if omitted, decrement with 1
+	 * @param {(Number|Date)} timestamp - Timestamp to set the gauge to
+	 * @returns {void}
+	 */
 	dec(labels, value, timestamp) {
 		dec.call(this, labels)(value, timestamp);
 	}
@@ -140,7 +140,8 @@ class Gauge {
 			help: this.help,
 			name: this.name,
 			type,
-			values: getProperties(this.hashMap)
+			values: getProperties(this.hashMap),
+			aggregator: this.aggregator
 		};
 	}
 

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -64,6 +64,7 @@ class Histogram {
 
 		this.name = config.name;
 		this.help = config.help;
+		this.aggregator = config.aggregator || 'sum';
 
 		this.upperBounds = config.buckets;
 		this.bucketValues = this.upperBounds.reduce((acc, upperBound) => {
@@ -113,7 +114,8 @@ class Histogram {
 			name: this.name,
 			help: this.help,
 			type,
-			values
+			values,
+			aggregator: this.aggregator
 		};
 	}
 

--- a/lib/metricAggregators.js
+++ b/lib/metricAggregators.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const util = require('./util');
+
+/**
+ * Returns a new function that applies the `aggregatorFn` to the values.
+ * @param {Function} aggregatorFn function to apply to values.
+ * @return {Function} aggregator function
+ */
+function AggregatorFactory(aggregatorFn) {
+	return metrics => {
+		if (metrics.length === 0) return;
+		const result = {
+			help: metrics[0].help,
+			name: metrics[0].name,
+			type: metrics[0].type,
+			values: []
+		};
+		// Gather metrics by metricName and labels.
+		const byLabels = new util.Grouper();
+		metrics.forEach(metric => {
+			metric.values.forEach(value => {
+				const key = util.hashObject(value.labels);
+				byLabels.add(`${value.metricName}_${key}`, value);
+			});
+		});
+		// Apply aggregator function to gathered metrics.
+		byLabels.forEach(values => {
+			if (values.length === 0) return;
+			const valObj = {
+				value: aggregatorFn(values),
+				labels: values[0].labels
+			};
+			if (values[0].metricName) {
+				valObj.metricName = values[0].metricName;
+			}
+			// NB: Timestamps are omitted.
+			result.values.push(valObj);
+		});
+		return result;
+	};
+}
+// Export for users to define their own aggregation methods.
+exports.AggregatorFactory = AggregatorFactory;
+
+/**
+ * Functions that can be used to aggregate metrics from multiple registries.
+ */
+exports.aggregators = {
+	/**
+	 * @return The sum of values.
+	 */
+	sum: AggregatorFactory(v => v.reduce((p, c) => p + c.value, 0)),
+	/**
+	 * @return The first value.
+	 */
+	first: AggregatorFactory(v => v[0].value),
+	/**
+	 * @return {undefined} Undefined; omits the metric.
+	 */
+	omit: () => {},
+	/**
+	 * @return The arithmetic mean of the values.
+	 */
+	average: AggregatorFactory(
+		v => v.reduce((p, c) => p + c.value, 0) / v.length
+	),
+	/**
+	 * @return The minimum of the values.
+	 */
+	min: AggregatorFactory(v =>
+		v.reduce((p, c) => Math.min(p, c.value), Infinity)
+	),
+	/**
+	 * @return The maximum of the values.
+	 */
+	max: AggregatorFactory(v =>
+		v.reduce((p, c) => Math.max(p, c.value), -Infinity)
+	)
+};

--- a/lib/metrics/eventLoopLag.js
+++ b/lib/metrics/eventLoopLag.js
@@ -16,7 +16,8 @@ module.exports = registry => {
 	const gauge = new Gauge({
 		name: NODEJS_EVENTLOOP_LAG,
 		help: 'Lag of event loop in seconds.',
-		registers: registry ? [registry] : undefined
+		registers: registry ? [registry] : undefined,
+		aggregator: 'average'
 	});
 
 	return () => {

--- a/lib/metrics/processStartTime.js
+++ b/lib/metrics/processStartTime.js
@@ -9,7 +9,8 @@ module.exports = registry => {
 	const cpuUserGauge = new Gauge({
 		name: PROCESS_START_TIME,
 		help: 'Start time of the process since unix epoch in seconds.',
-		registers: registry ? [registry] : undefined
+		registers: registry ? [registry] : undefined,
+		aggregator: 'omit'
 	});
 	let isSet = false;
 

--- a/lib/metrics/version.js
+++ b/lib/metrics/version.js
@@ -11,7 +11,8 @@ module.exports = registry => {
 		name: NODE_VERSION_INFO,
 		help: 'Node.js version info.',
 		labelNames: ['version', 'major', 'minor', 'patch'],
-		registers: registry ? [registry] : undefined
+		registers: registry ? [registry] : undefined,
+		aggregator: 'first'
 	});
 	let isSet = false;
 

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -65,6 +65,7 @@ class Summary {
 
 		this.name = config.name;
 		this.help = config.help;
+		this.aggregator = config.aggregator || 'sum';
 
 		this.percentiles = config.percentiles;
 		this.hashMap = {};
@@ -111,7 +112,8 @@ class Summary {
 			name: this.name,
 			help: this.help,
 			type,
-			values
+			values,
+			aggregator: this.aggregator
 		};
 	}
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -89,3 +89,21 @@ exports.printDeprecationCollectDefaultMetricsNumber = timeout => {
 		`prom-client - A number to defaultMetrics is deprecated, please use \`collectDefaultMetrics({ timeout: ${timeout} })\`.`
 	);
 };
+
+class Grouper extends Map {
+	/**
+	 * Adds the `value` to the `key`'s array of values.
+	 * @param {*} key Key to set.
+	 * @param {*} value Value to add to `key`'s array.
+	 * @returns {undefined} undefined.
+	 */
+	add(key, value) {
+		if (this.has(key)) {
+			this.get(key).push(value);
+		} else {
+			this.set(key, [value]);
+		}
+	}
+}
+
+exports.Grouper = Grouper;

--- a/test/aggregatorsTest.js
+++ b/test/aggregatorsTest.js
@@ -1,0 +1,121 @@
+'use strict';
+
+describe('aggregators', () => {
+	const aggregators = require('../index').aggregators;
+	const metrics = [
+		{
+			help: 'metric_help',
+			name: 'metric_name',
+			type: 'does not matter',
+			values: [{ labels: [], value: 1 }, { labels: ['label1'], value: 2 }]
+		},
+		{
+			help: 'metric_help',
+			name: 'metric_name',
+			type: 'does not matter',
+			values: [{ labels: [], value: 3 }, { labels: ['label1'], value: 4 }]
+		}
+	];
+
+	describe('sum', () => {
+		it('properly sums values', () => {
+			const result = aggregators.sum(metrics);
+			expect(result.help).toBe('metric_help');
+			expect(result.name).toBe('metric_name');
+			expect(result.type).toBe('does not matter');
+			expect(result.values).toEqual([
+				{ value: 4, labels: [] },
+				{ value: 6, labels: ['label1'] }
+			]);
+		});
+	});
+
+	describe('first', () => {
+		it('takes the first value', () => {
+			const result = aggregators.first(metrics);
+			expect(result.help).toBe('metric_help');
+			expect(result.name).toBe('metric_name');
+			expect(result.type).toBe('does not matter');
+			expect(result.values).toEqual([
+				{ value: 1, labels: [] },
+				{ value: 2, labels: ['label1'] }
+			]);
+		});
+	});
+
+	describe('omit', () => {
+		it('returns undefined', () => {
+			const result = aggregators.omit(metrics);
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('average', () => {
+		it('properly averages values', () => {
+			const result = aggregators.average(metrics);
+			expect(result.help).toBe('metric_help');
+			expect(result.name).toBe('metric_name');
+			expect(result.type).toBe('does not matter');
+			expect(result.values).toEqual([
+				{ value: 2, labels: [] },
+				{ value: 3, labels: ['label1'] }
+			]);
+		});
+	});
+
+	describe('min', () => {
+		it('takes the minimum of the values', () => {
+			const result = aggregators.min(metrics);
+			expect(result.help).toBe('metric_help');
+			expect(result.name).toBe('metric_name');
+			expect(result.type).toBe('does not matter');
+			expect(result.values).toEqual([
+				{ value: 1, labels: [] },
+				{ value: 2, labels: ['label1'] }
+			]);
+		});
+	});
+
+	describe('max', () => {
+		it('takes the maximum of the values', () => {
+			const result = aggregators.max(metrics);
+			expect(result.help).toBe('metric_help');
+			expect(result.name).toBe('metric_name');
+			expect(result.type).toBe('does not matter');
+			expect(result.values).toEqual([
+				{ value: 3, labels: [] },
+				{ value: 4, labels: ['label1'] }
+			]);
+		});
+	});
+
+	describe('(common)', () => {
+		it('separates metrics by metricName', () => {
+			const metrics2 = [
+				{
+					help: 'metric_help',
+					name: 'metric_name',
+					type: 'does not matter',
+					values: [{ labels: [], value: 1, metricName: 'abc' }]
+				},
+				{
+					help: 'metric_help',
+					name: 'metric_name',
+					type: 'does not matter',
+					values: [{ labels: [], value: 3, metricName: 'abc' }]
+				},
+				{
+					help: 'metric_help',
+					name: 'metric_name',
+					type: 'does not matter',
+					values: [{ labels: [], value: 5, metricName: 'def' }]
+				}
+			];
+			const result = aggregators.sum(metrics2);
+			expect(result.values).toEqual([
+				{ value: 4, labels: [], metricName: 'abc' },
+				{ value: 5, labels: [], metricName: 'def' }
+			]);
+		});
+	});
+});

--- a/test/clusterTest.js
+++ b/test/clusterTest.js
@@ -1,0 +1,234 @@
+'use strict';
+
+describe('AggregatorRegistry', () => {
+	describe('aggregatorRegistry.clusterMetrics()', () => {
+		it('works properly if there are no cluster workers', done => {
+			const AggregatorRegistry = require('../lib/cluster');
+			const ar = new AggregatorRegistry();
+			let cbCalled = false;
+			let promiseResolved = false;
+			let tickElapsed = false;
+			process.nextTick(() => {
+				tickElapsed = true;
+			});
+			const maybeDone = () => {
+				if (cbCalled && promiseResolved) done();
+			};
+			const ret = ar.clusterMetrics((err, metrics) => {
+				cbCalled = true;
+				expect(tickElapsed).toBe(true);
+				expect(err).toBeNull();
+				expect(metrics).toEqual('');
+				maybeDone();
+			});
+			ret.then(metrics => {
+				promiseResolved = true;
+				expect(tickElapsed).toBe(true);
+				expect(metrics).toEqual('');
+				maybeDone();
+			});
+		});
+	});
+
+	describe('AggregatorRegistry.aggregate()', () => {
+		const Registry = require('../lib/cluster');
+		// These mimic the output of `getMetricsAsJSON`.
+		const metricsArr1 = [
+			{
+				name: 'test_histogram',
+				help: 'Example of a histogram',
+				type: 'histogram',
+				values: [
+					{
+						labels: { le: 0.1, code: '300' },
+						value: 0,
+						metricName: 'test_histogram_bucket'
+					},
+					{
+						labels: { le: 10, code: '300' },
+						value: 1.6486727018068046,
+						metricName: 'test_histogram_bucket'
+					}
+				],
+				aggregator: 'sum'
+			},
+			{
+				help: 'Example of a gauge',
+				name: 'test_gauge',
+				type: 'gauge',
+				values: [
+					{ value: 0.47, labels: { method: 'get', code: 200 } },
+					{ value: 0.64, labels: {} },
+					{ value: 23, labels: { method: 'post', code: '300' } }
+				],
+				aggregator: 'sum'
+			},
+			{
+				help: 'Start time of the process since unix epoch in seconds.',
+				name: 'process_start_time_seconds',
+				type: 'gauge',
+				values: [{ value: 1502075832, labels: {} }],
+				aggregator: 'omit'
+			},
+			{
+				help: 'Lag of event loop in seconds.',
+				name: 'nodejs_eventloop_lag_seconds',
+				type: 'gauge',
+				values: [{ value: 0.009, labels: {}, timestamp: 1502075832298 }],
+				aggregator: 'average'
+			},
+			{
+				help: 'Node.js version info.',
+				name: 'nodejs_version_info',
+				type: 'gauge',
+				values: [
+					{
+						value: 1,
+						labels: { version: 'v6.11.1', major: 6, minor: 11, patch: 1 }
+					}
+				],
+				aggregator: 'first'
+			}
+		];
+		const metricsArr2 = [
+			{
+				name: 'test_histogram',
+				help: 'Example of a histogram',
+				type: 'histogram',
+				values: [
+					{
+						labels: { le: 0.1, code: '300' },
+						value: 0.235151,
+						metricName: 'test_histogram_bucket'
+					},
+					{
+						labels: { le: 10, code: '300' },
+						value: 1.192591,
+						metricName: 'test_histogram_bucket'
+					}
+				],
+				aggregator: 'sum'
+			},
+			{
+				help: 'Example of a gauge',
+				name: 'test_gauge',
+				type: 'gauge',
+				values: [
+					{ value: 0.02, labels: { method: 'get', code: 200 } },
+					{ value: 0.24, labels: {} },
+					{ value: 51, labels: { method: 'post', code: '300' } }
+				],
+				aggregator: 'sum'
+			},
+			{
+				help: 'Start time of the process since unix epoch in seconds.',
+				name: 'process_start_time_seconds',
+				type: 'gauge',
+				values: [{ value: 1502075849, labels: {} }],
+				aggregator: 'omit'
+			},
+			{
+				help: 'Lag of event loop in seconds.',
+				name: 'nodejs_eventloop_lag_seconds',
+				type: 'gauge',
+				values: [{ value: 0.008, labels: {}, timestamp: 1502075832321 }],
+				aggregator: 'average'
+			},
+			{
+				help: 'Node.js version info.',
+				name: 'nodejs_version_info',
+				type: 'gauge',
+				values: [
+					{
+						value: 1,
+						labels: { version: 'v6.11.1', major: 6, minor: 11, patch: 1 }
+					}
+				],
+				aggregator: 'first'
+			}
+		];
+
+		const aggregated = Registry.aggregate([metricsArr1, metricsArr2]);
+
+		it('defaults to summation, preserves histogram bins', () => {
+			const histogram = aggregated.getSingleMetric('test_histogram').get();
+			expect(histogram).toEqual({
+				name: 'test_histogram',
+				help: 'Example of a histogram',
+				type: 'histogram',
+				values: [
+					{
+						labels: { le: 0.1, code: '300' },
+						value: 0.235151,
+						metricName: 'test_histogram_bucket'
+					},
+					{
+						labels: { le: 10, code: '300' },
+						value: 2.8412637018068043,
+						metricName: 'test_histogram_bucket'
+					}
+				]
+			});
+		});
+
+		it('defaults to summation, works for gauges', () => {
+			const gauge = aggregated.getSingleMetric('test_gauge').get();
+			expect(gauge).toEqual({
+				help: 'Example of a gauge',
+				name: 'test_gauge',
+				type: 'gauge',
+				values: [
+					{ value: 0.49, labels: { method: 'get', code: 200 } },
+					{ value: 0.88, labels: {} },
+					{ value: 74, labels: { method: 'post', code: '300' } }
+				]
+			});
+		});
+
+		it('uses `aggregate` method defined for process_start_time', () => {
+			const procStartTime = aggregated.getSingleMetric(
+				'process_start_time_seconds'
+			);
+			expect(procStartTime).toBeUndefined();
+		});
+
+		it('uses `aggregate` method defined for nodejs_eventloop_lag_seconds', () => {
+			const ell = aggregated
+				.getSingleMetric('nodejs_eventloop_lag_seconds')
+				.get();
+			expect(ell).toEqual({
+				help: 'Lag of event loop in seconds.',
+				name: 'nodejs_eventloop_lag_seconds',
+				type: 'gauge',
+				values: [{ value: 0.0085, labels: {} }]
+			});
+		});
+
+		it('uses `aggregate` method defined for nodejs_evnetloop_lag_seconds', () => {
+			const ell = aggregated
+				.getSingleMetric('nodejs_eventloop_lag_seconds')
+				.get();
+			expect(ell).toEqual({
+				help: 'Lag of event loop in seconds.',
+				name: 'nodejs_eventloop_lag_seconds',
+				type: 'gauge',
+				values: [{ value: 0.0085, labels: {} }]
+			});
+		});
+
+		it('uses `aggregate` method defined for nodejs_version_info', () => {
+			const version = aggregated.getSingleMetric('nodejs_version_info').get();
+			expect(version).toEqual({
+				help: 'Node.js version info.',
+				name: 'nodejs_version_info',
+				type: 'gauge',
+				values: [
+					{
+						value: 1,
+						labels: { version: 'v6.11.1', major: 6, minor: 11, patch: 1 }
+					}
+				]
+			});
+		});
+	});
+});


### PR DESCRIPTION
Hello! This is an opening gambit for supporting aggregated metrics for use with node's `cluster` module. It's not ready for merge; looking for feedback first as to whether or not this would go in prom-client or a separate module that wraps prom-client.

It's only lightly tested, and there are no unit tests yet.

I made the changes completely isolated in a separate file that is not loaded by default. From reading issues #82 and #80, I wasn't sure if a PR that provides this functionality would be accepted, so I wanted the changes to work if the functionality was provided as a separate Node.js module. However, that means that [the `metric.aggregate` stuff](https://github.com/siimon/prom-client/compare/master...zbjornson:cluster?expand=1#diff-0faa53fc02580d5de2ebb484c41d691cR98) is a bit ugly. If this is something you want in prom-client, I could definitely add the aggregation mode to the metrics classes.

Ref #82 
Ref #80 

/cc @goofballLogic and @tommiv in case you're interested