### PR TITLE
Making global registry into singleton

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -138,5 +138,23 @@ class Registry {
 	}
 }
 
+var GlobalRegistry = (function () {
+    var reg;
+
+    function createInstance() {
+        var reg = new Registry()
+        return reg;
+    }
+
+    return {
+        getInstance: function () {
+            if (!reg) {
+                reg = createInstance();
+            }
+            return reg;
+        }
+    };
+})();
+
 module.exports = Registry;
-module.exports.globalRegistry = new Registry();
+module.exports.globalRegistry = GlobalRegistry.getInstance()

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -138,21 +138,21 @@ class Registry {
 	}
 }
 
-var GlobalRegistry = (function () {
-    let reg;
+const GlobalRegistry = (function() {
+	let reg;
 
-    function createInstance() {
-        return new Registry();
-    }
+	function createInstance() {
+		return new Registry();
+	}
 
-    return {
-        getInstance: function () {
-            if (!reg) {
-                reg = createInstance();
-            }
-            return reg;
-        }
-    };
+	return {
+		getInstance() {
+			if (!reg) {
+				reg = createInstance();
+			}
+			return reg;
+		}
+	};
 })();
 
 module.exports = Registry;

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -139,11 +139,10 @@ class Registry {
 }
 
 var GlobalRegistry = (function () {
-    var reg;
+    let reg;
 
     function createInstance() {
-        var reg = new Registry()
-        return reg;
+        return new Registry();
     }
 
     return {
@@ -157,4 +156,4 @@ var GlobalRegistry = (function () {
 })();
 
 module.exports = Registry;
-module.exports.globalRegistry = GlobalRegistry.getInstance()
+module.exports.globalRegistry = GlobalRegistry.getInstance();


### PR DESCRIPTION
This PR makes the 'prom-client.registry' call always give the user the same instance of a global registry. This allows the user to in completely different files do 
```
const client = require('prom-client');
const defaultRegistry = client.register;
```
to get the default registry. If that registry then is passed into a metric definition as 
```
const errorVec = new client.Counter({
  name: 'failed__total',
  help: 'Number of times failed',
  registers: [defaultRegistry]
});
```
then it will be added to the registry regardless in which file the `require` has been performed. Previously every `client.register` created a new by running `new Registry() `. 
This allows for more similar usage as the golang lib which where the client can be imported and if you run `MustRegister(metric)` anywhere then it will go onto the default registry.