### PR TITLE
Lazily initialize cluster event listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Breaking
 ### Changed
+- Don't add event listeners if cluster module is not used.
 ### Added
 
 ## [10.1.1] - 2017-09-26

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -18,9 +18,15 @@ const GET_METRICS_RES = 'prom-client:getMetricsRes';
 
 let registries = [Registry.globalRegistry];
 let requestCtr = 0; // Concurrency control
+let listenersAdded = false;
 const requests = new Map(); // Pending requests for workers' local metrics.
 
 class AggregatorRegistry extends Registry {
+	constructor() {
+		super();
+		addListeners();
+	}
+
 	/**
 	 * Gets aggregated metrics for all workers. The optional callback and
 	 * returned Promise resolve with the same value; either may be used.
@@ -128,35 +134,47 @@ class AggregatorRegistry extends Registry {
 	}
 }
 
-if (cluster.isMaster) {
-	// Listen for worker responses to requests for local metrics
-	cluster.on('message', function(worker, message) {
-		if (arguments.length === 2) {
-			// pre-Node.js v6.0
-			message = worker;
-			worker = undefined;
-		}
+/**
+ * Adds event listeners for cluster aggregation. Idempotent (safe to call more
+ * than once).
+ * @return {void}
+ */
+function addListeners() {
+	if (listenersAdded) return;
+	listenersAdded = true;
 
-		if (message.type === GET_METRICS_RES) {
-			const request = requests.get(message.requestId);
-			message.metrics.forEach(registry => request.responses.push(registry));
-			request.pending--;
-
-			if (request.pending === 0) {
-				// finalize
-				requests.delete(message.requestId);
-				clearTimeout(request.errorTimeout);
-
-				if (request.failed) return; // Callback already run with Error.
-
-				const registry = AggregatorRegistry.aggregate(request.responses);
-				const promString = registry.metrics();
-				request.callback(null, promString);
-				request.resolve(promString);
+	if (cluster.isMaster) {
+		// Listen for worker responses to requests for local metrics
+		cluster.on('message', function(worker, message) {
+			if (arguments.length === 2) {
+				// pre-Node.js v6.0
+				message = worker;
+				worker = undefined;
 			}
-		}
-	});
-} else if (cluster.isWorker) {
+
+			if (message.type === GET_METRICS_RES) {
+				const request = requests.get(message.requestId);
+				message.metrics.forEach(registry => request.responses.push(registry));
+				request.pending--;
+
+				if (request.pending === 0) {
+					// finalize
+					requests.delete(message.requestId);
+					clearTimeout(request.errorTimeout);
+
+					if (request.failed) return; // Callback already run with Error.
+
+					const registry = AggregatorRegistry.aggregate(request.responses);
+					const promString = registry.metrics();
+					request.callback(null, promString);
+					request.resolve(promString);
+				}
+			}
+		});
+	}
+}
+
+if (cluster.isWorker) {
 	// Respond to master's requests for worker's local metrics.
 	process.on('message', message => {
 		if (message.type === GET_METRICS_REQ) {

--- a/test/clusterTest.js
+++ b/test/clusterTest.js
@@ -1,6 +1,23 @@
 'use strict';
 
+const cluster = require('cluster');
+
 describe('AggregatorRegistry', () => {
+	it('requiring the cluster should not add any listeners', () => {
+		jest.resetModules();
+		expect(cluster.listenerCount('message')).toBe(0);
+
+		require('../lib/cluster');
+
+		expect(cluster.listenerCount('message')).toBe(0);
+
+		jest.resetModules();
+
+		require('../lib/cluster');
+
+		expect(cluster.listenerCount('message')).toBe(0);
+	});
+
 	describe('aggregatorRegistry.clusterMetrics()', () => {
 		it('works properly if there are no cluster workers', done => {
 			const AggregatorRegistry = require('../lib/cluster');

--- a/test/clusterTest.js
+++ b/test/clusterTest.js
@@ -4,18 +4,17 @@ const cluster = require('cluster');
 
 describe('AggregatorRegistry', () => {
 	it('requiring the cluster should not add any listeners', () => {
-		jest.resetModules();
-		expect(cluster.listenerCount('message')).toBe(0);
+		const originalListenerCount = cluster.listenerCount('message');
 
 		require('../lib/cluster');
 
-		expect(cluster.listenerCount('message')).toBe(0);
+		expect(cluster.listenerCount('message')).toBe(originalListenerCount);
 
 		jest.resetModules();
 
 		require('../lib/cluster');
 
-		expect(cluster.listenerCount('message')).toBe(0);
+		expect(cluster.listenerCount('message')).toBe(originalListenerCount);
 	});
 
 	describe('aggregatorRegistry.clusterMetrics()', () => {


### PR DESCRIPTION
Sorry for the delay, forgot about this. Small change aside from indenting (try [ignoring whitespace](https://github.com/siimon/prom-client/pull/159/files?w=1)).

Fixes #155 
