### PR TITLE
Add optional prefix to default metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+* Added ability to set a name prefix in the default metrics
+
 ### Breaking
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ In addition, some Node-specific metrics are included, such as event loop lag,
 active handles and Node.js version. See what metrics there are in
 [lib/metrics](lib/metrics).
 
-`collectDefaultMetrics` takes 1 options object with 2 entries, a timeout for how
-often the probe should be fired and a registry to which metrics should be
-registered. By default probes are launched every 10 seconds, but this can be
-modified like this:
+`collectDefaultMetrics` takes 1 options object with 3 entries, a timeout for how
+often the probe should be fired, an optional prefix for metric names
+and a registry to which metrics should be registered. By default probes are
+launched every 10 seconds, but this can be modified like this:
 
 ```js
 const client = require('prom-client');
@@ -75,6 +75,17 @@ const Registry = client.Registry;
 const register = new Registry();
 
 collectDefaultMetrics({ register });
+```
+
+To prefix metric names with your own arbitrary string, pass in a `prefix`:
+
+```js
+const client = require('prom-client');
+
+const collectDefaultMetrics = client.collectDefaultMetrics;
+
+// Probe every 5th second.
+collectDefaultMetrics({ prefix: 'my_application_' });
 ```
 
 You can get the full list of metrics by inspecting

--- a/lib/defaultMetrics.js
+++ b/lib/defaultMetrics.js
@@ -58,7 +58,7 @@ module.exports = function startDefaultMetrics(config) {
 			);
 		}
 
-		return defaultMetric(normalizedConfig.register);
+		return defaultMetric(normalizedConfig.register, config);
 	});
 
 	function updateAllMetrics() {

--- a/lib/metrics/eventLoopLag.js
+++ b/lib/metrics/eventLoopLag.js
@@ -12,9 +12,11 @@ function reportEventloopLag(start, gauge) {
 	gauge.set(seconds, Date.now());
 }
 
-module.exports = registry => {
+module.exports = (registry, config = {}) => {
+	const namePrefix = config.prefix ? config.prefix : '';
+
 	const gauge = new Gauge({
-		name: NODEJS_EVENTLOOP_LAG,
+		name: namePrefix + NODEJS_EVENTLOOP_LAG,
 		help: 'Lag of event loop in seconds.',
 		registers: registry ? [registry] : undefined,
 		aggregator: 'average'

--- a/lib/metrics/heapSizeAndUsed.js
+++ b/lib/metrics/heapSizeAndUsed.js
@@ -7,20 +7,21 @@ const NODEJS_HEAP_SIZE_TOTAL = 'nodejs_heap_size_total_bytes';
 const NODEJS_HEAP_SIZE_USED = 'nodejs_heap_size_used_bytes';
 const NODEJS_EXTERNAL_MEMORY = 'nodejs_external_memory_bytes';
 
-module.exports = registry => {
+module.exports = (registry, config = {}) => {
 	if (typeof process.memoryUsage !== 'function') {
 		return () => {};
 	}
 
 	const registers = registry ? [registry] : undefined;
+	const namePrefix = config.prefix ? config.prefix : '';
 
 	const heapSizeTotal = new Gauge({
-		name: NODEJS_HEAP_SIZE_TOTAL,
+		name: namePrefix + NODEJS_HEAP_SIZE_TOTAL,
 		help: 'Process heap size from node.js in bytes.',
 		registers
 	});
 	const heapSizeUsed = new Gauge({
-		name: NODEJS_HEAP_SIZE_USED,
+		name: namePrefix + NODEJS_HEAP_SIZE_USED,
 		help: 'Process heap size used from node.js in bytes.',
 		registers
 	});
@@ -29,7 +30,7 @@ module.exports = registry => {
 	const usage = safeMemoryUsage();
 	if (usage && usage.external) {
 		externalMemUsed = new Gauge({
-			name: NODEJS_EXTERNAL_MEMORY,
+			name: namePrefix + NODEJS_EXTERNAL_MEMORY,
 			help: 'Nodejs external memory size in bytes.',
 			registers
 		});

--- a/lib/metrics/heapSpacesSizeAndUsed.js
+++ b/lib/metrics/heapSpacesSizeAndUsed.js
@@ -18,7 +18,7 @@ METRICS.forEach(metricType => {
 	NODEJS_HEAP_SIZE[metricType] = `nodejs_heap_space_size_${metricType}_bytes`;
 });
 
-module.exports = registry => {
+module.exports = (registry, config = {}) => {
 	if (
 		typeof v8 === 'undefined' ||
 		typeof v8.getHeapSpaceStatistics !== 'function'
@@ -27,12 +27,13 @@ module.exports = registry => {
 	}
 
 	const registers = registry ? [registry] : undefined;
+	const namePrefix = config.prefix ? config.prefix : '';
 
 	const gauges = {};
 
 	METRICS.forEach(metricType => {
 		gauges[metricType] = new Gauge({
-			name: NODEJS_HEAP_SIZE[metricType],
+			name: namePrefix + NODEJS_HEAP_SIZE[metricType],
 			help: `Process heap space size ${metricType} from node.js in bytes.`,
 			labelNames: ['space'],
 			registers

--- a/lib/metrics/osMemoryHeap.js
+++ b/lib/metrics/osMemoryHeap.js
@@ -6,9 +6,11 @@ const safeMemoryUsage = require('./helpers/safeMemoryUsage');
 
 const PROCESS_RESIDENT_MEMORY = 'process_resident_memory_bytes';
 
-function notLinuxVariant(registry) {
+function notLinuxVariant(registry, config = {}) {
+	const namePrefix = config.prefix ? config.prefix : '';
+
 	const residentMemGauge = new Gauge({
-		name: PROCESS_RESIDENT_MEMORY,
+		name: namePrefix + PROCESS_RESIDENT_MEMORY,
 		help: 'Resident memory size in bytes.',
 		registers: registry ? [registry] : undefined
 	});
@@ -23,10 +25,10 @@ function notLinuxVariant(registry) {
 	};
 }
 
-module.exports = registry =>
+module.exports = (registry, config) =>
 	process.platform === 'linux'
-		? linuxVariant(registry)
-		: notLinuxVariant(registry);
+		? linuxVariant(registry, config)
+		: notLinuxVariant(registry, config);
 
 module.exports.metricNames =
 	process.platform === 'linux'

--- a/lib/metrics/osMemoryHeapLinux.js
+++ b/lib/metrics/osMemoryHeapLinux.js
@@ -31,20 +31,22 @@ function structureOutput(input) {
 	return returnValue;
 }
 
-module.exports = registry => {
+module.exports = (registry, config = {}) => {
 	const registers = registry ? [registry] : undefined;
+	const namePrefix = config.prefix ? config.prefix : '';
+
 	const residentMemGauge = new Gauge({
-		name: PROCESS_RESIDENT_MEMORY,
+		name: namePrefix + PROCESS_RESIDENT_MEMORY,
 		help: 'Resident memory size in bytes.',
 		registers
 	});
 	const virtualMemGauge = new Gauge({
-		name: PROCESS_VIRTUAL_MEMORY,
+		name: namePrefix + PROCESS_VIRTUAL_MEMORY,
 		help: 'Virtual memory size in bytes.',
 		registers
 	});
 	const heapSizeMemGauge = new Gauge({
-		name: PROCESS_HEAP,
+		name: namePrefix + PROCESS_HEAP,
 		help: 'Process heap size in bytes.',
 		registers
 	});

--- a/lib/metrics/processCpuTotal.js
+++ b/lib/metrics/processCpuTotal.js
@@ -5,26 +5,27 @@ const PROCESS_CPU_USER_SECONDS = 'process_cpu_user_seconds_total';
 const PROCESS_CPU_SYSTEM_SECONDS = 'process_cpu_system_seconds_total';
 const PROCESS_CPU_SECONDS = 'process_cpu_seconds_total';
 
-module.exports = registry => {
+module.exports = (registry, config = {}) => {
 	// Don't do anything if the function doesn't exist (introduced in node@6.1.0)
 	if (typeof process.cpuUsage !== 'function') {
 		return () => {};
 	}
 
 	const registers = registry ? [registry] : undefined;
+	const namePrefix = config.prefix ? config.prefix : '';
 
 	const cpuUserUsageCounter = new Counter({
-		name: PROCESS_CPU_USER_SECONDS,
+		name: namePrefix + PROCESS_CPU_USER_SECONDS,
 		help: 'Total user CPU time spent in seconds.',
 		registers
 	});
 	const cpuSystemUsageCounter = new Counter({
-		name: PROCESS_CPU_SYSTEM_SECONDS,
+		name: namePrefix + PROCESS_CPU_SYSTEM_SECONDS,
 		help: 'Total system CPU time spent in seconds.',
 		registers
 	});
 	const cpuUsageCounter = new Counter({
-		name: PROCESS_CPU_SECONDS,
+		name: namePrefix + PROCESS_CPU_SECONDS,
 		help: 'Total user and system CPU time spent in seconds.',
 		registers
 	});

--- a/lib/metrics/processHandles.js
+++ b/lib/metrics/processHandles.js
@@ -4,14 +4,16 @@ const Gauge = require('../gauge');
 
 const NODEJS_ACTIVE_HANDLES = 'nodejs_active_handles_total';
 
-module.exports = registry => {
+module.exports = (registry, config = {}) => {
 	// Don't do anything if the function is removed in later nodes (exists in node@6)
 	if (typeof process._getActiveHandles !== 'function') {
 		return () => {};
 	}
 
+	const namePrefix = config.prefix ? config.prefix : '';
+
 	const gauge = new Gauge({
-		name: NODEJS_ACTIVE_HANDLES,
+		name: namePrefix + NODEJS_ACTIVE_HANDLES,
 		help: 'Number of active handles.',
 		registers: registry ? [registry] : undefined
 	});

--- a/lib/metrics/processMaxFileDescriptors.js
+++ b/lib/metrics/processMaxFileDescriptors.js
@@ -5,14 +5,17 @@ const fs = require('fs');
 
 const PROCESS_MAX_FDS = 'process_max_fds';
 
-module.exports = registry => {
+module.exports = (registry, config = {}) => {
 	let isSet = false;
 
 	if (process.platform !== 'linux') {
 		return () => {};
 	}
+
+	const namePrefix = config.prefix ? config.prefix : '';
+
 	const fileDescriptorsGauge = new Gauge({
-		name: PROCESS_MAX_FDS,
+		name: namePrefix + PROCESS_MAX_FDS,
 		help: 'Maximum number of open file descriptors.',
 		registers: registry ? [registry] : undefined
 	});

--- a/lib/metrics/processOpenFileDescriptors.js
+++ b/lib/metrics/processOpenFileDescriptors.js
@@ -5,13 +5,15 @@ const fs = require('fs');
 
 const PROCESS_OPEN_FDS = 'process_open_fds';
 
-module.exports = registry => {
+module.exports = (registry, config) => {
 	if (process.platform !== 'linux') {
 		return () => {};
 	}
 
+	const namePrefix = config.prefix ? config.prefix : '';
+
 	const fileDescriptorsGauge = new Gauge({
-		name: PROCESS_OPEN_FDS,
+		name: namePrefix + PROCESS_OPEN_FDS,
 		help: 'Number of open file descriptors.',
 		registers: registry ? [registry] : undefined
 	});

--- a/lib/metrics/processRequests.js
+++ b/lib/metrics/processRequests.js
@@ -4,14 +4,16 @@ const Gauge = require('../gauge');
 
 const NODEJS_ACTIVE_REQUESTS = 'nodejs_active_requests_total';
 
-module.exports = registry => {
+module.exports = (registry, config = {}) => {
 	// Don't do anything if the function is removed in later nodes (exists in node@6)
 	if (typeof process._getActiveRequests !== 'function') {
 		return () => {};
 	}
 
+	const namePrefix = config.prefix ? config.prefix : '';
+
 	const gauge = new Gauge({
-		name: NODEJS_ACTIVE_REQUESTS,
+		name: namePrefix + NODEJS_ACTIVE_REQUESTS,
 		help: 'Number of active requests.',
 		registers: registry ? [registry] : undefined
 	});

--- a/lib/metrics/processStartTime.js
+++ b/lib/metrics/processStartTime.js
@@ -5,9 +5,11 @@ const nowInSeconds = Math.round(Date.now() / 1000 - process.uptime());
 
 const PROCESS_START_TIME = 'process_start_time_seconds';
 
-module.exports = registry => {
+module.exports = (registry, config = {}) => {
+	const namePrefix = config.prefix ? config.prefix : '';
+
 	const cpuUserGauge = new Gauge({
-		name: PROCESS_START_TIME,
+		name: namePrefix + PROCESS_START_TIME,
 		help: 'Start time of the process since unix epoch in seconds.',
 		registers: registry ? [registry] : undefined,
 		aggregator: 'omit'

--- a/lib/metrics/version.js
+++ b/lib/metrics/version.js
@@ -9,9 +9,11 @@ const versionSegments = version
 
 const NODE_VERSION_INFO = 'nodejs_version_info';
 
-module.exports = registry => {
+module.exports = (registry, config = {}) => {
+	const namePrefix = config.prefix ? config.prefix : '';
+
 	const nodeVersionGauge = new Gauge({
-		name: NODE_VERSION_INFO,
+		name: namePrefix + NODE_VERSION_INFO,
 		help: 'Node.js version info.',
 		labelNames: ['version', 'major', 'minor', 'patch'],
 		registers: registry ? [registry] : undefined,

--- a/test/defaultMetricsTest.js
+++ b/test/defaultMetricsTest.js
@@ -63,6 +63,14 @@ describe('collectDefaultMetrics', () => {
 		expect(register.getMetricsAsJSON()).toHaveLength(0);
 	});
 
+	it('should prefix metric names when configured', () => {
+		interval = collectDefaultMetrics({ prefix: 'some_prefix_' });
+		expect(register.getMetricsAsJSON()).not.toHaveLength(0);
+		register.getMetricsAsJSON().forEach(metric => {
+			expect(metric.name.substring(0, 12)).toEqual('some_prefix_');
+		});
+	});
+
 	describe('disabling', () => {
 		it('should not throw error', () => {
 			const fn = function() {


### PR DESCRIPTION
Adds the ability to provide a `prefix` string to the default metrics.

This helps in our use-case, where we have many applications residing on a single Prometheus instance and need to easily identify which metrics belong to which application.