### PR TITLE
fix for issue #156

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed
 ### Added
 
+## [10.1.2] - 2017-10-16
+### Changed
+- Fixed issue with counters having extra records when using empty labels
+
 ## [10.1.1] - 2017-09-26
 ### Changed
 - Update TypeScript definitions and JSDoc comments to match JavaScript sources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Breaking
 ### Changed
-### Added
-
-## [10.1.2] - 2017-10-16
-### Changed
 - Fixed issue with counters having extra records when using empty labels
+### Added
 
 ## [10.1.1] - 2017-09-26
 ### Changed

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -137,6 +137,7 @@ const inc = function(labels, hash) {
 };
 
 function createValue(hashMap, value, timestamp, labels, hash) {
+	hash = hash || '';
 	timestamp = isDate(timestamp)
 		? timestamp.valueOf()
 		: Number.isFinite(timestamp) ? timestamp : undefined;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prom-client",
-  "version": "10.1.2",
+  "version": "10.1.1",
   "description": "Client for prometheus",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prom-client",
-  "version": "10.1.1",
+  "version": "10.1.2",
   "description": "Client for prometheus",
   "main": "index.js",
   "files": [

--- a/test/counterTest.js
+++ b/test/counterTest.js
@@ -101,6 +101,24 @@ describe('counter', () => {
 					expect(values[0].value).toEqual(100);
 				});
 			});
+
+			describe('empty labels', () => {
+				beforeEach(() => {
+					instance = new Counter('gauge_test_3', 'test');
+				});
+
+				it('should increment counter', () => {
+					instance.inc({});
+					expect(instance.get().values[0].value).toEqual(1);
+					expect(instance.get().values[0].timestamp).toEqual(undefined);
+				});
+
+				it('should increment with a provided value', () => {
+					instance.inc({}, 100);
+					expect(instance.get().values[0].value).toEqual(100);
+					expect(instance.get().values[0].timestamp).toEqual(undefined);
+				});
+			});
 		});
 	});
 

--- a/test/counterTest.js
+++ b/test/counterTest.js
@@ -110,13 +110,13 @@ describe('counter', () => {
 				it('should increment counter', () => {
 					instance.inc({});
 					expect(instance.get().values[0].value).toEqual(1);
-					expect(instance.get().values[0].timestamp).toEqual(undefined);
+					expect(instance.get().values[0].timestamp).toBeUndefined();
 				});
 
 				it('should increment with a provided value', () => {
 					instance.inc({}, 100);
 					expect(instance.get().values[0].value).toEqual(100);
-					expect(instance.get().values[0].timestamp).toEqual(undefined);
+					expect(instance.get().values[0].timestamp).toBeUndefined();
 				});
 			});
 		});


### PR DESCRIPTION
set default hash to empty string (`''`) -- same as `hashObject({})`