### PR TITLE
Remove Sinon dependency

### DIFF
--- a/lib/metrics/processOpenFileDescriptors.js
+++ b/lib/metrics/processOpenFileDescriptors.js
@@ -2,6 +2,7 @@
 
 const Gauge = require('../gauge');
 const fs = require('fs');
+const process = require('process');
 
 const PROCESS_OPEN_FDS = 'process_open_fds';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,17 +37,6 @@
 				"any-observable": "^0.3.0"
 			}
 		},
-		"@sinonjs/formatio": {
-			"version": "2.0.0",
-			"resolved":
-				"https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-			"integrity":
-				"sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
-			"dev": true,
-			"requires": {
-				"samsam": "1.3.0"
-			}
-		},
 		"abab": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -4514,14 +4503,6 @@
 				"verror": "1.10.0"
 			}
 		},
-		"just-extend": {
-			"version": "1.1.27",
-			"resolved":
-				"https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-			"integrity":
-				"sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
-			"dev": true
-		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -5267,13 +5248,6 @@
 				"sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
 			"dev": true
 		},
-		"lodash.get": {
-			"version": "4.4.2",
-			"resolved":
-				"https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-			"dev": true
-		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved":
@@ -5642,38 +5616,6 @@
 				"https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
 			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
 			"dev": true
-		},
-		"nise": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.2.tgz",
-			"integrity":
-				"sha512-BxH/DxoQYYdhKgVAfqVy4pzXRZELHOIewzoesxpjYvpU+7YOalQhGNPf7wAx8pLrTNPrHRDlLOkAl8UI0ZpXjw==",
-			"dev": true,
-			"requires": {
-				"@sinonjs/formatio": "^2.0.0",
-				"just-extend": "^1.1.27",
-				"lolex": "^2.3.2",
-				"path-to-regexp": "^1.7.0",
-				"text-encoding": "^0.6.4"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				},
-				"path-to-regexp": {
-					"version": "1.7.0",
-					"resolved":
-						"https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-					"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-					"dev": true,
-					"requires": {
-						"isarray": "0.0.1"
-					}
-				}
-			}
 		},
 		"node-int64": {
 			"version": "0.4.0",
@@ -6800,13 +6742,6 @@
 				"sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
-		"samsam": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-			"integrity":
-				"sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
-			"dev": true
-		},
 		"sane": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
@@ -7289,35 +7224,6 @@
 				"https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 			"dev": true
-		},
-		"sinon": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-6.0.1.tgz",
-			"integrity":
-				"sha512-rfszhNcfamK2+ofIPi9XqeH89pH7KGDcAtM+F9CsjHXOK3jzWG99vyhyD2V+r7s4IipmWcWUFYq4ftZ9/Eu2Wg==",
-			"dev": true,
-			"requires": {
-				"@sinonjs/formatio": "^2.0.0",
-				"diff": "^3.5.0",
-				"lodash.get": "^4.4.2",
-				"lolex": "^2.4.2",
-				"nise": "^1.3.3",
-				"supports-color": "^5.4.0",
-				"type-detect": "^4.0.8"
-			},
-			"dependencies": {
-				"supports-color": {
-					"version": "5.4.0",
-					"resolved":
-						"https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity":
-						"sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
 		},
 		"slash": {
 			"version": "1.0.0",
@@ -8126,13 +8032,6 @@
 				}
 			}
 		},
-		"text-encoding": {
-			"version": "0.6.4",
-			"resolved":
-				"https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
-			"dev": true
-		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved":
@@ -8291,14 +8190,6 @@
 			"requires": {
 				"prelude-ls": "~1.1.2"
 			}
-		},
-		"type-detect": {
-			"version": "4.0.8",
-			"resolved":
-				"https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity":
-				"sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-			"dev": true
 		},
 		"type-is": {
 			"version": "1.6.16",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
 		"lint-staged": "^7.0.0",
 		"lolex": "^2.1.3",
 		"prettier": "1.11.1",
-		"sinon": "^6.0.1",
 		"typescript": "^2.5.2"
 	},
 	"dependencies": {

--- a/test/metrics/processOpenFileDescriptorsTest.js
+++ b/test/metrics/processOpenFileDescriptorsTest.js
@@ -1,20 +1,21 @@
 'use strict';
 
 describe('processOpenFileDescriptors', () => {
-	const sinon = require('sinon');
 	const register = require('../../index').register;
 	const processOpenFileDescriptors = require('../../lib/metrics/processOpenFileDescriptors');
 
-	const sinonSandbox = sinon.createSandbox();
+	jest.mock(
+		'process',
+		() =>
+			Object.assign({}, jest.requireActual('process'), { platform: 'linux' }) // This metric only works on Linux
+	);
 
 	beforeAll(() => {
-		sinonSandbox.stub(process, 'platform').value('linux'); // This metric only works on Linux
 		register.clear();
 	});
 
 	afterEach(() => {
 		register.clear();
-		sinonSandbox.restore();
 	});
 
 	it('should add metric to the registry', () => {


### PR DESCRIPTION
This is a follow-up of my PR #201. As pointed out by @SimenB [in the comments](https://github.com/siimon/prom-client/pull/201#discussion_r199135034), the Sinon dependency is not necessary to mock `process.platform` in order to make the `processOpenFileDescriptors` unit test pass on any platform.

This PR removes the Sinon dependency by using Jest to do the same thing.

Best regards!