### PR TITLE
Bugfix - cannot get cluster info in node version < 6

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -130,7 +130,7 @@ class AggregatorRegistry extends Registry {
 
 if (cluster.isMaster) {
 	// Listen for worker responses to requests for local metrics
-	cluster.on('message', (worker, message) => {
+	cluster.on('message', function(worker, message) {
 		if (arguments.length === 2) {
 			// pre-Node.js v6.0
 			message = worker;


### PR DESCRIPTION
The `cluster.on('message')` function doesn't have the worker as the first argument in node < 6. To do this, the official way is to check the number of arguments received. However, because this is using a fat arrow function (`() => {}`), the variable `arguments` is hoisted outside the scope so the actual arguments
has a length of 5.

If you run the old version of the code in [Babel](http://bit.ly/2wbApcb) this shows the problem:
```javascript
cluster.on('message', (worker, message) => {
  if (arguments.length === 2) {
      // pre-Node.js v6.0
      message = worker;
      worker = undefined;
  }
});
```

This gets compiled to:
```javascript
var _arguments = arguments;
cluster.on('message', function (worker, message) {
    if (_arguments.length === 2) {
        // pre-Node.js v6.0
        message = worker;
        worker = undefined;
    }
});
```