### PR TITLE
Fixed typing of DefaultMetricsCollectorConfiguration in definitions file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 - Added registerMetric to definitions file
 ### Changed
+- Fixed typing of DefaultMetricsCollectorConfiguration in definitions file
 
 ## [10.0.2] - 2017-07-07
 ### Changed

--- a/index.d.ts
+++ b/index.d.ts
@@ -540,7 +540,7 @@ export function exponentialBuckets(
 
 export interface DefaultMetricsCollectorConfiguration {
 	interval?: number;
-	registry?: Registry;
+	register?: Registry;
 }
 
 /**


### PR DESCRIPTION
Fixed mismatch type definition. I have checked that the corresponding test case is using `register` instead of `registry`.