### PR TITLE
Fix `startTimer` utility to not mutate passed `startLabels` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Fixed `startTimer` utility to not mutate objects passed as `startLabels`
+
 ### Added
 
 ## [11.0.0] - 2018-03-10

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -184,7 +184,7 @@ function startTimer(startLabels) {
 		return endLabels => {
 			const delta = process.hrtime(start);
 			this.set(
-				Object.assign(startLabels || {}, endLabels),
+				Object.assign({}, startLabels, endLabels),
 				delta[0] + delta[1] / 1e9
 			);
 		};

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -154,7 +154,7 @@ function startTimer(startLabels) {
 		return endLabels => {
 			const delta = process.hrtime(start);
 			this.observe(
-				Object.assign(startLabels || {}, endLabels),
+				Object.assign({}, startLabels, endLabels),
 				delta[0] + delta[1] / 1e9
 			);
 		};

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -183,7 +183,7 @@ function startTimer(startLabels) {
 		return endLabels => {
 			const delta = process.hrtime(start);
 			this.observe(
-				Object.assign(startLabels || {}, endLabels),
+				Object.assign({}, startLabels, endLabels),
 				delta[0] + delta[1] / 1e9
 			);
 		};

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -112,6 +112,12 @@ describe('gauge', () => {
 					expectValue(1);
 					clock.uninstall();
 				});
+				it('should not mutate passed startLabels', () => {
+					const startLabels = { code: '200' };
+					const end = instance.startTimer(startLabels);
+					end({ code: '400' });
+					expect(startLabels).toEqual({ code: '200' });
+				});
 			});
 
 			describe('with timestamp', () => {
@@ -266,6 +272,12 @@ describe('gauge', () => {
 					end({ success: 'SUCCESS' });
 					expectValue(1);
 					clock.uninstall();
+				});
+				it('should not mutate passed startLabels', () => {
+					const startLabels = { code: '200' };
+					const end = instance.startTimer(startLabels);
+					end({ code: '400' });
+					expect(startLabels).toEqual({ code: '200' });
 				});
 			});
 

--- a/test/histogramTest.js
+++ b/test/histogramTest.js
@@ -215,6 +215,13 @@ describe('histogram', () => {
 				expect(res2.value).toEqual(1);
 				clock.uninstall();
 			});
+
+			it('should not mutate passed startLabels', () => {
+				const startLabels = { method: 'GET' };
+				const end = instance.startTimer(startLabels);
+				end({ method: 'POST' });
+				expect(startLabels).toEqual({ method: 'GET' });
+			});
 		});
 	});
 
@@ -440,6 +447,13 @@ describe('histogram', () => {
 					expect(res1.value).toEqual(1);
 					expect(res2.value).toEqual(1);
 					clock.uninstall();
+				});
+
+				it('should not mutate passed startLabels', () => {
+					const startLabels = { method: 'GET' };
+					const end = instance.startTimer(startLabels);
+					end({ method: 'POST' });
+					expect(startLabels).toEqual({ method: 'GET' });
 				});
 			});
 		});

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -272,6 +272,13 @@ describe('summary', () => {
 
 					clock.uninstall();
 				});
+
+				it('should not mutate passed startLabels', () => {
+					const startLabels = { method: 'GET' };
+					const end = instance.startTimer(startLabels);
+					end({ endpoint: '/test' });
+					expect(startLabels).toEqual({ method: 'GET' });
+				});
 			});
 		});
 
@@ -527,6 +534,13 @@ describe('summary', () => {
 					expect(values[2].value).toEqual(1);
 
 					clock.uninstall();
+				});
+
+				it('should not mutate passed startLabels', () => {
+					const startLabels = { method: 'GET' };
+					const end = instance.startTimer(startLabels);
+					end({ endpoint: '/test' });
+					expect(startLabels).toEqual({ method: 'GET' });
 				});
 			});
 		});


### PR DESCRIPTION
Fixes #176.