### PR TITLE
Use base units (seconds) for current time in gauge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking
 
+* Fixed `gauge.setToCurrentTime()` to use seconds instead of milliseconds
+  * This conforms to Prometheus [best practices](https://prometheus.io/docs/practices/naming/#base-units)
+
 ### Changed
 
 ### Added

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -169,7 +169,7 @@ class Gauge {
 
 function setToCurrentTime(labels) {
 	return () => {
-		const now = Date.now();
+		const now = Date.now() / 1000;
 		if (labels === undefined) {
 			this.set(now);
 		} else {


### PR DESCRIPTION
I think this is the only instance where this is incorrect.

Breaking change

Fixes #167