### PR TITLE
reset Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Breaking
 ### Changed
 ### Added
+- Added `reset` to Counter and Gauge
+- Added `resetMetrics` to register to calling `reset` of all metric instances
 
 ## [10.1.1] - 2017-09-26
 ### Changed

--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ counter.inc(); // Inc with 1
 counter.inc(10); // Inc with 10
 ```
 
-A counter can be reset manually.
+A counter can be reset manually. This removes the label-values combinations and
+initializes to 0.
+
 ```js
 counter.reset();
 counter.inc(); // Inc with 1 starting from 0
@@ -123,7 +125,8 @@ gauge.inc(10); // Inc with 10
 gauge.dec(); // Dec with 1
 gauge.dec(10); // Dec with 10
 ```
-A gauge can be reset manually.
+A gauge can be reset manually. This removes the label-values combinations and
+initializes to 0.
 
 ```js
 gauge.reset();

--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ counter.inc(); // Inc with 1
 counter.inc(10); // Inc with 10
 ```
 
+A counter can be reset manually.
+```js
+counter.reset();
+counter.inc(); // Inc with 1 starting from 0
+```
+
 #### Gauge
 
 Gauges are similar to Counters but Gauges value can be decreased.
@@ -116,6 +122,12 @@ gauge.inc(); // Inc with 1
 gauge.inc(10); // Inc with 10
 gauge.dec(); // Dec with 1
 gauge.dec(10); // Dec with 10
+```
+A gauge can be reset manually.
+
+```js
+gauge.reset();
+gauge.inc(); // Inc with 1 starting from 0
 ```
 
 There are some utilities for common use cases:
@@ -298,6 +310,11 @@ If you need to get a reference to a previously registered metric, you can use `r
 
 You can remove all metrics by calling `register.clear()`. You can also remove a single metric by calling
 `register.removeSingleMetric(*name of metric*)`.
+
+##### Resetting metrics
+
+If you need to reset all metrics, you can use `register.resetMetrics()`. The metrics will remain present in the register and can be used without the need to
+instantiate them again, like you would need to do after `register.clear()`.
 
 ##### Cluster metrics
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ xhrRequest(function(err, res) {
 	end(); // Observes the value to xhrRequests duration in seconds
 });
 ```
+A Histogram can be reset manually. This removes the label-values combinations and
+reinitializes the observations.
+
+```js
+histogram.reset();
+```
 
 #### Summary
 
@@ -204,6 +210,13 @@ const end = summary.startTimer();
 xhrRequest(function(err, res) {
 	end(); // Observes the value to xhrRequests duration in seconds
 });
+```
+
+A Summary can be reset manually. This removes the label-values combinations and
+reinitializes the observations.
+
+```js
+summary.reset();
 ```
 
 #### Labels

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,11 @@ export class Registry {
 	clear(): void;
 
 	/**
+	 * Reset all metrics in the registry
+	 */
+	resetMetrics(): void;
+
+	/**
 	 * Register metric to register
 	 * @param metric Metric to add to register
 	 */
@@ -185,6 +190,11 @@ export class Counter {
 	 * @return Configured counter with given labels
 	 */
 	labels(...values: string[]): Counter.Internal;
+
+	/**
+	 * Reset counter values
+	 */
+	reset(): void;
 }
 
 export namespace Counter {
@@ -287,6 +297,11 @@ export class Gauge {
 	 * @return Configured gauge with given labels
 	 */
 	labels(...values: string[]): Gauge.Internal;
+
+	/**
+	 * Reset gauge values
+	 */
+	reset(): void;
 }
 
 export namespace Gauge {

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -64,13 +64,10 @@ class Counter {
 		}
 
 		this.name = config.name;
-		this.hashMap = {};
 
 		this.labelNames = config.labelNames || [];
 
-		if (this.labelNames.length === 0) {
-			this.hashMap = createValue({}, 0);
-		}
+		this.reset();
 
 		this.help = config.help;
 		this.aggregator = config.aggregator || 'sum';

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -125,7 +125,11 @@ class Counter {
 }
 
 const reset = function() {
-	this.hashMap = createValue({}, 0);
+	this.hashMap = {};
+
+	if (this.labelNames.length === 0) {
+		this.hashMap = createValue({}, 0);
+	}
 };
 
 const inc = function(labels, hash) {

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -96,6 +96,14 @@ class Counter {
 		return inc.call(this, labels, hash)(value, timestamp);
 	}
 
+	/**
+	 * Reset counter
+	 * @returns {void}
+	 */
+	reset() {
+		return reset.call(this);
+	}
+
 	get() {
 		return {
 			help: this.help,
@@ -115,6 +123,10 @@ class Counter {
 		};
 	}
 }
+
+const reset = function() {
+	this.hashMap = createValue({}, 0);
+};
 
 const inc = function(labels, hash) {
 	return (value, timestamp) => {

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -64,10 +64,7 @@ class Gauge {
 
 		this.name = config.name;
 		this.labelNames = config.labelNames || [];
-		this.hashMap = {};
-		if (this.labelNames.length === 0) {
-			this.hashMap = createValue({}, 0, {});
-		}
+		this.reset();
 		this.help = config.help;
 		this.aggregator = config.aggregator || 'sum';
 

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -91,6 +91,14 @@ class Gauge {
 	}
 
 	/**
+	 * Reset a gauge
+	 * @returns {void}
+	 */
+	reset() {
+		return reset.call(this);
+	}
+
+	/**
 	 * Increment a gauge value
 	 * @param {object} labels - Object with labels where key is the label key and value is label value. Can only be one level deep
 	 * @param {Number} value - Value to increment - if omitted, increment with 1
@@ -224,6 +232,10 @@ function set(labels) {
 		validateLabels(this.labelNames, labels);
 		this.hashMap = createValue(this.hashMap, value, labels, timestamp);
 	};
+}
+
+function reset() {
+	this.hashMap = createValue({}, 0, {});
 }
 
 function convertLabelsAndValues(labels, value) {

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -91,7 +91,7 @@ class Gauge {
 	}
 
 	/**
-	 * Reset a gauge
+	 * Reset gauge
 	 * @returns {void}
 	 */
 	reset() {
@@ -235,7 +235,11 @@ function set(labels) {
 }
 
 function reset() {
-	this.hashMap = createValue({}, 0, {});
+	this.hashMap = {};
+
+	if (this.labelNames.length === 0) {
+		this.hashMap = createValue({}, 0, {});
+	}
 }
 
 function convertLabelsAndValues(labels, value) {

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -101,6 +101,12 @@ class Registry {
 		this._defaultLabels = labels;
 	}
 
+	resetMetrics() {
+		for (const metric in this._metrics) {
+			this._metrics[metric].reset();
+		}
+	}
+
 	get contentType() {
 		return 'text/plain; version=0.0.4; charset=utf-8';
 	}

--- a/test/counterTest.js
+++ b/test/counterTest.js
@@ -241,7 +241,10 @@ describe('counter', () => {
 		});
 	});
 	describe('counter reset', () => {
-		xit('should reset labelless counter', () => {
+		afterEach(() => {
+			globalRegistry.clear();
+		});
+		it('should reset labelless counter', () => {
 			const instance = new Counter({
 				name: 'test_metric',
 				help: 'Another test metric'

--- a/test/counterTest.js
+++ b/test/counterTest.js
@@ -240,4 +240,42 @@ describe('counter', () => {
 			expect(instance.get().values[0].timestamp).toEqual(undefined);
 		});
 	});
+	describe('counter reset', () => {
+		xit('should reset labelless counter', () => {
+			const instance = new Counter({
+				name: 'test_metric',
+				help: 'Another test metric'
+			});
+
+			instance.inc(12);
+			expect(instance.get().values[0].value).toEqual(12);
+
+			instance.reset();
+			expect(instance.get().values[0].value).toEqual(0);
+
+			instance.inc(10);
+			expect(instance.get().values[0].value).toEqual(10);
+		});
+		it('should reset the counter, incl labels', () => {
+			const instance = new Counter({
+				name: 'test_metric',
+				help: 'Another test metric',
+				labelNames: ['serial', 'active']
+			});
+
+			instance.inc({ serial: '12345', active: 'yes' }, 12);
+			expect(instance.get().values[0].value).toEqual(12);
+			expect(instance.get().values[0].labels.serial).toEqual('12345');
+			expect(instance.get().values[0].labels.active).toEqual('yes');
+
+			instance.reset();
+
+			expect(instance.get().values).toEqual([]);
+
+			instance.inc({ serial: '12345', active: 'no' }, 10);
+			expect(instance.get().values[0].value).toEqual(10);
+			expect(instance.get().values[0].labels.serial).toEqual('12345');
+			expect(instance.get().values[0].labels.active).toEqual('no');
+		});
+	});
 });

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -376,7 +376,10 @@ describe('gauge', () => {
 		});
 	});
 	describe('gauge reset', () => {
-		xit('should reset labelless gauge', () => {
+		afterEach(() => {
+			globalRegistry.clear();
+		});
+		it('should reset labelless gauge', () => {
 			const instance = new Gauge({
 				name: 'test_metric',
 				help: 'Another test metric'

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -375,6 +375,44 @@ describe('gauge', () => {
 			});
 		});
 	});
+	describe('gauge reset', () => {
+		xit('should reset labelless gauge', () => {
+			const instance = new Gauge({
+				name: 'test_metric',
+				help: 'Another test metric'
+			});
+
+			instance.set(12);
+			expect(instance.get().values[0].value).toEqual(12);
+
+			instance.reset();
+			expect(instance.get().values[0].value).toEqual(0);
+
+			instance.set(10);
+			expect(instance.get().values[0].value).toEqual(10);
+		});
+		it('should reset the gauge, incl labels', () => {
+			const instance = new Gauge({
+				name: 'test_metric',
+				help: 'Another test metric',
+				labelNames: ['serial', 'active']
+			});
+
+			instance.set({ serial: '12345', active: 'yes' }, 12);
+			expect(instance.get().values[0].value).toEqual(12);
+			expect(instance.get().values[0].labels.serial).toEqual('12345');
+			expect(instance.get().values[0].labels.active).toEqual('yes');
+
+			instance.reset();
+
+			expect(instance.get().values).toEqual([]);
+
+			instance.set({ serial: '12345', active: 'no' }, 10);
+			expect(instance.get().values[0].value).toEqual(10);
+			expect(instance.get().values[0].labels.serial).toEqual('12345');
+			expect(instance.get().values[0].labels.active).toEqual('no');
+		});
+	});
 
 	function expectValue(val, timestamp) {
 		expect(instance.get().values[0].value).toEqual(val);

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -204,6 +204,49 @@ describe('register', () => {
 		expect(output).toEqual(metric);
 	});
 
+	it('should allow resetting a counter', () => {
+		const metric = new Counter({
+			name: 'test_metric',
+			help: 'Another test metric',
+			labelNames: ['serial', 'active']
+		});
+		register.registerMetric(metric);
+
+		metric.inc({ serial: '12345', active: 'yes' }, 12);
+		expect(metric.get().values[0].value).toEqual(12);
+		expect(metric.get().values[0].labels.serial).toEqual('12345');
+		expect(metric.get().values[0].labels.active).toEqual('yes');
+
+		register.resetMetrics('serial');
+
+		const output = register.getSingleMetric('test_metric');
+		expect(output.get().values[0].value).toEqual(0);
+		expect(output.get().values[0].labels.serial).toEqual(undefined);
+		expect(output.get().values[0].labels.active).toEqual(undefined);
+	});
+
+	it('should allow resetting a gauge', () => {
+		const metric = new Gauge({
+			name: 'test_metric',
+			help: 'Another test metric',
+			labelNames: ['serial', 'active']
+		});
+		register.registerMetric(metric);
+
+		// const output = register.getSingleMetric('test_metric');
+		metric.set({ serial: '12345', active: 'yes' }, 12);
+		expect(metric.get().values[0].value).toEqual(12);
+		expect(metric.get().values[0].labels.serial).toEqual('12345');
+		expect(metric.get().values[0].labels.active).toEqual('yes');
+
+		register.resetMetrics();
+
+		const output = register.getSingleMetric('test_metric');
+		expect(output.get().values[0].value).toEqual(0);
+		expect(output.get().values[0].labels.serial).toEqual(undefined);
+		expect(output.get().values[0].labels.active).toEqual(undefined);
+	});
+
 	it('should allow gettings metrics without timestamps', () => {
 		const metric = getMetric();
 		register.registerMetric(metric);


### PR DESCRIPTION
I needed a way to reset metrics, without removing the metric instances, see also #145. 
This solution is not completely tested, but I would like to know if this is a right way to go.