### PR TITLE
Cluster metrics aggregation ignores default labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Fixed issue that `registry.getMetricsAsJSON()` ignores registry default labels
+
 ### Added
 
 ## [10.2.2] - 2017-11-02

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -82,7 +82,21 @@ class Registry {
 	}
 
 	getMetricsAsJSON() {
-		return this.getMetricsAsArray().map(metric => metric.get());
+		return this.getMetricsAsArray().map(metric => {
+			const item = metric.get();
+			if (!item.values) {
+				return item;
+			}
+
+			item.values = item.values.map(val =>
+				// Avoid mutation and merge metric labels with registry default labels
+				Object.assign({}, val, {
+					labels: Object.assign({}, this._defaultLabels, val.labels)
+				})
+			);
+
+			return item;
+		});
 	}
 
 	removeSingleMetric(name) {

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -179,6 +179,25 @@ describe('register', () => {
 			expect(output[0].help).toEqual('A test metric');
 			expect(output[0].values.length).toEqual(2);
 		});
+
+		it('should add default labels to JSON', () => {
+			register.registerMetric(getMetric());
+			register.setDefaultLabels({
+				defaultRegistryLabel: 'testValue'
+			});
+			const output = register.getMetricsAsJSON();
+
+			expect(output.length).toEqual(1);
+			expect(output[0].name).toEqual('test_metric');
+			expect(output[0].type).toEqual('counter');
+			expect(output[0].help).toEqual('A test metric');
+			expect(output[0].values.length).toEqual(2);
+			expect(output[0].values[0].labels).toEqual({
+				code: '303',
+				label: 'hello',
+				defaultRegistryLabel: 'testValue'
+			});
+		});
 	});
 
 	it('should allow removing single metrics', () => {


### PR DESCRIPTION
registry.getMetricsAsJSON should merge metric labels and registry default labels