### PR TITLE
Only resolve/reject `clusterMetrics` promise if no callback is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Breaking
 ### Changed
+- Only resolve/reject `clusterMetrics` promise if no callback is provided
 ### Added
 
 ## [10.2.0] - 2017-10-16

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -37,29 +37,31 @@ class AggregatorRegistry extends Registry {
 	clusterMetrics(callback) {
 		const requestId = requestCtr++;
 
-		callback = callback || function() {};
-
 		return new Promise((resolve, reject) => {
 			const nWorkers = Object.keys(cluster.workers).length;
 
+			function done(err, result) {
+				// Don't resolve/reject the promise if a callback is provided
+				if (typeof callback === 'function') {
+					callback(err, result);
+				} else {
+					if (err) reject(err);
+					else resolve(result);
+				}
+			}
+
 			if (nWorkers === 0) {
-				return process.nextTick(() => {
-					callback(null, '');
-					resolve('');
-				});
+				return process.nextTick(() => done(null, ''));
 			}
 
 			const request = {
 				responses: [],
 				pending: nWorkers,
-				callback,
-				resolve,
-				reject,
+				done,
 				errorTimeout: setTimeout(() => {
 					request.failed = true;
 					const err = new Error('Operation timed out.');
-					request.callback(err);
-					reject(err);
+					request.done(err);
 				}, 5000),
 				failed: false
 			};
@@ -166,8 +168,7 @@ function addListeners() {
 
 					const registry = AggregatorRegistry.aggregate(request.responses);
 					const promString = registry.metrics();
-					request.callback(null, promString);
-					request.resolve(promString);
+					request.done(null, promString);
 				}
 			}
 		});

--- a/test/clusterTest.js
+++ b/test/clusterTest.js
@@ -21,27 +21,15 @@ describe('AggregatorRegistry', () => {
 		it('works properly if there are no cluster workers', done => {
 			const AggregatorRegistry = require('../lib/cluster');
 			const ar = new AggregatorRegistry();
-			let cbCalled = false;
-			let promiseResolved = false;
 			let tickElapsed = false;
 			process.nextTick(() => {
 				tickElapsed = true;
 			});
-			const maybeDone = () => {
-				if (cbCalled && promiseResolved) done();
-			};
-			const ret = ar.clusterMetrics((err, metrics) => {
-				cbCalled = true;
+			ar.clusterMetrics((err, metrics) => {
 				expect(tickElapsed).toBe(true);
 				expect(err).toBeNull();
 				expect(metrics).toEqual('');
-				maybeDone();
-			});
-			ret.then(metrics => {
-				promiseResolved = true;
-				expect(tickElapsed).toBe(true);
-				expect(metrics).toEqual('');
-				maybeDone();
+				done();
 			});
 		});
 	});


### PR DESCRIPTION
Small behavior change: Don't resolve/reject the promise returned by `clusterMetrics` if a callback is provided to that function. This prevents `UnhandledPromiseRejectionWarnings` from occurring if you're using callbacks.