### PR TITLE
upgrade dependencies

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -86,9 +86,7 @@ exports.printDeprecationObjectConstructor = () => {
 
 exports.printDeprecationCollectDefaultMetricsNumber = timeout => {
 	printDeprecation(
-		`prom-client - A number to defaultMetrics is deprecated, please use \`collectDefaultMetrics({ timeout: ${
-			timeout
-		} })\`.`
+		`prom-client - A number to defaultMetrics is deprecated, please use \`collectDefaultMetrics({ timeout: ${timeout} })\`.`
 	);
 };
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -24,9 +24,9 @@ exports.validateLabel = function validateLabel(savedLabels, labels) {
 	Object.keys(labels).forEach(label => {
 		if (savedLabels.indexOf(label) === -1) {
 			throw new Error(
-				`Added label "${
-					label
-				}" is not included in initial labelset: ${util.inspect(savedLabels)}`
+				`Added label "${label}" is not included in initial labelset: ${util.inspect(
+					savedLabels
+				)}`
 			);
 		}
 	});

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
 		"eslint-plugin-prettier": "^2.1.2",
 		"express": "^4.13.3",
 		"husky": "^0.14.3",
-		"jest": "^21.2.1",
-		"lint-staged": "^5.0.0",
+		"jest": "^22.4.2",
+		"lint-staged": "^7.0.0",
 		"lolex": "^2.1.3",
-		"prettier": "1.8.2",
+		"prettier": "1.11.1",
 		"typescript": "^2.5.2"
 	},
 	"dependencies": {


### PR DESCRIPTION
Both Jest and lint-staged has dropped node 4 (same as us now), and prettier was locked down