### PR TITLE
Fix aggregator method being lost when aggregating several registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 * Fixed `startTimer` utility to not mutate objects passed as `startLabels`
 * Fixed `Counter` to validate labels parameter of `inc()` against initial labelset
+* Fixed `AggregatorFactory` losing the aggregator method of metrics
 
 ### Added
 

--- a/lib/metricAggregators.js
+++ b/lib/metricAggregators.js
@@ -14,7 +14,8 @@ function AggregatorFactory(aggregatorFn) {
 			help: metrics[0].help,
 			name: metrics[0].name,
 			type: metrics[0].type,
-			values: []
+			values: [],
+			aggregator: metrics[0].aggregator
 		};
 		// Gather metrics by metricName and labels.
 		const byLabels = new util.Grouper();

--- a/test/clusterTest.js
+++ b/test/clusterTest.js
@@ -171,7 +171,8 @@ describe('AggregatorRegistry', () => {
 						value: 2.8412637018068043,
 						metricName: 'test_histogram_bucket'
 					}
-				]
+				],
+				aggregator: 'sum'
 			});
 		});
 
@@ -185,7 +186,8 @@ describe('AggregatorRegistry', () => {
 					{ value: 0.49, labels: { method: 'get', code: 200 } },
 					{ value: 0.88, labels: {} },
 					{ value: 74, labels: { method: 'post', code: '300' } }
-				]
+				],
+				aggregator: 'sum'
 			});
 		});
 
@@ -204,7 +206,8 @@ describe('AggregatorRegistry', () => {
 				help: 'Lag of event loop in seconds.',
 				name: 'nodejs_eventloop_lag_seconds',
 				type: 'gauge',
-				values: [{ value: 0.0085, labels: {} }]
+				values: [{ value: 0.0085, labels: {} }],
+				aggregator: 'average'
 			});
 		});
 
@@ -216,7 +219,8 @@ describe('AggregatorRegistry', () => {
 				help: 'Lag of event loop in seconds.',
 				name: 'nodejs_eventloop_lag_seconds',
 				type: 'gauge',
-				values: [{ value: 0.0085, labels: {} }]
+				values: [{ value: 0.0085, labels: {} }],
+				aggregator: 'average'
 			});
 		});
 
@@ -231,7 +235,8 @@ describe('AggregatorRegistry', () => {
 						value: 1,
 						labels: { version: 'v6.11.1', major: 6, minor: 11, patch: 1 }
 					}
-				]
+				],
+				aggregator: 'first'
 			});
 		});
 	});


### PR DESCRIPTION
When aggregating registries, the `aggregator` property of the metrics is lost. This PR aims to repopulate it with the aggregator property of the first metric, for better consistency.

This will prevent the `AggregatorRegistry#aggregate` function from breaking when attempting to aggregate an already-aggregated registry.