### PR TITLE
Complementing prefix in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -614,6 +614,7 @@ export function exponentialBuckets(
 export interface DefaultMetricsCollectorConfiguration {
 	timeout?: number;
 	register?: Registry;
+	prefix?: string;
 }
 
 /**


### PR DESCRIPTION
adding prefix to DefaultMetricsCollectorConfiguration, related to the release v11.1.0.