### PR TITLE
Include invalid values in the error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Breaking
 ### Added
+- Include invalid values in the error messages
+
 ### Changed
 
 ## [10.0.3] - 2017-08-07

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -2,9 +2,10 @@
  * Counter metric
  */
 'use strict';
+
+const util = require('util');
 const globalRegistry = require('./registry').globalRegistry;
 const type = 'counter';
-const isNumber = require('./util').isNumber;
 const isDate = require('./util').isDate;
 const getProperties = require('./util').getPropertiesFromObj;
 const hashObject = require('./util').hashObject;
@@ -86,7 +87,7 @@ class Counter {
 	 * @returns {void}
 	 */
 	inc(labels, value, timestamp) {
-		if (isNumber(labels) || !labels) {
+		if (!isObject(labels)) {
 			return inc.call(this, null)(labels, value);
 		}
 
@@ -115,11 +116,13 @@ class Counter {
 
 const inc = function(labels, hash) {
 	return (value, timestamp) => {
-		if (value && !isNumber(value)) {
-			throw new Error('Value is not a valid number', value);
+		if (value && !Number.isFinite(value)) {
+			throw new TypeError(`Value is not a valid number: ${util.format(value)}`);
 		}
-		if (timestamp && !isDate(timestamp) && !isNumber(timestamp)) {
-			throw new Error('Timestamp is not a valid date or number', value);
+		if (timestamp && !isDate(timestamp) && !Number.isFinite(timestamp)) {
+			throw new TypeError(
+				`Timestamp is not a valid date or number: ${util.format(timestamp)}`
+			);
 		}
 		if (value < 0) {
 			throw new Error('It is not possible to decrease a counter');
@@ -134,7 +137,7 @@ const inc = function(labels, hash) {
 function createValue(hashMap, value, timestamp, labels, hash) {
 	timestamp = isDate(timestamp)
 		? timestamp.valueOf()
-		: isNumber(timestamp) ? timestamp : undefined;
+		: Number.isFinite(timestamp) ? timestamp : undefined;
 	if (hashMap[hash]) {
 		hashMap[hash].value += value;
 		hashMap[hash].timestamp = timestamp;

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -3,10 +3,10 @@
  */
 'use strict';
 
+const util = require('util');
 const globalRegistry = require('./registry').globalRegistry;
 const type = 'gauge';
 
-const isNumber = require('./util').isNumber;
 const isDate = require('./util').isDate;
 const createValue = require('./util').setValue;
 const getProperties = require('./util').getPropertiesFromObj;
@@ -83,7 +83,7 @@ class Gauge {
 	 * @returns {void}
 	 */
 	set(labels, value, timestamp) {
-		if (isNumber(labels)) {
+		if (!isObject(labels)) {
 			return set.call(this, null)(labels, value);
 		}
 		return set.call(this, labels)(value, timestamp);
@@ -163,7 +163,12 @@ class Gauge {
 
 function setToCurrentTime(labels) {
 	return () => {
-		this.set(labels, Date.now());
+		const now = Date.now();
+		if (labels === undefined) {
+			this.set(now);
+		} else {
+			this.set(labels, now);
+		}
 	};
 }
 
@@ -204,11 +209,13 @@ function inc(labels) {
 
 function set(labels) {
 	return (value, timestamp) => {
-		if (!isNumber(value)) {
-			throw new Error('Value is not a valid number', value);
+		if (!Number.isFinite(value)) {
+			throw new TypeError(`Value is not a valid number: ${util.format(value)}`);
 		}
-		if (timestamp && !isDate(timestamp) && !isNumber(timestamp)) {
-			throw new Error('Timestamp is not a valid date or number', value);
+		if (timestamp && !isDate(timestamp) && !Number.isFinite(timestamp)) {
+			throw new TypeError(
+				`Timestamp is not a valid date or number: ${util.format(timestamp)}`
+			);
 		}
 
 		labels = labels || {};
@@ -219,7 +226,7 @@ function set(labels) {
 }
 
 function convertLabelsAndValues(labels, value) {
-	if (isNumber(labels)) {
+	if (!isObject(labels)) {
 		return {
 			value: labels,
 			labels: {}

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -3,9 +3,9 @@
  */
 'use strict';
 
+const util = require('util');
 const globalRegistry = require('./registry').globalRegistry;
 const type = 'histogram';
-const isNumber = require('./util').isNumber;
 const getProperties = require('./util').getPropertiesFromObj;
 const getLabels = require('./util').getLabels;
 const hashObject = require('./util').hashObject;
@@ -225,8 +225,10 @@ function observe(labels) {
 		const labelValuePair = convertLabelsAndValues(labels, value);
 
 		validateLabels(this.labelNames, labelValuePair.labels);
-		if (!isNumber(labelValuePair.value)) {
-			throw new Error('Value is not a valid number', labelValuePair.value);
+		if (!Number.isFinite(labelValuePair.value)) {
+			throw new TypeError(
+				`Value is not a valid number: ${util.format(labelValuePair.value)}`
+			);
 		}
 
 		const hash = hashObject(labelValuePair.labels);
@@ -261,7 +263,7 @@ function createBaseValues(labels, bucketValues) {
 }
 
 function convertLabelsAndValues(labels, value) {
-	if (isNumber(labels)) {
+	if (!isObject(labels)) {
 		return {
 			value: labels,
 			labels: {}

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -3,9 +3,9 @@
  */
 'use strict';
 
+const util = require('util');
 const globalRegistry = require('./registry').globalRegistry;
 const type = 'summary';
-const isNumber = require('./util').isNumber;
 const getProperties = require('./util').getPropertiesFromObj;
 const getLabels = require('./util').getLabels;
 const hashObject = require('./util').hashObject;
@@ -227,8 +227,10 @@ function observe(labels) {
 		const labelValuePair = convertLabelsAndValues(labels, value);
 
 		validateLabels(this.labelNames, this.labels);
-		if (!isNumber(labelValuePair.value)) {
-			throw new Error('Value is not a valid number', labelValuePair.value);
+		if (!Number.isFinite(labelValuePair.value)) {
+			throw new TypeError(
+				`Value is not a valid number: ${util.format(labelValuePair.value)}`
+			);
 		}
 
 		const hash = hashObject(labelValuePair.labels);
@@ -250,12 +252,13 @@ function observe(labels) {
 }
 
 function convertLabelsAndValues(labels, value) {
-	if (isNumber(labels)) {
+	if (value === undefined) {
 		return {
 			value: labels,
 			labels: {}
 		};
 	}
+
 	return {
 		labels,
 		value

--- a/lib/util.js
+++ b/lib/util.js
@@ -2,7 +2,6 @@
 
 const deprecationsEmitted = {};
 
-exports.isNumber = isNumber;
 exports.isDate = isDate;
 
 exports.getPropertiesFromObj = function(hashMap) {
@@ -13,11 +12,11 @@ exports.getPropertiesFromObj = function(hashMap) {
 exports.setValue = function setValue(hashMap, value, labels, timestamp) {
 	const hash = hashObject(labels);
 	hashMap[hash] = {
-		value: isNumber(value) ? value : 0,
+		value: Number.isFinite(value) ? value : 0,
 		labels: labels || {},
 		timestamp: isDate(timestamp)
 			? timestamp.valueOf()
-			: isNumber(timestamp) ? timestamp : undefined
+			: Number.isFinite(timestamp) ? timestamp : undefined
 	};
 	return hashMap;
 };
@@ -55,10 +54,6 @@ function hashObject(labels) {
 	return elems.join(',');
 }
 exports.hashObject = hashObject;
-
-function isNumber(obj) {
-	return !isNaN(parseFloat(obj));
-}
 
 function isDate(obj) {
 	return obj instanceof Date && !isNaN(obj.valueOf());

--- a/test/__snapshots__/counterTest.js.snap
+++ b/test/__snapshots__/counterTest.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`counter global registry with a parameter for each variable labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+
+exports[`counter global registry with a parameter for each variable should not allow invalid date as timestamp 1`] = `"Timestamp is not a valid date or number: Invalid Date"`;
+
+exports[`counter global registry with a parameter for each variable should not allow non number as timestamp 1`] = `"Timestamp is not a valid date or number: blah"`;
+
+exports[`counter global registry with a parameter for each variable should not be possible to decrease a counter 1`] = `"It is not possible to decrease a counter"`;
+
+exports[`counter global registry with a parameter for each variable should throw an error when the value is not a number 1`] = `"Value is not a valid number: 3ms"`;
+
+exports[`counter with params as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+
+exports[`counter with params as object labels should throw error if label lengths does not match 2`] = `"Invalid number of arguments"`;
+
+exports[`counter with params as object should not allow invalid date as timestamp 1`] = `"Timestamp is not a valid date or number: Invalid Date"`;
+
+exports[`counter with params as object should not allow non number as timestamp 1`] = `"Timestamp is not a valid date or number: blah"`;
+
+exports[`counter with params as object should not be possible to decrease a counter 1`] = `"It is not possible to decrease a counter"`;
+
+exports[`counter with params as object should throw an error when the value is not a number 1`] = `"Value is not a valid number: 3ms"`;

--- a/test/__snapshots__/gaugeTest.js.snap
+++ b/test/__snapshots__/gaugeTest.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gauge global registry with a parameter for each variable should not allow non numbers 1`] = `"Value is not a valid number: asd"`;
+
+exports[`gauge global registry with a parameter for each variable with timestamp should not allow invalid dates 1`] = `"Timestamp is not a valid date or number: Invalid Date"`;
+
+exports[`gauge global registry with a parameter for each variable with timestamp should not allow non numbers 1`] = `"Timestamp is not a valid date or number: blah"`;
+
+exports[`gauge global registry with parameters as object should not allow non numbers 1`] = `"Value is not a valid number: asd"`;
+
+exports[`gauge global registry with parameters as object with timestamp should not allow invalid dates 1`] = `"Timestamp is not a valid date or number: Invalid Date"`;
+
+exports[`gauge global registry with parameters as object with timestamp should not allow non numbers 1`] = `"Timestamp is not a valid date or number: blah"`;
+
+exports[`gauge registry instance with timestamp should not allow invalid dates 1`] = `"Timestamp is not a valid date or number: Invalid Date"`;
+
+exports[`gauge registry instance with timestamp should not allow non numbers 1`] = `"Timestamp is not a valid date or number: blah"`;

--- a/test/__snapshots__/histogramTest.js.snap
+++ b/test/__snapshots__/histogramTest.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`histogram with a parameter for each variable labels should not allow different number of labels 1`] = `"Invalid number of arguments"`;
+
+exports[`histogram with a parameter for each variable should not allow le as a custom label 1`] = `"le is a reserved label keyword"`;
+
+exports[`histogram with a parameter for each variable should not allow non numbers 1`] = `"Value is not a valid number: asd"`;
+
+exports[`histogram with object as params with global registry labels should not allow different number of labels 1`] = `"Invalid number of arguments"`;
+
+exports[`histogram with object as params with global registry should not allow le as a custom label 1`] = `"le is a reserved label keyword"`;
+
+exports[`histogram with object as params with global registry should not allow non numbers 1`] = `"Value is not a valid number: asd"`;

--- a/test/__snapshots__/summaryTest.js.snap
+++ b/test/__snapshots__/summaryTest.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`summary global registry with a parameter for each variable labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+
+exports[`summary global registry with a parameter for each variable should throw an error when the value is not a number 1`] = `"Value is not a valid number: 3ms"`;
+
+exports[`summary global registry with param as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;

--- a/test/counterTest.js
+++ b/test/counterTest.js
@@ -34,19 +34,25 @@ describe('counter', () => {
 				const fn = function() {
 					instance.inc(1, 'blah');
 				};
-				expect(fn).toThrowError(Error);
+				expect(fn).toThrowErrorMatchingSnapshot();
 			});
 			it('should not allow invalid date as timestamp', () => {
 				const fn = function() {
 					instance.inc(1, new Date('blah'));
 				};
-				expect(fn).toThrowError(Error);
+				expect(fn).toThrowErrorMatchingSnapshot();
 			});
 			it('should not be possible to decrease a counter', () => {
 				const fn = function() {
 					instance.inc(-100);
 				};
-				expect(fn).toThrowError(Error);
+				expect(fn).toThrowErrorMatchingSnapshot();
+			});
+			it('should throw an error when the value is not a number', () => {
+				const fn = () => {
+					instance.inc('3ms');
+				};
+				expect(fn).toThrowErrorMatchingSnapshot();
 			});
 			it('should handle incrementing with 0', () => {
 				instance.inc(0);
@@ -86,7 +92,7 @@ describe('counter', () => {
 					const fn = function() {
 						instance.labels('GET').inc();
 					};
-					expect(fn).toThrowError(Error);
+					expect(fn).toThrowErrorMatchingSnapshot();
 				});
 
 				it('should increment label value with provided value', () => {
@@ -125,19 +131,25 @@ describe('counter', () => {
 			const fn = function() {
 				instance.inc(1, 'blah');
 			};
-			expect(fn).toThrowError(Error);
+			expect(fn).toThrowErrorMatchingSnapshot();
 		});
 		it('should not allow invalid date as timestamp', () => {
 			const fn = function() {
 				instance.inc(1, new Date('blah'));
 			};
-			expect(fn).toThrowError(Error);
+			expect(fn).toThrowErrorMatchingSnapshot();
 		});
 		it('should not be possible to decrease a counter', () => {
 			const fn = function() {
 				instance.inc(-100);
 			};
-			expect(fn).toThrowError(Error);
+			expect(fn).toThrowErrorMatchingSnapshot();
+		});
+		it('should throw an error when the value is not a number', () => {
+			const fn = () => {
+				instance.inc('3ms');
+			};
+			expect(fn).toThrowErrorMatchingSnapshot();
 		});
 		it('should handle incrementing with 0', () => {
 			instance.inc(0);
@@ -178,14 +190,14 @@ describe('counter', () => {
 				const fn = function() {
 					instance.labels('GET').inc();
 				};
-				expect(fn).toThrowError(Error);
+				expect(fn).toThrowErrorMatchingSnapshot();
 			});
 
 			it('should throw error if label lengths does not match', () => {
 				const fn = function() {
 					instance.labels('GET').inc();
 				};
-				expect(fn).toThrowError(Error);
+				expect(fn).toThrowErrorMatchingSnapshot();
 			});
 
 			it('should increment label value with provided value', () => {

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -61,7 +61,7 @@ describe('gauge', () => {
 				const fn = function() {
 					instance.set('asd');
 				};
-				expect(fn).toThrowError(Error);
+				expect(fn).toThrowErrorMatchingSnapshot();
 			});
 
 			describe('with labels', () => {
@@ -131,13 +131,13 @@ describe('gauge', () => {
 					const fn = function() {
 						instance.labels('200').set(500, 'blah');
 					};
-					expect(fn).toThrowError(Error);
+					expect(fn).toThrowErrorMatchingSnapshot();
 				});
 				it('should not allow invalid dates', () => {
 					const fn = function() {
 						instance.labels('200').set(500, new Date('blah'));
 					};
-					expect(fn).toThrowError(Error);
+					expect(fn).toThrowErrorMatchingSnapshot();
 				});
 				it('should be able to increment', () => {
 					instance.labels('200').inc(1, 1485392700000);
@@ -200,7 +200,7 @@ describe('gauge', () => {
 				const fn = function() {
 					instance.set('asd');
 				};
-				expect(fn).toThrowError(Error);
+				expect(fn).toThrowErrorMatchingSnapshot();
 			});
 
 			it('should init to 0', () => {
@@ -286,13 +286,13 @@ describe('gauge', () => {
 					const fn = function() {
 						instance.labels('200').set(500, 'blah');
 					};
-					expect(fn).toThrowError(Error);
+					expect(fn).toThrowErrorMatchingSnapshot();
 				});
 				it('should not allow invalid dates', () => {
 					const fn = function() {
 						instance.labels('200').set(500, new Date('blah'));
 					};
-					expect(fn).toThrowError(Error);
+					expect(fn).toThrowErrorMatchingSnapshot();
 				});
 				it('should be able to increment', () => {
 					instance.labels('200').inc(1, 1485392700000);
@@ -357,13 +357,13 @@ describe('gauge', () => {
 				const fn = function() {
 					instance.labels('200').set(500, 'blah');
 				};
-				expect(fn).toThrowError(Error);
+				expect(fn).toThrowErrorMatchingSnapshot();
 			});
 			it('should not allow invalid dates', () => {
 				const fn = function() {
 					instance.labels('200').set(500, new Date('blah'));
 				};
-				expect(fn).toThrowError(Error);
+				expect(fn).toThrowErrorMatchingSnapshot();
 			});
 			it('should be able to increment', () => {
 				instance.labels('200').inc(1, 1485392700000);

--- a/test/histogramTest.js
+++ b/test/histogramTest.js
@@ -96,7 +96,7 @@ describe('histogram', () => {
 			const fn = function() {
 				instance.observe('asd');
 			};
-			expect(fn).toThrowError(Error);
+			expect(fn).toThrowErrorMatchingSnapshot();
 		});
 
 		it('should allow custom labels', () => {
@@ -110,7 +110,7 @@ describe('histogram', () => {
 			const fn = function() {
 				new Histogram('name', 'help', ['le']);
 			};
-			expect(fn).toThrowError(Error);
+			expect(fn).toThrowErrorMatchingSnapshot();
 		});
 
 		it('should observe value if outside most upper bound', () => {
@@ -156,7 +156,7 @@ describe('histogram', () => {
 				const fn = function() {
 					instance.labels('get', '500').observe(4);
 				};
-				expect(fn).toThrowError(Error);
+				expect(fn).toThrowErrorMatchingSnapshot();
 			});
 
 			it('should start a timer', () => {
@@ -309,7 +309,7 @@ describe('histogram', () => {
 				const fn = function() {
 					instance.observe('asd');
 				};
-				expect(fn).toThrowError(Error);
+				expect(fn).toThrowErrorMatchingSnapshot();
 			});
 
 			it('should allow custom labels', () => {
@@ -327,7 +327,7 @@ describe('histogram', () => {
 				const fn = function() {
 					new Histogram({ name: 'name', help: 'help', labelNames: ['le'] });
 				};
-				expect(fn).toThrowError(Error);
+				expect(fn).toThrowErrorMatchingSnapshot();
 			});
 
 			it('should observe value if outside most upper bound', () => {
@@ -382,7 +382,7 @@ describe('histogram', () => {
 					const fn = function() {
 						instance.labels('get', '500').observe(4);
 					};
-					expect(fn).toThrowError(Error);
+					expect(fn).toThrowErrorMatchingSnapshot();
 				});
 
 				it('should start a timer', () => {

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -136,6 +136,13 @@ describe('summary', () => {
 				});
 			});
 
+			it('should throw an error when the value is not a number', () => {
+				const fn = () => {
+					instance.observe('3ms');
+				};
+				expect(fn).toThrowErrorMatchingSnapshot();
+			});
+
 			describe('labels', () => {
 				beforeEach(() => {
 					globalRegistry.clear();
@@ -188,7 +195,7 @@ describe('summary', () => {
 					const fn = function() {
 						instance.labels('GET').observe();
 					};
-					expect(fn).toThrowError(Error);
+					expect(fn).toThrowErrorMatchingSnapshot();
 				});
 
 				it('should start a timer', () => {
@@ -444,7 +451,7 @@ describe('summary', () => {
 					const fn = function() {
 						instance.labels('GET').observe();
 					};
-					expect(fn).toThrowError(Error);
+					expect(fn).toThrowErrorMatchingSnapshot();
 				});
 
 				it('should start a timer', () => {


### PR DESCRIPTION
`Error` only expects one argument, the `message`, which means that the invalid values were lost in the second argument.