### PR TITLE
fixed invalid memory report on linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Breaking
 ### Changed
+- Fixed invalid process_virtual_memory_bytes reported under linux
 ### Added
 
 ## [10.2.1] - 2017-10-27

--- a/lib/metrics/osMemoryHeapLinux.js
+++ b/lib/metrics/osMemoryHeapLinux.js
@@ -23,7 +23,7 @@ function structureOutput(input) {
 			// Remove trailing ` kb`
 			value = value.substr(0, value.length - 3);
 			// Make it into a number in bytes bytes
-			value = Number(value) * 1000;
+			value = Number(value) * 1024;
 
 			returnValue[split[0]] = value;
 		});


### PR DESCRIPTION
You have to multiply memory reported by the `/proc/self/status` by 1024, not 1000; because it's in KiB.

Proof:
```
$ ps -o vsz -p 15301
   VSZ
 13820
$ grep VmSize /proc/15301/status
VmSize:    13820 kB
$ man ps | grep vsz             
       %z     vsz      VSZ
                             vsz and rss.
       vsize       VSZ       see vsz.  (alias vsz).
       vsz         VSZ       virtual memory size of the process in KiB (1024-byte
```

Replace 15301 with the PID of your choice.