### PR TITLE
chore: upgrade prettier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-* Allow setting Gauge values to NaN, +Inf, and -Inf
+- Allow setting Gauge values to NaN, +Inf, and -Inf
 
 ### Added
 
@@ -19,27 +19,27 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-* Fixed `processOpenFileDescriptors` metric when no custom config was set
+- Fixed `processOpenFileDescriptors` metric when no custom config was set
 
 ## [11.1.0] - 2018-06-29
 
-* Added ability to set a name prefix in the default metrics
+- Added ability to set a name prefix in the default metrics
 
 ### Changed
 
-* Fixed `startTimer` utility to not mutate objects passed as `startLabels`
-* Fixed `Counter` to validate labels parameter of `inc()` against initial
+- Fixed `startTimer` utility to not mutate objects passed as `startLabels`
+- Fixed `Counter` to validate labels parameter of `inc()` against initial
   labelset
-* Fixed `AggregatorFactory` losing the aggregator method of metrics
+- Fixed `AggregatorFactory` losing the aggregator method of metrics
 
 ## [11.0.0] - 2018-03-10
 
 ### Breaking
 
-* Fixed `gauge.setToCurrentTime()` to use seconds instead of milliseconds
-  * This conforms to Prometheus
+- Fixed `gauge.setToCurrentTime()` to use seconds instead of milliseconds
+  - This conforms to Prometheus
     [best practices](https://prometheus.io/docs/practices/naming/#base-units)
-* Dropped support for node 4
+- Dropped support for node 4
 
 ## [10.2.3] - 2018-02-28
 
@@ -47,7 +47,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-* Fixed issue that `registry.getMetricsAsJSON()` ignores registry default labels
+- Fixed issue that `registry.getMetricsAsJSON()` ignores registry default labels
 
 ### Added
 
@@ -55,123 +55,123 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-* Fixed invalid `process_virtual_memory_bytes` reported under linux
+- Fixed invalid `process_virtual_memory_bytes` reported under linux
 
 ## [10.2.1] - 2017-10-27
 
 ### Changed
 
-* Only resolve/reject `clusterMetrics` promise if no callback is provided
+- Only resolve/reject `clusterMetrics` promise if no callback is provided
 
 ## [10.2.0] - 2017-10-16
 
 ### Changed
 
-* Don't add event listeners if cluster module is not used.
-* Fixed issue with counters having extra records when using empty labels
+- Don't add event listeners if cluster module is not used.
+- Fixed issue with counters having extra records when using empty labels
 
 ### Added
 
-* Added `reset` to Counter and Gauge
-* Added `resetMetrics` to register to calling `reset` of all metric instances
+- Added `reset` to Counter and Gauge
+- Added `resetMetrics` to register to calling `reset` of all metric instances
 
 ## [10.1.1] - 2017-09-26
 
 ### Changed
 
-* Update TypeScript definitions and JSDoc comments to match JavaScript sources
-* Fix lexical scope of `arguments` in cluster code
+- Update TypeScript definitions and JSDoc comments to match JavaScript sources
+- Fix lexical scope of `arguments` in cluster code
 
 ## [10.1.0] - 2017-09-04
 
 ### Added
 
-* Support aggregating metrics across workers in a Node.js cluster.
+- Support aggregating metrics across workers in a Node.js cluster.
 
 ## [10.0.4] - 2017-08-22
 
 ### Changed
 
-* Include invalid values in the error messages
+- Include invalid values in the error messages
 
 ## [10.0.3] - 2017-08-07
 
 ### Added
 
-* Added registerMetric to definitions file
+- Added registerMetric to definitions file
 
 ### Changed
 
-* Fixed typing of DefaultMetricsCollectorConfiguration in definitions file
-* Don't pass timestamps through to pushgateway by default
+- Fixed typing of DefaultMetricsCollectorConfiguration in definitions file
+- Don't pass timestamps through to pushgateway by default
 
 ## [10.0.2] - 2017-07-07
 
 ### Changed
 
-* Don't poll default metrics every single tick
+- Don't poll default metrics every single tick
 
 ## [10.0.1] - 2017-07-06
 
 ### Added
 
-* Metrics should be initialized to 0 when there are no labels
+- Metrics should be initialized to 0 when there are no labels
 
 ## [10.0.0] - 2017-07-04
 
 ### Breaking
 
-* Print deprecation warning when metrics are constructed using non-objects
-* Print deprecation warning when `collectDefaultMetrics` is called with a number
+- Print deprecation warning when metrics are constructed using non-objects
+- Print deprecation warning when `collectDefaultMetrics` is called with a number
 
 ### Added
 
-* Ability to set default labels by registry
-* Allow passing in `registry` as second argument to `collectDefaultMetrics` to
+- Ability to set default labels by registry
+- Allow passing in `registry` as second argument to `collectDefaultMetrics` to
   use that instead of the default registry
 
 ### Changed
 
-* Convert code base to ES2015 code (node 4)
-  * add engines field to package.json
-  * Use object shorthand
-  * Remove `util-extend` in favor of `Object.assign`
-  * Arrow functions over binding or putting `this` in a variable
-  * Use template strings
-  * `prototype` -> `class`
+- Convert code base to ES2015 code (node 4)
+  - add engines field to package.json
+  - Use object shorthand
+  - Remove `util-extend` in favor of `Object.assign`
+  - Arrow functions over binding or putting `this` in a variable
+  - Use template strings
+  - `prototype` -> `class`
 
 ## [9.1.1] - 2017-06-17
 
 ### Changed
 
-* Don't set timestamps for metrics that are never updated
+- Don't set timestamps for metrics that are never updated
 
 ## [9.1.0] - 2017-06-07
 
 ### Added
 
-* Ability to merge registries
+- Ability to merge registries
 
 ### Changed
 
-* Correct typedefs for object constructor of metrics
+- Correct typedefs for object constructor of metrics
 
 ## [9.0.0] - 2017-05-06
 
 ### Added
 
-* Support for multiple registers
-* Support for object literals in metric constructors
-* Timestamp support
+- Support for multiple registers
+- Support for object literals in metric constructors
+- Timestamp support
 
 ### Changed
 
-* Collection of default metrics is now disabled by default. Start collection by
+- Collection of default metrics is now disabled by default. Start collection by
   running `collectDefaultMetrics()`.
 
 ### Deprecated
 
-* Creating metrics with one argument per parameter - use object literals
+- Creating metrics with one argument per parameter - use object literals
   instead.
 
 [unreleased]: https://github.com/siimon/prom-client/compare/v10.2.2...HEAD

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,10 +3,10 @@ init:
 
 environment:
   matrix:
-  - nodejs_version: 6
-  - nodejs_version: 7
-  - nodejs_version: 8
-  - nodejs_version: 9
+    - nodejs_version: 6
+    - nodejs_version: 7
+    - nodejs_version: 8
+    - nodejs_version: 9
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -156,7 +156,9 @@ function createValue(hashMap, value, timestamp, labels, hash) {
 	hash = hash || '';
 	timestamp = isDate(timestamp)
 		? timestamp.valueOf()
-		: Number.isFinite(timestamp) ? timestamp : undefined;
+		: Number.isFinite(timestamp)
+			? timestamp
+			: undefined;
 	if (hashMap[hash]) {
 		hashMap[hash].value += value;
 		hashMap[hash].timestamp = timestamp;

--- a/lib/util.js
+++ b/lib/util.js
@@ -30,7 +30,9 @@ exports.setValue = function setValue(hashMap, value, labels, timestamp) {
 		labels: labels || {},
 		timestamp: isDate(timestamp)
 			? timestamp.valueOf()
-			: Number.isFinite(timestamp) ? timestamp : undefined
+			: Number.isFinite(timestamp)
+				? timestamp
+				: undefined
 	};
 	return hashMap;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,7 @@
 	"dependencies": {
 		"@babel/code-frame": {
 			"version": "7.0.0-beta.51",
-			"resolved":
-				"https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
 			"integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
 			"dev": true,
 			"requires": {
@@ -16,8 +15,7 @@
 		},
 		"@babel/highlight": {
 			"version": "7.0.0-beta.51",
-			"resolved":
-				"https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
 			"integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
 			"dev": true,
 			"requires": {
@@ -28,10 +26,8 @@
 		},
 		"@samverschueren/stream-to-observable": {
 			"version": "0.3.0",
-			"resolved":
-				"https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
-			"integrity":
-				"sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
+			"resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
+			"integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
 			"dev": true,
 			"requires": {
 				"any-observable": "^0.3.0"
@@ -56,16 +52,13 @@
 		"acorn": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
-			"integrity":
-				"sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
+			"integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
 			"dev": true
 		},
 		"acorn-globals": {
 			"version": "4.1.0",
-			"resolved":
-				"https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
-			"integrity":
-				"sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
 			"dev": true,
 			"requires": {
 				"acorn": "^5.0.0"
@@ -102,15 +95,13 @@
 		},
 		"ajv-keywords": {
 			"version": "2.1.1",
-			"resolved":
-				"https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
 			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
 			"dev": true
 		},
 		"align-text": {
 			"version": "0.1.4",
-			"resolved":
-				"https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 			"dev": true,
 			"requires": {
@@ -127,39 +118,32 @@
 		},
 		"ansi-escapes": {
 			"version": "3.1.0",
-			"resolved":
-				"https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-			"integrity":
-				"sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
 			"dev": true
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
-			"resolved":
-				"https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 			"dev": true
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
-			"resolved":
-				"https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
 			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
 			"dev": true
 		},
 		"any-observable": {
 			"version": "0.3.0",
-			"resolved":
-				"https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
-			"integrity":
-				"sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+			"resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+			"integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
 			"dev": true
 		},
 		"anymatch": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-			"integrity":
-				"sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"dev": true,
 			"requires": {
 				"micromatch": "^3.1.4",
@@ -168,23 +152,20 @@
 			"dependencies": {
 				"arr-diff": {
 					"version": "4.0.0",
-					"resolved":
-						"https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
 					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
 					"dev": true
 				},
 				"array-unique": {
 					"version": "0.3.2",
-					"resolved":
-						"https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 					"dev": true
 				},
 				"braces": {
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity":
-						"sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.1.0",
@@ -201,8 +182,7 @@
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved":
-								"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
@@ -214,8 +194,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -223,8 +202,7 @@
 				},
 				"expand-brackets": {
 					"version": "2.1.4",
-					"resolved":
-						"https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
@@ -239,8 +217,7 @@
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
-							"resolved":
-								"https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
@@ -249,8 +226,7 @@
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved":
-								"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
@@ -259,8 +235,7 @@
 						},
 						"is-accessor-descriptor": {
 							"version": "0.1.6",
-							"resolved":
-								"https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
@@ -269,8 +244,7 @@
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
-									"resolved":
-										"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
@@ -281,8 +255,7 @@
 						},
 						"is-data-descriptor": {
 							"version": "0.1.4",
-							"resolved":
-								"https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
@@ -291,8 +264,7 @@
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
-									"resolved":
-										"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
@@ -303,10 +275,8 @@
 						},
 						"is-descriptor": {
 							"version": "0.1.6",
-							"resolved":
-								"https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity":
-								"sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^0.1.6",
@@ -316,10 +286,8 @@
 						},
 						"kind-of": {
 							"version": "5.1.0",
-							"resolved":
-								"https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity":
-								"sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
 							"dev": true
 						}
 					}
@@ -327,8 +295,7 @@
 				"extglob": {
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity":
-						"sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
 						"array-unique": "^0.3.2",
@@ -343,8 +310,7 @@
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
-							"resolved":
-								"https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
@@ -353,8 +319,7 @@
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved":
-								"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
@@ -365,8 +330,7 @@
 				},
 				"fill-range": {
 					"version": "4.0.0",
-					"resolved":
-						"https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
@@ -378,8 +342,7 @@
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved":
-								"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
@@ -390,10 +353,8 @@
 				},
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -401,10 +362,8 @@
 				},
 				"is-data-descriptor": {
 					"version": "1.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -412,10 +371,8 @@
 				},
 				"is-descriptor": {
 					"version": "1.0.2",
-					"resolved":
-						"https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity":
-						"sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -425,8 +382,7 @@
 				},
 				"is-number": {
 					"version": "3.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
@@ -435,8 +391,7 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "3.2.2",
-							"resolved":
-								"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
@@ -447,24 +402,20 @@
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"dev": true
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity":
-						"sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
 					"dev": true
 				},
 				"micromatch": {
 					"version": "3.1.10",
-					"resolved":
-						"https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity":
-						"sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
@@ -484,8 +435,7 @@
 				},
 				"normalize-path": {
 					"version": "2.1.1",
-					"resolved":
-						"https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"dev": true,
 					"requires": {
@@ -496,17 +446,14 @@
 		},
 		"app-root-path": {
 			"version": "2.1.0",
-			"resolved":
-				"https://registry.npmjs.org/app-root-path/-/app-root-path-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.1.0.tgz",
 			"integrity": "sha1-mL9lmTJ+zqGZMJhm6BQDaP0uZGo=",
 			"dev": true
 		},
 		"append-transform": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
-			"integrity":
-				"sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+			"integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
 			"dev": true,
 			"requires": {
 				"default-require-extensions": "^2.0.0"
@@ -515,8 +462,7 @@
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity":
-				"sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
@@ -533,10 +479,8 @@
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
-			"resolved":
-				"https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity":
-				"sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
 			"dev": true
 		},
 		"arr-union": {
@@ -547,22 +491,19 @@
 		},
 		"array-equal": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
 			"dev": true
 		},
 		"array-flatten": {
 			"version": "1.1.1",
-			"resolved":
-				"https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
 			"dev": true
 		},
 		"array-union": {
 			"version": "1.0.2",
-			"resolved":
-				"https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"dev": true,
 			"requires": {
@@ -571,15 +512,13 @@
 		},
 		"array-uniq": {
 			"version": "1.0.3",
-			"resolved":
-				"https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
 			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
 			"dev": true
 		},
 		"array-unique": {
 			"version": "0.2.1",
-			"resolved":
-				"https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
 			"dev": true
 		},
@@ -597,31 +536,26 @@
 		},
 		"assert-plus": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 			"dev": true
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
 			"dev": true
 		},
 		"astral-regex": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-			"integrity":
-				"sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
 			"dev": true
 		},
 		"async": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-			"integrity":
-				"sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.10"
@@ -629,10 +563,8 @@
 		},
 		"async-limiter": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity":
-				"sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
 			"dev": true
 		},
 		"asynckit": {
@@ -656,14 +588,12 @@
 		"aws4": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-			"integrity":
-				"sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
 			"dev": true
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
-			"resolved":
-				"https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
@@ -687,8 +617,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
@@ -699,10 +628,8 @@
 		},
 		"babel-core": {
 			"version": "6.26.3",
-			"resolved":
-				"https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-			"integrity":
-				"sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.26.0",
@@ -729,8 +656,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -740,10 +666,8 @@
 		},
 		"babel-generator": {
 			"version": "6.26.1",
-			"resolved":
-				"https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-			"integrity":
-				"sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"dev": true,
 			"requires": {
 				"babel-messages": "^6.23.0",
@@ -758,8 +682,7 @@
 		},
 		"babel-helpers": {
 			"version": "6.24.1",
-			"resolved":
-				"https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"dev": true,
 			"requires": {
@@ -769,10 +692,8 @@
 		},
 		"babel-jest": {
 			"version": "22.4.4",
-			"resolved":
-				"https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.4.tgz",
-			"integrity":
-				"sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.4.tgz",
+			"integrity": "sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==",
 			"dev": true,
 			"requires": {
 				"babel-plugin-istanbul": "^4.1.5",
@@ -781,8 +702,7 @@
 		},
 		"babel-messages": {
 			"version": "6.23.0",
-			"resolved":
-				"https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"dev": true,
 			"requires": {
@@ -791,10 +711,8 @@
 		},
 		"babel-plugin-istanbul": {
 			"version": "4.1.6",
-			"resolved":
-				"https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
-			"integrity":
-				"sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
@@ -805,25 +723,20 @@
 		},
 		"babel-plugin-jest-hoist": {
 			"version": "22.4.4",
-			"resolved":
-				"https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz",
-			"integrity":
-				"sha512-DUvGfYaAIlkdnygVIEl0O4Av69NtuQWcrjMOv6DODPuhuGLDnbsARz3AwiiI/EkIMMlxQDUcrZ9yoyJvTNjcVQ==",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz",
+			"integrity": "sha512-DUvGfYaAIlkdnygVIEl0O4Av69NtuQWcrjMOv6DODPuhuGLDnbsARz3AwiiI/EkIMMlxQDUcrZ9yoyJvTNjcVQ==",
 			"dev": true
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
-			"resolved":
-				"https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
 			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
 			"dev": true
 		},
 		"babel-preset-jest": {
 			"version": "22.4.4",
-			"resolved":
-				"https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz",
-			"integrity":
-				"sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz",
+			"integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
 			"dev": true,
 			"requires": {
 				"babel-plugin-jest-hoist": "^22.4.4",
@@ -832,8 +745,7 @@
 		},
 		"babel-register": {
 			"version": "6.26.0",
-			"resolved":
-				"https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"dev": true,
 			"requires": {
@@ -848,10 +760,8 @@
 			"dependencies": {
 				"source-map-support": {
 					"version": "0.4.18",
-					"resolved":
-						"https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-					"integrity":
-						"sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 					"dev": true,
 					"requires": {
 						"source-map": "^0.5.6"
@@ -861,8 +771,7 @@
 		},
 		"babel-runtime": {
 			"version": "6.26.0",
-			"resolved":
-				"https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"dev": true,
 			"requires": {
@@ -872,8 +781,7 @@
 		},
 		"babel-template": {
 			"version": "6.26.0",
-			"resolved":
-				"https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"dev": true,
 			"requires": {
@@ -886,8 +794,7 @@
 		},
 		"babel-traverse": {
 			"version": "6.26.0",
-			"resolved":
-				"https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"dev": true,
 			"requires": {
@@ -905,8 +812,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -915,16 +821,14 @@
 				"globals": {
 					"version": "9.18.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-					"integrity":
-						"sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
 					"dev": true
 				}
 			}
 		},
 		"babel-types": {
 			"version": "6.26.0",
-			"resolved":
-				"https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"dev": true,
 			"requires": {
@@ -937,22 +841,19 @@
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity":
-				"sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
 			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
 		"base": {
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-			"integrity":
-				"sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"dev": true,
 			"requires": {
 				"cache-base": "^1.0.1",
@@ -966,8 +867,7 @@
 			"dependencies": {
 				"define-property": {
 					"version": "1.0.0",
-					"resolved":
-						"https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
@@ -976,10 +876,8 @@
 				},
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -987,10 +885,8 @@
 				},
 				"is-data-descriptor": {
 					"version": "1.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -998,10 +894,8 @@
 				},
 				"is-descriptor": {
 					"version": "1.0.2",
-					"resolved":
-						"https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity":
-						"sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -1011,24 +905,21 @@
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"dev": true
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity":
-						"sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
 					"dev": true
 				}
 			}
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
-			"resolved":
-				"https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"dev": true,
 			"optional": true,
@@ -1043,8 +934,7 @@
 		},
 		"body-parser": {
 			"version": "1.18.2",
-			"resolved":
-				"https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
 			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
 			"dev": true,
 			"requires": {
@@ -1063,8 +953,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -1072,20 +961,16 @@
 				},
 				"iconv-lite": {
 					"version": "0.4.19",
-					"resolved":
-						"https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-					"integrity":
-						"sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
 					"dev": true
 				}
 			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
-			"resolved":
-				"https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity":
-				"sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
@@ -1105,17 +990,14 @@
 		},
 		"browser-process-hrtime": {
 			"version": "0.1.2",
-			"resolved":
-				"https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
 			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
 			"dev": true
 		},
 		"browser-resolve": {
 			"version": "1.11.3",
-			"resolved":
-				"https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
-			"integrity":
-				"sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+			"integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
 			"dev": true,
 			"requires": {
 				"resolve": "1.1.7"
@@ -1132,16 +1014,13 @@
 		},
 		"buffer-from": {
 			"version": "1.1.0",
-			"resolved":
-				"https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-			"integrity":
-				"sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+			"integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
 			"dev": true
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
-			"resolved":
-				"https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
 			"dev": true
 		},
@@ -1153,10 +1032,8 @@
 		},
 		"cache-base": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-			"integrity":
-				"sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"dev": true,
 			"requires": {
 				"collection-visit": "^1.0.0",
@@ -1172,8 +1049,7 @@
 			"dependencies": {
 				"isobject": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"dev": true
 				}
@@ -1181,8 +1057,7 @@
 		},
 		"caller-path": {
 			"version": "0.1.0",
-			"resolved":
-				"https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
 			"dev": true,
 			"requires": {
@@ -1204,8 +1079,7 @@
 		},
 		"capture-exit": {
 			"version": "1.2.0",
-			"resolved":
-				"https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
 			"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
 			"dev": true,
 			"requires": {
@@ -1220,8 +1094,7 @@
 		},
 		"center-align": {
 			"version": "0.1.3",
-			"resolved":
-				"https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
 			"dev": true,
 			"optional": true,
@@ -1233,8 +1106,7 @@
 		"chalk": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-			"integrity":
-				"sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
@@ -1244,10 +1116,8 @@
 			"dependencies": {
 				"ansi-styles": {
 					"version": "3.2.1",
-					"resolved":
-						"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity":
-						"sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
@@ -1255,10 +1125,8 @@
 				},
 				"supports-color": {
 					"version": "5.4.0",
-					"resolved":
-						"https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity":
-						"sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -1275,24 +1143,19 @@
 		"ci-info": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-			"integrity":
-				"sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+			"integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
 			"dev": true
 		},
 		"circular-json": {
 			"version": "0.3.3",
-			"resolved":
-				"https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity":
-				"sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
 			"dev": true
 		},
 		"class-utils": {
 			"version": "0.3.6",
-			"resolved":
-				"https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-			"integrity":
-				"sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
@@ -1303,8 +1166,7 @@
 			"dependencies": {
 				"define-property": {
 					"version": "0.2.5",
-					"resolved":
-						"https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
@@ -1313,8 +1175,7 @@
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"dev": true
 				}
@@ -1322,8 +1183,7 @@
 		},
 		"cli-cursor": {
 			"version": "2.1.0",
-			"resolved":
-				"https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"dev": true,
 			"requires": {
@@ -1332,15 +1192,13 @@
 		},
 		"cli-spinners": {
 			"version": "0.1.2",
-			"resolved":
-				"https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
 			"integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
 			"dev": true
 		},
 		"cli-truncate": {
 			"version": "0.2.1",
-			"resolved":
-				"https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
 			"integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
 			"dev": true,
 			"requires": {
@@ -1350,8 +1208,7 @@
 			"dependencies": {
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
@@ -1360,15 +1217,13 @@
 				},
 				"slice-ansi": {
 					"version": "0.0.4",
-					"resolved":
-						"https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
 					"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
 					"dev": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved":
-						"https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
@@ -1379,8 +1234,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
@@ -1409,8 +1263,7 @@
 			"dependencies": {
 				"wordwrap": {
 					"version": "0.0.2",
-					"resolved":
-						"https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
 					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
 					"dev": true,
 					"optional": true
@@ -1425,15 +1278,13 @@
 		},
 		"code-point-at": {
 			"version": "1.1.0",
-			"resolved":
-				"https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 			"dev": true
 		},
 		"collection-visit": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"dev": true,
 			"requires": {
@@ -1443,10 +1294,8 @@
 		},
 		"color-convert": {
 			"version": "1.9.2",
-			"resolved":
-				"https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
-			"integrity":
-				"sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+			"integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
 			"dev": true,
 			"requires": {
 				"color-name": "1.1.1"
@@ -1454,15 +1303,13 @@
 		},
 		"color-name": {
 			"version": "1.1.1",
-			"resolved":
-				"https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
 			"integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
 			"dev": true
 		},
 		"combined-stream": {
 			"version": "1.0.6",
-			"resolved":
-				"https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"dev": true,
 			"requires": {
@@ -1472,38 +1319,31 @@
 		"commander": {
 			"version": "2.15.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-			"integrity":
-				"sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
 			"dev": true
 		},
 		"compare-versions": {
 			"version": "3.3.0",
-			"resolved":
-				"https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.0.tgz",
-			"integrity":
-				"sha512-MAAAIOdi2s4Gl6rZ76PNcUa9IOYB+5ICdT41o5uMRf09aEu/F9RK+qhe8RjXNPwcTjGV7KU7h2P/fljThFVqyQ==",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.0.tgz",
+			"integrity": "sha512-MAAAIOdi2s4Gl6rZ76PNcUa9IOYB+5ICdT41o5uMRf09aEu/F9RK+qhe8RjXNPwcTjGV7KU7h2P/fljThFVqyQ==",
 			"dev": true
 		},
 		"component-emitter": {
 			"version": "1.2.1",
-			"resolved":
-				"https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
 			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
 			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
-			"resolved":
-				"https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.2",
-			"resolved":
-				"https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-			"integrity":
-				"sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -1514,23 +1354,19 @@
 		},
 		"content-disposition": {
 			"version": "0.5.2",
-			"resolved":
-				"https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
 			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
 			"dev": true
 		},
 		"content-type": {
 			"version": "1.0.4",
-			"resolved":
-				"https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity":
-				"sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
 			"dev": true
 		},
 		"convert-source-map": {
 			"version": "1.5.1",
-			"resolved":
-				"https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
 			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
 			"dev": true
 		},
@@ -1542,38 +1378,32 @@
 		},
 		"cookie-signature": {
 			"version": "1.0.6",
-			"resolved":
-				"https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
 			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
 			"dev": true
 		},
 		"copy-descriptor": {
 			"version": "0.1.1",
-			"resolved":
-				"https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
 		},
 		"core-js": {
 			"version": "2.5.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity":
-				"sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
 			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
-			"resolved":
-				"https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"dev": true
 		},
 		"cosmiconfig": {
 			"version": "5.0.5",
-			"resolved":
-				"https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.5.tgz",
-			"integrity":
-				"sha512-94j37OtvxS5w7qr7Ta6dt67tWdnOxigBVN4VnSxNXFez9o18PGQ0D33SchKP17r9LAcWVTYV72G6vDayAUBFIg==",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.5.tgz",
+			"integrity": "sha512-94j37OtvxS5w7qr7Ta6dt67tWdnOxigBVN4VnSxNXFez9o18PGQ0D33SchKP17r9LAcWVTYV72G6vDayAUBFIg==",
 			"dev": true,
 			"requires": {
 				"is-directory": "^0.3.1",
@@ -1583,8 +1413,7 @@
 			"dependencies": {
 				"parse-json": {
 					"version": "4.0.0",
-					"resolved":
-						"https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
@@ -1596,8 +1425,7 @@
 		},
 		"cross-spawn": {
 			"version": "5.1.0",
-			"resolved":
-				"https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"dev": true,
 			"requires": {
@@ -1609,15 +1437,13 @@
 		"cssom": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.3.tgz",
-			"integrity":
-				"sha512-pjE/I/NSp3iyeoxXN5QaoJpgzYUMj2dJHx9OSufoTliJLDx+kuOQaMCJW8OwvrKJswhXUHnHN6eUmUSETN0msg==",
+			"integrity": "sha512-pjE/I/NSp3iyeoxXN5QaoJpgzYUMj2dJHx9OSufoTliJLDx+kuOQaMCJW8OwvrKJswhXUHnHN6eUmUSETN0msg==",
 			"dev": true
 		},
 		"cssstyle": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.3.1.tgz",
-			"integrity":
-				"sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
+			"integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
 			"dev": true,
 			"requires": {
 				"cssom": "0.3.x"
@@ -1635,8 +1461,7 @@
 		"data-urls": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
-			"integrity":
-				"sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+			"integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
 			"dev": true,
 			"requires": {
 				"abab": "^1.0.4",
@@ -1647,15 +1472,13 @@
 		"date-fns": {
 			"version": "1.29.0",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
-			"integrity":
-				"sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+			"integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
 			"dev": true
 		},
 		"debug": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-			"integrity":
-				"sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
@@ -1663,15 +1486,13 @@
 		},
 		"decamelize": {
 			"version": "1.2.0",
-			"resolved":
-				"https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
-			"resolved":
-				"https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
 		},
@@ -1689,8 +1510,7 @@
 		},
 		"default-require-extensions": {
 			"version": "2.0.0",
-			"resolved":
-				"https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
 			"integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
 			"dev": true,
 			"requires": {
@@ -1699,8 +1519,7 @@
 		},
 		"define-properties": {
 			"version": "1.1.2",
-			"resolved":
-				"https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
 			"dev": true,
 			"requires": {
@@ -1710,10 +1529,8 @@
 		},
 		"define-property": {
 			"version": "2.0.2",
-			"resolved":
-				"https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-			"integrity":
-				"sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"dev": true,
 			"requires": {
 				"is-descriptor": "^1.0.2",
@@ -1722,10 +1539,8 @@
 			"dependencies": {
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -1733,10 +1548,8 @@
 				},
 				"is-data-descriptor": {
 					"version": "1.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -1744,10 +1557,8 @@
 				},
 				"is-descriptor": {
 					"version": "1.0.2",
-					"resolved":
-						"https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity":
-						"sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -1757,16 +1568,14 @@
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"dev": true
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity":
-						"sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
 					"dev": true
 				}
 			}
@@ -1788,8 +1597,7 @@
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
 		},
@@ -1807,8 +1615,7 @@
 		},
 		"detect-indent": {
 			"version": "4.0.0",
-			"resolved":
-				"https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"dev": true,
 			"requires": {
@@ -1817,23 +1624,20 @@
 		},
 		"detect-newline": {
 			"version": "2.1.0",
-			"resolved":
-				"https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
 			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
 			"dev": true
 		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity":
-				"sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
 		},
 		"doctrine": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-			"integrity":
-				"sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2"
@@ -1841,10 +1645,8 @@
 		},
 		"domexception": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
-			"integrity":
-				"sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
 			"dev": true,
 			"requires": {
 				"webidl-conversions": "^4.0.2"
@@ -1868,8 +1670,7 @@
 		},
 		"elegant-spinner": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
 			"integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
 			"dev": true
 		},
@@ -1882,8 +1683,7 @@
 		"error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-			"integrity":
-				"sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
@@ -1891,10 +1691,8 @@
 		},
 		"es-abstract": {
 			"version": "1.12.0",
-			"resolved":
-				"https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-			"integrity":
-				"sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.1.1",
@@ -1906,8 +1704,7 @@
 		},
 		"es-to-primitive": {
 			"version": "1.1.1",
-			"resolved":
-				"https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
 			"dev": true,
 			"requires": {
@@ -1918,23 +1715,20 @@
 		},
 		"escape-html": {
 			"version": "1.0.3",
-			"resolved":
-				"https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
 			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
 			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
-			"resolved":
-				"https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 			"dev": true
 		},
 		"escodegen": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.10.0.tgz",
-			"integrity":
-				"sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==",
+			"integrity": "sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==",
 			"dev": true,
 			"requires": {
 				"esprima": "^3.1.3",
@@ -1952,10 +1746,8 @@
 				},
 				"source-map": {
 					"version": "0.6.1",
-					"resolved":
-						"https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity":
-						"sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true,
 					"optional": true
 				}
@@ -1964,8 +1756,7 @@
 		"eslint": {
 			"version": "4.19.1",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-			"integrity":
-				"sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
 			"dev": true,
 			"requires": {
 				"ajv": "^5.3.0",
@@ -2010,10 +1801,8 @@
 		},
 		"eslint-plugin-prettier": {
 			"version": "2.6.1",
-			"resolved":
-				"https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.1.tgz",
-			"integrity":
-				"sha512-wNZ2z0oVCWnf+3BSI7roS+z4gGu2AwcPKUek+SlLZMZg+X0KbZLsB2knul7fd0K3iuIp402HIYzm4f2+OyfXxA==",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.1.tgz",
+			"integrity": "sha512-wNZ2z0oVCWnf+3BSI7roS+z4gGu2AwcPKUek+SlLZMZg+X0KbZLsB2knul7fd0K3iuIp402HIYzm4f2+OyfXxA==",
 			"dev": true,
 			"requires": {
 				"fast-diff": "^1.1.1",
@@ -2022,8 +1811,7 @@
 		},
 		"eslint-scope": {
 			"version": "3.7.1",
-			"resolved":
-				"https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
 			"dev": true,
 			"requires": {
@@ -2033,17 +1821,14 @@
 		},
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity":
-				"sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
 			"dev": true
 		},
 		"espree": {
 			"version": "3.5.4",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-			"integrity":
-				"sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
 			"dev": true,
 			"requires": {
 				"acorn": "^5.5.0",
@@ -2053,15 +1838,13 @@
 		"esprima": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity":
-				"sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
 			"dev": true
 		},
 		"esquery": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-			"integrity":
-				"sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
 			"dev": true,
 			"requires": {
 				"estraverse": "^4.0.0"
@@ -2070,8 +1853,7 @@
 		"esrecurse": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-			"integrity":
-				"sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"dev": true,
 			"requires": {
 				"estraverse": "^4.1.0"
@@ -2079,8 +1861,7 @@
 		},
 		"estraverse": {
 			"version": "4.2.0",
-			"resolved":
-				"https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
 			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
 			"dev": true
 		},
@@ -2099,8 +1880,7 @@
 		"exec-sh": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
-			"integrity":
-				"sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+			"integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
 			"dev": true,
 			"requires": {
 				"merge": "^1.2.0"
@@ -2135,8 +1915,7 @@
 		},
 		"expand-brackets": {
 			"version": "0.1.5",
-			"resolved":
-				"https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 			"dev": true,
 			"requires": {
@@ -2145,8 +1924,7 @@
 		},
 		"expand-range": {
 			"version": "1.8.2",
-			"resolved":
-				"https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"dev": true,
 			"requires": {
@@ -2156,8 +1934,7 @@
 		"expect": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
-			"integrity":
-				"sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
+			"integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
 			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.0",
@@ -2170,10 +1947,8 @@
 			"dependencies": {
 				"ansi-styles": {
 					"version": "3.2.1",
-					"resolved":
-						"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity":
-						"sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
@@ -2222,8 +1997,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -2231,10 +2005,8 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
-					"resolved":
-						"https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-					"integrity":
-						"sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
 					"dev": true
 				}
 			}
@@ -2247,8 +2019,7 @@
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
-			"resolved":
-				"https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"dev": true,
 			"requires": {
@@ -2258,10 +2029,8 @@
 			"dependencies": {
 				"is-extendable": {
 					"version": "1.0.1",
-					"resolved":
-						"https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-					"integrity":
-						"sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
@@ -2271,10 +2040,8 @@
 		},
 		"external-editor": {
 			"version": "2.2.0",
-			"resolved":
-				"https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-			"integrity":
-				"sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 			"dev": true,
 			"requires": {
 				"chardet": "^0.4.0",
@@ -2293,43 +2060,37 @@
 		},
 		"extsprintf": {
 			"version": "1.3.0",
-			"resolved":
-				"https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
 			"dev": true
 		},
 		"fast-deep-equal": {
 			"version": "1.1.0",
-			"resolved":
-				"https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
 			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
 			"dev": true
 		},
 		"fast-diff": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-			"integrity":
-				"sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+			"integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
 			"dev": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
-			"resolved":
-				"https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
 			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
 			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
-			"resolved":
-				"https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
 		"fb-watchman": {
 			"version": "2.0.0",
-			"resolved":
-				"https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
 			"dev": true,
 			"requires": {
@@ -2347,8 +2108,7 @@
 		},
 		"file-entry-cache": {
 			"version": "2.0.0",
-			"resolved":
-				"https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
 			"dev": true,
 			"requires": {
@@ -2358,8 +2118,7 @@
 		},
 		"filename-regex": {
 			"version": "2.0.1",
-			"resolved":
-				"https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
 			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
 			"dev": true
 		},
@@ -2375,10 +2134,8 @@
 		},
 		"fill-range": {
 			"version": "2.2.4",
-			"resolved":
-				"https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-			"integrity":
-				"sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
 			"dev": true,
 			"requires": {
 				"is-number": "^2.1.0",
@@ -2390,10 +2147,8 @@
 		},
 		"finalhandler": {
 			"version": "1.1.1",
-			"resolved":
-				"https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-			"integrity":
-				"sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
 			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
@@ -2408,8 +2163,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -2419,8 +2173,7 @@
 		},
 		"find-parent-dir": {
 			"version": "0.3.0",
-			"resolved":
-				"https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
 			"integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
 			"dev": true
 		},
@@ -2435,8 +2188,7 @@
 		},
 		"flat-cache": {
 			"version": "1.3.0",
-			"resolved":
-				"https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
 			"dev": true,
 			"requires": {
@@ -2469,8 +2221,7 @@
 		},
 		"forever-agent": {
 			"version": "0.6.1",
-			"resolved":
-				"https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
 			"dev": true
 		},
@@ -2493,8 +2244,7 @@
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
-			"resolved":
-				"https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"dev": true,
 			"requires": {
@@ -2509,16 +2259,14 @@
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
 		},
 		"fsevents": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-			"integrity":
-				"sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -3046,38 +2794,31 @@
 		},
 		"function-bind": {
 			"version": "1.1.1",
-			"resolved":
-				"https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity":
-				"sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
 			"dev": true
 		},
 		"functional-red-black-tree": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
 		},
 		"get-caller-file": {
 			"version": "1.0.2",
-			"resolved":
-				"https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
 			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
 			"dev": true
 		},
 		"get-own-enumerable-property-symbols": {
 			"version": "2.0.1",
-			"resolved":
-				"https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
-			"integrity":
-				"sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
+			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+			"integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
 			"dev": true
 		},
 		"get-stream": {
 			"version": "3.0.0",
-			"resolved":
-				"https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 			"dev": true
 		},
@@ -3099,8 +2840,7 @@
 		"glob": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-			"integrity":
-				"sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -3123,8 +2863,7 @@
 		},
 		"glob-parent": {
 			"version": "2.0.0",
-			"resolved":
-				"https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 			"dev": true,
 			"requires": {
@@ -3134,8 +2873,7 @@
 		"globals": {
 			"version": "11.7.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-			"integrity":
-				"sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+			"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
 			"dev": true
 		},
 		"globby": {
@@ -3154,8 +2892,7 @@
 		},
 		"graceful-fs": {
 			"version": "4.1.11",
-			"resolved":
-				"https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
 			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
 			"dev": true
 		},
@@ -3167,8 +2904,7 @@
 		},
 		"handlebars": {
 			"version": "4.0.11",
-			"resolved":
-				"https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
 			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
 			"dev": true,
 			"requires": {
@@ -3186,8 +2922,7 @@
 				},
 				"source-map": {
 					"version": "0.4.4",
-					"resolved":
-						"https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"dev": true,
 					"requires": {
@@ -3198,15 +2933,13 @@
 		},
 		"har-schema": {
 			"version": "2.0.0",
-			"resolved":
-				"https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
 			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
 			"dev": true
 		},
 		"har-validator": {
 			"version": "5.0.3",
-			"resolved":
-				"https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"dev": true,
 			"requires": {
@@ -3217,8 +2950,7 @@
 		"has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity":
-				"sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
@@ -3252,8 +2984,7 @@
 			"dependencies": {
 				"isobject": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"dev": true
 				}
@@ -3261,8 +2992,7 @@
 		},
 		"has-values": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"dev": true,
 			"requires": {
@@ -3272,8 +3002,7 @@
 			"dependencies": {
 				"is-number": {
 					"version": "3.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
@@ -3282,8 +3011,7 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "3.2.2",
-							"resolved":
-								"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
@@ -3305,8 +3033,7 @@
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
-			"resolved":
-				"https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"dev": true,
 			"requires": {
@@ -3316,18 +3043,14 @@
 		},
 		"hosted-git-info": {
 			"version": "2.6.1",
-			"resolved":
-				"https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.1.tgz",
-			"integrity":
-				"sha512-Ba4+0M4YvIDUUsprMjhVTU1yN9F2/LJSAl69ZpzaLT4l4j5mwTS6jqqW9Ojvj6lKz/veqPzpJBqGbXspOb533A==",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.1.tgz",
+			"integrity": "sha512-Ba4+0M4YvIDUUsprMjhVTU1yN9F2/LJSAl69ZpzaLT4l4j5mwTS6jqqW9Ojvj6lKz/veqPzpJBqGbXspOb533A==",
 			"dev": true
 		},
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
-			"resolved":
-				"https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-			"integrity":
-				"sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
 			"dev": true,
 			"requires": {
 				"whatwg-encoding": "^1.0.1"
@@ -3335,8 +3058,7 @@
 		},
 		"http-errors": {
 			"version": "1.6.3",
-			"resolved":
-				"https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"dev": true,
 			"requires": {
@@ -3348,8 +3070,7 @@
 		},
 		"http-signature": {
 			"version": "1.2.0",
-			"resolved":
-				"https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
@@ -3361,8 +3082,7 @@
 		"husky": {
 			"version": "0.14.3",
 			"resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
-			"integrity":
-				"sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+			"integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
 			"dev": true,
 			"requires": {
 				"is-ci": "^1.0.10",
@@ -3372,10 +3092,8 @@
 		},
 		"iconv-lite": {
 			"version": "0.4.23",
-			"resolved":
-				"https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-			"integrity":
-				"sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+			"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
 			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
@@ -3384,16 +3102,13 @@
 		"ignore": {
 			"version": "3.3.10",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-			"integrity":
-				"sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
 			"dev": true
 		},
 		"import-local": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-			"integrity":
-				"sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
 			"dev": true,
 			"requires": {
 				"pkg-dir": "^2.0.0",
@@ -3402,15 +3117,13 @@
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
-			"resolved":
-				"https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
 			"dev": true
 		},
 		"indent-string": {
 			"version": "2.1.0",
-			"resolved":
-				"https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 			"dev": true,
 			"requires": {
@@ -3436,8 +3149,7 @@
 		"inquirer": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-			"integrity":
-				"sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.0.0",
@@ -3459,8 +3171,7 @@
 		"invariant": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity":
-				"sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
@@ -3480,8 +3191,7 @@
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
-			"resolved":
-				"https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"dev": true,
 			"requires": {
@@ -3490,22 +3200,19 @@
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
-			"resolved":
-				"https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
 			"dev": true
 		},
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity":
-				"sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
@@ -3514,16 +3221,14 @@
 		},
 		"is-callable": {
 			"version": "1.1.3",
-			"resolved":
-				"https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
 			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
 			"dev": true
 		},
 		"is-ci": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-			"integrity":
-				"sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
 			"dev": true,
 			"requires": {
 				"ci-info": "^1.0.0"
@@ -3531,8 +3236,7 @@
 		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
-			"resolved":
-				"https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"dev": true,
 			"requires": {
@@ -3541,17 +3245,14 @@
 		},
 		"is-date-object": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
 			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
 			"dev": true
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
-			"resolved":
-				"https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-			"integrity":
-				"sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 			"dev": true,
 			"requires": {
 				"is-accessor-descriptor": "^0.1.6",
@@ -3562,30 +3263,26 @@
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity":
-						"sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
 					"dev": true
 				}
 			}
 		},
 		"is-directory": {
 			"version": "0.3.1",
-			"resolved":
-				"https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
 			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
 			"dev": true
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
-			"resolved":
-				"https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
 			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
 			"dev": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
-			"resolved":
-				"https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"dev": true,
 			"requires": {
@@ -3594,15 +3291,13 @@
 		},
 		"is-extendable": {
 			"version": "0.1.1",
-			"resolved":
-				"https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
 			"dev": true
 		},
 		"is-extglob": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
 			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
 			"dev": true
 		},
@@ -3617,15 +3312,13 @@
 		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
-			"resolved":
-				"https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 			"dev": true
 		},
 		"is-generator-fn": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
 			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
 			"dev": true
 		},
@@ -3655,10 +3348,8 @@
 		},
 		"is-observable": {
 			"version": "1.1.0",
-			"resolved":
-				"https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
-			"integrity":
-				"sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
 			"dev": true,
 			"requires": {
 				"symbol-observable": "^1.1.0"
@@ -3666,17 +3357,14 @@
 		},
 		"is-path-cwd": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
 			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
 			"dev": true
 		},
 		"is-path-in-cwd": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-			"integrity":
-				"sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
 			"dev": true,
 			"requires": {
 				"is-path-inside": "^1.0.0"
@@ -3684,8 +3372,7 @@
 		},
 		"is-path-inside": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 			"dev": true,
 			"requires": {
@@ -3694,10 +3381,8 @@
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
-			"resolved":
-				"https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity":
-				"sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
@@ -3705,8 +3390,7 @@
 			"dependencies": {
 				"isobject": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"dev": true
 				}
@@ -3714,22 +3398,19 @@
 		},
 		"is-posix-bracket": {
 			"version": "0.1.1",
-			"resolved":
-				"https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
 			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
 			"dev": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
-			"resolved":
-				"https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
 			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
 			"dev": true
 		},
 		"is-promise": {
 			"version": "2.1.0",
-			"resolved":
-				"https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
 			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
 			"dev": true
 		},
@@ -3750,10 +3431,8 @@
 		},
 		"is-resolvable": {
 			"version": "1.1.0",
-			"resolved":
-				"https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-			"integrity":
-				"sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
 			"dev": true
 		},
 		"is-stream": {
@@ -3770,8 +3449,7 @@
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 			"dev": true
 		},
@@ -3783,10 +3461,8 @@
 		},
 		"is-windows": {
 			"version": "1.0.2",
-			"resolved":
-				"https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity":
-				"sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
 			"dev": true
 		},
 		"isarray": {
@@ -3818,10 +3494,8 @@
 		},
 		"istanbul-api": {
 			"version": "1.3.1",
-			"resolved":
-				"https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.1.tgz",
-			"integrity":
-				"sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
+			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.1.tgz",
+			"integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
 			"dev": true,
 			"requires": {
 				"async": "^2.1.4",
@@ -3840,10 +3514,8 @@
 			"dependencies": {
 				"istanbul-lib-source-maps": {
 					"version": "1.2.5",
-					"resolved":
-						"https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz",
-					"integrity":
-						"sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz",
+					"integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
 					"dev": true,
 					"requires": {
 						"debug": "^3.1.0",
@@ -3857,18 +3529,14 @@
 		},
 		"istanbul-lib-coverage": {
 			"version": "1.2.0",
-			"resolved":
-				"https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
-			"integrity":
-				"sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
+			"integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
 			"dev": true
 		},
 		"istanbul-lib-hook": {
 			"version": "1.2.1",
-			"resolved":
-				"https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.1.tgz",
-			"integrity":
-				"sha512-eLAMkPG9FU0v5L02lIkcj/2/Zlz9OuluaXikdr5iStk8FDbSwAixTK9TkYxbF0eNnzAJTwM2fkV2A1tpsIp4Jg==",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.1.tgz",
+			"integrity": "sha512-eLAMkPG9FU0v5L02lIkcj/2/Zlz9OuluaXikdr5iStk8FDbSwAixTK9TkYxbF0eNnzAJTwM2fkV2A1tpsIp4Jg==",
 			"dev": true,
 			"requires": {
 				"append-transform": "^1.0.0"
@@ -3876,10 +3544,8 @@
 		},
 		"istanbul-lib-instrument": {
 			"version": "1.10.1",
-			"resolved":
-				"https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
-			"integrity":
-				"sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
+			"integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
 			"dev": true,
 			"requires": {
 				"babel-generator": "^6.18.0",
@@ -3893,10 +3559,8 @@
 		},
 		"istanbul-lib-report": {
 			"version": "1.1.4",
-			"resolved":
-				"https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
-			"integrity":
-				"sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
+			"integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
 			"dev": true,
 			"requires": {
 				"istanbul-lib-coverage": "^1.2.0",
@@ -3907,15 +3571,13 @@
 			"dependencies": {
 				"has-flag": {
 					"version": "1.0.0",
-					"resolved":
-						"https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
 					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
-					"resolved":
-						"https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
@@ -3926,10 +3588,8 @@
 		},
 		"istanbul-lib-source-maps": {
 			"version": "1.2.3",
-			"resolved":
-				"https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
-			"integrity":
-				"sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
+			"integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
 			"dev": true,
 			"requires": {
 				"debug": "^3.1.0",
@@ -3941,10 +3601,8 @@
 		},
 		"istanbul-reports": {
 			"version": "1.3.0",
-			"resolved":
-				"https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
-			"integrity":
-				"sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
+			"integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
 			"dev": true,
 			"requires": {
 				"handlebars": "^4.0.3"
@@ -3953,8 +3611,7 @@
 		"jest": {
 			"version": "22.4.4",
 			"resolved": "https://registry.npmjs.org/jest/-/jest-22.4.4.tgz",
-			"integrity":
-				"sha512-eBhhW8OS/UuX3HxgzNBSVEVhSuRDh39Z1kdYkQVWna+scpgsrD7vSeBI7tmEvsguPDMnfJodW28YBnhv/BzSew==",
+			"integrity": "sha512-eBhhW8OS/UuX3HxgzNBSVEVhSuRDh39Z1kdYkQVWna+scpgsrD7vSeBI7tmEvsguPDMnfJodW28YBnhv/BzSew==",
 			"dev": true,
 			"requires": {
 				"import-local": "^1.0.0",
@@ -3963,10 +3620,8 @@
 			"dependencies": {
 				"jest-cli": {
 					"version": "22.4.4",
-					"resolved":
-						"https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.4.tgz",
-					"integrity":
-						"sha512-I9dsgkeyjVEEZj9wrGrqlH+8OlNob9Iptyl+6L5+ToOLJmHm4JwOPatin1b2Bzp5R5YRQJ+oiedx7o1H7wJzhA==",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.4.tgz",
+					"integrity": "sha512-I9dsgkeyjVEEZj9wrGrqlH+8OlNob9Iptyl+6L5+ToOLJmHm4JwOPatin1b2Bzp5R5YRQJ+oiedx7o1H7wJzhA==",
 					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.0.0",
@@ -4009,10 +3664,8 @@
 		},
 		"jest-changed-files": {
 			"version": "22.4.3",
-			"resolved":
-				"https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.4.3.tgz",
-			"integrity":
-				"sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.4.3.tgz",
+			"integrity": "sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==",
 			"dev": true,
 			"requires": {
 				"throat": "^4.0.0"
@@ -4020,10 +3673,8 @@
 		},
 		"jest-config": {
 			"version": "22.4.4",
-			"resolved":
-				"https://registry.npmjs.org/jest-config/-/jest-config-22.4.4.tgz",
-			"integrity":
-				"sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.4.tgz",
+			"integrity": "sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
@@ -4042,8 +3693,7 @@
 		"jest-diff": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
-			"integrity":
-				"sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
+			"integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
@@ -4054,18 +3704,14 @@
 		},
 		"jest-docblock": {
 			"version": "21.2.0",
-			"resolved":
-				"https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-			"integrity":
-				"sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+			"integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
 			"dev": true
 		},
 		"jest-environment-jsdom": {
 			"version": "22.4.3",
-			"resolved":
-				"https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
-			"integrity":
-				"sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
+			"integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
 			"dev": true,
 			"requires": {
 				"jest-mock": "^22.4.3",
@@ -4075,10 +3721,8 @@
 		},
 		"jest-environment-node": {
 			"version": "22.4.3",
-			"resolved":
-				"https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
-			"integrity":
-				"sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
+			"integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
 			"dev": true,
 			"requires": {
 				"jest-mock": "^22.4.3",
@@ -4087,18 +3731,14 @@
 		},
 		"jest-get-type": {
 			"version": "22.4.3",
-			"resolved":
-				"https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-			"integrity":
-				"sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
 			"dev": true
 		},
 		"jest-haste-map": {
 			"version": "22.4.3",
-			"resolved":
-				"https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.3.tgz",
-			"integrity":
-				"sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.3.tgz",
+			"integrity": "sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
 			"dev": true,
 			"requires": {
 				"fb-watchman": "^2.0.0",
@@ -4112,10 +3752,8 @@
 			"dependencies": {
 				"jest-docblock": {
 					"version": "22.4.3",
-					"resolved":
-						"https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
-					"integrity":
-						"sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
+					"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
+					"integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
 					"dev": true,
 					"requires": {
 						"detect-newline": "^2.1.0"
@@ -4125,10 +3763,8 @@
 		},
 		"jest-jasmine2": {
 			"version": "22.4.4",
-			"resolved":
-				"https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.4.tgz",
-			"integrity":
-				"sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.4.tgz",
+			"integrity": "sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
@@ -4146,10 +3782,8 @@
 		},
 		"jest-leak-detector": {
 			"version": "22.4.3",
-			"resolved":
-				"https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
-			"integrity":
-				"sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
+			"integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
 			"dev": true,
 			"requires": {
 				"pretty-format": "^22.4.3"
@@ -4157,10 +3791,8 @@
 		},
 		"jest-matcher-utils": {
 			"version": "22.4.3",
-			"resolved":
-				"https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
-			"integrity":
-				"sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+			"integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
@@ -4170,10 +3802,8 @@
 		},
 		"jest-message-util": {
 			"version": "22.4.3",
-			"resolved":
-				"https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
-			"integrity":
-				"sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
+			"integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0-beta.35",
@@ -4186,24 +3816,19 @@
 		"jest-mock": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
-			"integrity":
-				"sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q==",
+			"integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q==",
 			"dev": true
 		},
 		"jest-regex-util": {
 			"version": "22.4.3",
-			"resolved":
-				"https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
-			"integrity":
-				"sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
+			"integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
 			"dev": true
 		},
 		"jest-resolve": {
 			"version": "22.4.3",
-			"resolved":
-				"https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
-			"integrity":
-				"sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
+			"integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
 			"dev": true,
 			"requires": {
 				"browser-resolve": "^1.11.2",
@@ -4212,10 +3837,8 @@
 		},
 		"jest-resolve-dependencies": {
 			"version": "22.4.3",
-			"resolved":
-				"https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz",
-			"integrity":
-				"sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz",
+			"integrity": "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
 			"dev": true,
 			"requires": {
 				"jest-regex-util": "^22.4.3"
@@ -4223,10 +3846,8 @@
 		},
 		"jest-runner": {
 			"version": "22.4.4",
-			"resolved":
-				"https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.4.tgz",
-			"integrity":
-				"sha512-5S/OpB51igQW9xnkM5Tgd/7ZjiAuIoiJAVtvVTBcEBiXBIFzWM3BAMPBM19FX68gRV0KWyFuGKj0EY3M3aceeQ==",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.4.tgz",
+			"integrity": "sha512-5S/OpB51igQW9xnkM5Tgd/7ZjiAuIoiJAVtvVTBcEBiXBIFzWM3BAMPBM19FX68gRV0KWyFuGKj0EY3M3aceeQ==",
 			"dev": true,
 			"requires": {
 				"exit": "^0.1.2",
@@ -4244,10 +3865,8 @@
 			"dependencies": {
 				"jest-docblock": {
 					"version": "22.4.3",
-					"resolved":
-						"https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
-					"integrity":
-						"sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
+					"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
+					"integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
 					"dev": true,
 					"requires": {
 						"detect-newline": "^2.1.0"
@@ -4257,10 +3876,8 @@
 		},
 		"jest-runtime": {
 			"version": "22.4.4",
-			"resolved":
-				"https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.4.tgz",
-			"integrity":
-				"sha512-WRTj9m///npte1YjuphCYX7GRY/c2YvJImU9t7qOwFcqHr4YMzmX6evP/3Sehz5DKW2Vi8ONYPCFWe36JVXxfw==",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.4.tgz",
+			"integrity": "sha512-WRTj9m///npte1YjuphCYX7GRY/c2YvJImU9t7qOwFcqHr4YMzmX6evP/3Sehz5DKW2Vi8ONYPCFWe36JVXxfw==",
 			"dev": true,
 			"requires": {
 				"babel-core": "^6.0.0",
@@ -4287,18 +3904,14 @@
 		},
 		"jest-serializer": {
 			"version": "22.4.3",
-			"resolved":
-				"https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.3.tgz",
-			"integrity":
-				"sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw==",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.3.tgz",
+			"integrity": "sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw==",
 			"dev": true
 		},
 		"jest-snapshot": {
 			"version": "22.4.3",
-			"resolved":
-				"https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
-			"integrity":
-				"sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
+			"integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
@@ -4312,8 +3925,7 @@
 		"jest-util": {
 			"version": "22.4.3",
 			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
-			"integrity":
-				"sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
+			"integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
 			"dev": true,
 			"requires": {
 				"callsites": "^2.0.0",
@@ -4327,27 +3939,22 @@
 			"dependencies": {
 				"callsites": {
 					"version": "2.0.0",
-					"resolved":
-						"https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
 					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
 					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
-					"resolved":
-						"https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity":
-						"sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				}
 			}
 		},
 		"jest-validate": {
 			"version": "22.4.4",
-			"resolved":
-				"https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.4.tgz",
-			"integrity":
-				"sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.4.tgz",
+			"integrity": "sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
@@ -4359,10 +3966,8 @@
 		},
 		"jest-worker": {
 			"version": "22.4.3",
-			"resolved":
-				"https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
-			"integrity":
-				"sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
+			"integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
 			"dev": true,
 			"requires": {
 				"merge-stream": "^1.0.1"
@@ -4377,8 +3982,7 @@
 		"js-yaml": {
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-			"integrity":
-				"sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -4395,8 +3999,7 @@
 		"jsdom": {
 			"version": "11.11.0",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.11.0.tgz",
-			"integrity":
-				"sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
+			"integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
 			"dev": true,
 			"requires": {
 				"abab": "^1.0.4",
@@ -4435,30 +4038,25 @@
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
-			"resolved":
-				"https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity":
-				"sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
 			"dev": true
 		},
 		"json-schema": {
 			"version": "0.2.3",
-			"resolved":
-				"https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
 			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
 			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
-			"resolved":
-				"https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
 			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
 			"dev": true
 		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 			"dev": true,
 			"requires": {
@@ -4467,15 +4065,13 @@
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
 			"dev": true
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
-			"resolved":
-				"https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
 		},
@@ -4514,8 +4110,7 @@
 		},
 		"lazy-cache": {
 			"version": "1.0.4",
-			"resolved":
-				"https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
 			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
 			"dev": true,
 			"optional": true
@@ -4532,8 +4127,7 @@
 		"left-pad": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-			"integrity":
-				"sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
 			"dev": true
 		},
 		"leven": {
@@ -4554,10 +4148,8 @@
 		},
 		"lint-staged": {
 			"version": "7.2.0",
-			"resolved":
-				"https://registry.npmjs.org/lint-staged/-/lint-staged-7.2.0.tgz",
-			"integrity":
-				"sha512-jPoIMbmgtWMUrz/l0rhBVa1j6H71zr0rEoxDWBA333PZcaqBvELdg0Sf4tdGHlwrBM0GXaXMVgTRkLTm2vA7Jg==",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-7.2.0.tgz",
+			"integrity": "sha512-jPoIMbmgtWMUrz/l0rhBVa1j6H71zr0rEoxDWBA333PZcaqBvELdg0Sf4tdGHlwrBM0GXaXMVgTRkLTm2vA7Jg==",
 			"dev": true,
 			"requires": {
 				"app-root-path": "^2.0.1",
@@ -4587,17 +4179,14 @@
 			"dependencies": {
 				"ansi-regex": {
 					"version": "3.0.0",
-					"resolved":
-						"https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
-					"resolved":
-						"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity":
-						"sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
@@ -4605,23 +4194,20 @@
 				},
 				"arr-diff": {
 					"version": "4.0.0",
-					"resolved":
-						"https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
 					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
 					"dev": true
 				},
 				"array-unique": {
 					"version": "0.3.2",
-					"resolved":
-						"https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 					"dev": true
 				},
 				"braces": {
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity":
-						"sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.1.0",
@@ -4638,8 +4224,7 @@
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved":
-								"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
@@ -4651,8 +4236,7 @@
 				"execa": {
 					"version": "0.9.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
-					"integrity":
-						"sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
+					"integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
@@ -4666,8 +4250,7 @@
 				},
 				"expand-brackets": {
 					"version": "2.1.4",
-					"resolved":
-						"https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
@@ -4683,8 +4266,7 @@
 						"debug": {
 							"version": "2.6.9",
 							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-							"integrity":
-								"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 							"dev": true,
 							"requires": {
 								"ms": "2.0.0"
@@ -4692,8 +4274,7 @@
 						},
 						"define-property": {
 							"version": "0.2.5",
-							"resolved":
-								"https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
@@ -4702,8 +4283,7 @@
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved":
-								"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
@@ -4712,8 +4292,7 @@
 						},
 						"is-accessor-descriptor": {
 							"version": "0.1.6",
-							"resolved":
-								"https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
@@ -4722,8 +4301,7 @@
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
-									"resolved":
-										"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
@@ -4734,8 +4312,7 @@
 						},
 						"is-data-descriptor": {
 							"version": "0.1.4",
-							"resolved":
-								"https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
@@ -4744,8 +4321,7 @@
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
-									"resolved":
-										"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
@@ -4756,10 +4332,8 @@
 						},
 						"is-descriptor": {
 							"version": "0.1.6",
-							"resolved":
-								"https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity":
-								"sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^0.1.6",
@@ -4769,10 +4343,8 @@
 						},
 						"kind-of": {
 							"version": "5.1.0",
-							"resolved":
-								"https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity":
-								"sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
 							"dev": true
 						}
 					}
@@ -4780,8 +4352,7 @@
 				"extglob": {
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity":
-						"sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
 						"array-unique": "^0.3.2",
@@ -4796,8 +4367,7 @@
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
-							"resolved":
-								"https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
@@ -4806,8 +4376,7 @@
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved":
-								"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
@@ -4818,8 +4387,7 @@
 				},
 				"fill-range": {
 					"version": "4.0.0",
-					"resolved":
-						"https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
@@ -4831,8 +4399,7 @@
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved":
-								"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
@@ -4843,10 +4410,8 @@
 				},
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -4854,10 +4419,8 @@
 				},
 				"is-data-descriptor": {
 					"version": "1.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -4865,10 +4428,8 @@
 				},
 				"is-descriptor": {
 					"version": "1.0.2",
-					"resolved":
-						"https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity":
-						"sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -4878,8 +4439,7 @@
 				},
 				"is-extglob": {
 					"version": "2.1.1",
-					"resolved":
-						"https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
 					"dev": true
 				},
@@ -4894,8 +4454,7 @@
 				},
 				"is-number": {
 					"version": "3.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
@@ -4904,8 +4463,7 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "3.2.2",
-							"resolved":
-								"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
@@ -4916,15 +4474,13 @@
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"dev": true
 				},
 				"jest-validate": {
 					"version": "23.2.0",
-					"resolved":
-						"https://registry.npmjs.org/jest-validate/-/jest-validate-23.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.2.0.tgz",
 					"integrity": "sha1-Z8i5CeEa8XAXZSOIlMZ6wykbGV4=",
 					"dev": true,
 					"requires": {
@@ -4937,16 +4493,13 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity":
-						"sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
 					"dev": true
 				},
 				"micromatch": {
 					"version": "3.1.10",
-					"resolved":
-						"https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity":
-						"sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
@@ -4972,8 +4525,7 @@
 				},
 				"pretty-format": {
 					"version": "23.2.0",
-					"resolved":
-						"https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
 					"integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
 					"dev": true,
 					"requires": {
@@ -4986,8 +4538,7 @@
 		"listr": {
 			"version": "0.14.1",
 			"resolved": "https://registry.npmjs.org/listr/-/listr-0.14.1.tgz",
-			"integrity":
-				"sha512-MSMUUVN1f8aRnPi4034RkOqdiUlpYW+FqwFE3aL0uYNPRavkt2S2SsSpDDofn8BDpqv2RNnsdOcCHWsChcq77A==",
+			"integrity": "sha512-MSMUUVN1f8aRnPi4034RkOqdiUlpYW+FqwFE3aL0uYNPRavkt2S2SsSpDDofn8BDpqv2RNnsdOcCHWsChcq77A==",
 			"dev": true,
 			"requires": {
 				"@samverschueren/stream-to-observable": "^0.3.0",
@@ -5033,8 +4584,7 @@
 				},
 				"log-symbols": {
 					"version": "1.0.2",
-					"resolved":
-						"https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 					"dev": true,
 					"requires": {
@@ -5043,8 +4593,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
@@ -5055,15 +4604,13 @@
 		},
 		"listr-silent-renderer": {
 			"version": "1.1.1",
-			"resolved":
-				"https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
 			"integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
 			"dev": true
 		},
 		"listr-update-renderer": {
 			"version": "0.4.0",
-			"resolved":
-				"https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
 			"integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
 			"dev": true,
 			"requires": {
@@ -5102,15 +4649,13 @@
 				},
 				"indent-string": {
 					"version": "3.2.0",
-					"resolved":
-						"https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
 					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
 					"dev": true
 				},
 				"log-symbols": {
 					"version": "1.0.2",
-					"resolved":
-						"https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 					"dev": true,
 					"requires": {
@@ -5119,8 +4664,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
@@ -5131,8 +4675,7 @@
 		},
 		"listr-verbose-renderer": {
 			"version": "0.4.1",
-			"resolved":
-				"https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+			"resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
 			"integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
 			"dev": true,
 			"requires": {
@@ -5157,8 +4700,7 @@
 				},
 				"cli-cursor": {
 					"version": "1.0.2",
-					"resolved":
-						"https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"dev": true,
 					"requires": {
@@ -5183,8 +4725,7 @@
 				},
 				"restore-cursor": {
 					"version": "1.0.1",
-					"resolved":
-						"https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"dev": true,
 					"requires": {
@@ -5194,8 +4735,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
@@ -5206,8 +4746,7 @@
 		},
 		"load-json-file": {
 			"version": "1.1.0",
-			"resolved":
-				"https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"dev": true,
 			"requires": {
@@ -5220,8 +4759,7 @@
 			"dependencies": {
 				"strip-bom": {
 					"version": "2.0.0",
-					"resolved":
-						"https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
@@ -5232,8 +4770,7 @@
 		},
 		"locate-path": {
 			"version": "2.0.0",
-			"resolved":
-				"https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"dev": true,
 			"requires": {
@@ -5244,23 +4781,19 @@
 		"lodash": {
 			"version": "4.17.10",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-			"integrity":
-				"sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
 			"dev": true
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
-			"resolved":
-				"https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
 		},
 		"log-symbols": {
 			"version": "2.2.0",
-			"resolved":
-				"https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-			"integrity":
-				"sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1"
@@ -5268,8 +4801,7 @@
 		},
 		"log-update": {
 			"version": "1.0.2",
-			"resolved":
-				"https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
 			"integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
 			"dev": true,
 			"requires": {
@@ -5279,15 +4811,13 @@
 			"dependencies": {
 				"ansi-escapes": {
 					"version": "1.4.0",
-					"resolved":
-						"https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
 					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
 					"dev": true
 				},
 				"cli-cursor": {
 					"version": "1.0.2",
-					"resolved":
-						"https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"dev": true,
 					"requires": {
@@ -5302,8 +4832,7 @@
 				},
 				"restore-cursor": {
 					"version": "1.0.1",
-					"resolved":
-						"https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"dev": true,
 					"requires": {
@@ -5316,8 +4845,7 @@
 		"lolex": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz",
-			"integrity":
-				"sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg==",
+			"integrity": "sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg==",
 			"dev": true
 		},
 		"longest": {
@@ -5328,8 +4856,7 @@
 		},
 		"loose-envify": {
 			"version": "1.3.1",
-			"resolved":
-				"https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
 			"dev": true,
 			"requires": {
@@ -5339,8 +4866,7 @@
 		"lru-cache": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-			"integrity":
-				"sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 			"dev": true,
 			"requires": {
 				"pseudomap": "^1.0.2",
@@ -5373,15 +4899,13 @@
 		},
 		"math-random": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
 			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
 			"dev": true
 		},
 		"media-typer": {
 			"version": "0.3.0",
-			"resolved":
-				"https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
 			"dev": true
 		},
@@ -5402,15 +4926,13 @@
 		},
 		"merge-descriptors": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
 			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
 			"dev": true
 		},
 		"merge-stream": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
 			"dev": true,
 			"requires": {
@@ -5425,8 +4947,7 @@
 		},
 		"micromatch": {
 			"version": "2.3.11",
-			"resolved":
-				"https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"dev": true,
 			"requires": {
@@ -5447,8 +4968,7 @@
 			"dependencies": {
 				"normalize-path": {
 					"version": "2.1.1",
-					"resolved":
-						"https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"dev": true,
 					"requires": {
@@ -5460,23 +4980,19 @@
 		"mime": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-			"integrity":
-				"sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
 			"dev": true
 		},
 		"mime-db": {
 			"version": "1.33.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-			"integrity":
-				"sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
 			"dev": true
 		},
 		"mime-types": {
 			"version": "2.1.18",
-			"resolved":
-				"https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-			"integrity":
-				"sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"dev": true,
 			"requires": {
 				"mime-db": "~1.33.0"
@@ -5485,15 +5001,13 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity":
-				"sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
 			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity":
-				"sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
@@ -5507,10 +5021,8 @@
 		},
 		"mixin-deep": {
 			"version": "1.3.1",
-			"resolved":
-				"https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-			"integrity":
-				"sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 			"dev": true,
 			"requires": {
 				"for-in": "^1.0.2",
@@ -5519,10 +5031,8 @@
 			"dependencies": {
 				"is-extendable": {
 					"version": "1.0.1",
-					"resolved":
-						"https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-					"integrity":
-						"sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
@@ -5547,24 +5057,21 @@
 		},
 		"mute-stream": {
 			"version": "0.0.7",
-			"resolved":
-				"https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
 			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
 			"dev": true
 		},
 		"nan": {
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-			"integrity":
-				"sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
 			"dev": true,
 			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-			"integrity":
-				"sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
 			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
@@ -5582,54 +5089,46 @@
 			"dependencies": {
 				"arr-diff": {
 					"version": "4.0.0",
-					"resolved":
-						"https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
 					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
 					"dev": true
 				},
 				"array-unique": {
 					"version": "0.3.2",
-					"resolved":
-						"https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 					"dev": true
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity":
-						"sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
 					"dev": true
 				}
 			}
 		},
 		"natural-compare": {
 			"version": "1.4.0",
-			"resolved":
-				"https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
 		"negotiator": {
 			"version": "0.6.1",
-			"resolved":
-				"https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
 			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
 			"dev": true
 		},
 		"node-int64": {
 			"version": "0.4.0",
-			"resolved":
-				"https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
 			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
 			"dev": true
 		},
 		"node-notifier": {
 			"version": "5.2.1",
-			"resolved":
-				"https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
-			"integrity":
-				"sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
 			"dev": true,
 			"requires": {
 				"growly": "^1.3.0",
@@ -5640,10 +5139,8 @@
 		},
 		"normalize-package-data": {
 			"version": "2.4.0",
-			"resolved":
-				"https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity":
-				"sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
@@ -5654,16 +5151,14 @@
 		},
 		"normalize-path": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
 			"integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
 			"dev": true
 		},
 		"npm-path": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
-			"integrity":
-				"sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
+			"integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
 			"dev": true,
 			"requires": {
 				"which": "^1.2.10"
@@ -5671,8 +5166,7 @@
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
-			"resolved":
-				"https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
@@ -5692,36 +5186,31 @@
 		},
 		"number-is-nan": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 			"dev": true
 		},
 		"nwsapi": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.4.tgz",
-			"integrity":
-				"sha512-Zt6HRR6RcJkuj5/N9zeE7FN6YitRW//hK2wTOwX274IBphbY3Zf5+yn5mZ9v/SzAOTMjQNxZf9KkmPLWn0cV4g==",
+			"integrity": "sha512-Zt6HRR6RcJkuj5/N9zeE7FN6YitRW//hK2wTOwX274IBphbY3Zf5+yn5mZ9v/SzAOTMjQNxZf9KkmPLWn0cV4g==",
 			"dev": true
 		},
 		"oauth-sign": {
 			"version": "0.8.2",
-			"resolved":
-				"https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
 			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
 			"dev": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
-			"resolved":
-				"https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 			"dev": true
 		},
 		"object-copy": {
 			"version": "0.1.0",
-			"resolved":
-				"https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"dev": true,
 			"requires": {
@@ -5732,8 +5221,7 @@
 			"dependencies": {
 				"define-property": {
 					"version": "0.2.5",
-					"resolved":
-						"https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
@@ -5744,16 +5232,13 @@
 		},
 		"object-keys": {
 			"version": "1.0.12",
-			"resolved":
-				"https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-			"integrity":
-				"sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
 			"dev": true
 		},
 		"object-visit": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"dev": true,
 			"requires": {
@@ -5762,8 +5247,7 @@
 			"dependencies": {
 				"isobject": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"dev": true
 				}
@@ -5771,8 +5255,7 @@
 		},
 		"object.getownpropertydescriptors": {
 			"version": "2.0.3",
-			"resolved":
-				"https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
 			"dev": true,
 			"requires": {
@@ -5782,8 +5265,7 @@
 		},
 		"object.omit": {
 			"version": "2.0.1",
-			"resolved":
-				"https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"dev": true,
 			"requires": {
@@ -5793,8 +5275,7 @@
 		},
 		"object.pick": {
 			"version": "1.3.0",
-			"resolved":
-				"https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"dev": true,
 			"requires": {
@@ -5803,8 +5284,7 @@
 			"dependencies": {
 				"isobject": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"dev": true
 				}
@@ -5812,8 +5292,7 @@
 		},
 		"on-finished": {
 			"version": "2.3.0",
-			"resolved":
-				"https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
 			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
 			"dev": true,
 			"requires": {
@@ -5850,8 +5329,7 @@
 			"dependencies": {
 				"wordwrap": {
 					"version": "0.0.3",
-					"resolved":
-						"https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
 					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
 					"dev": true
 				}
@@ -5859,8 +5337,7 @@
 		},
 		"optionator": {
 			"version": "0.8.2",
-			"resolved":
-				"https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
@@ -5899,8 +5376,7 @@
 				},
 				"cli-cursor": {
 					"version": "1.0.2",
-					"resolved":
-						"https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"dev": true,
 					"requires": {
@@ -5915,8 +5391,7 @@
 				},
 				"restore-cursor": {
 					"version": "1.0.1",
-					"resolved":
-						"https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"dev": true,
 					"requires": {
@@ -5926,8 +5401,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
@@ -5938,16 +5412,14 @@
 		},
 		"os-homedir": {
 			"version": "1.0.2",
-			"resolved":
-				"https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 			"dev": true
 		},
 		"os-locale": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-			"integrity":
-				"sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 			"dev": true,
 			"requires": {
 				"execa": "^0.7.0",
@@ -5970,8 +5442,7 @@
 		"p-limit": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity":
-				"sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 			"dev": true,
 			"requires": {
 				"p-try": "^1.0.0"
@@ -5989,8 +5460,7 @@
 		"p-map": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-			"integrity":
-				"sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
 			"dev": true
 		},
 		"p-try": {
@@ -6001,8 +5471,7 @@
 		},
 		"parse-glob": {
 			"version": "3.0.4",
-			"resolved":
-				"https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"dev": true,
 			"requires": {
@@ -6014,8 +5483,7 @@
 		},
 		"parse-json": {
 			"version": "2.2.0",
-			"resolved":
-				"https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"dev": true,
 			"requires": {
@@ -6025,8 +5493,7 @@
 		"parse5": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-			"integrity":
-				"sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
 			"dev": true
 		},
 		"parseurl": {
@@ -6037,29 +5504,25 @@
 		},
 		"pascalcase": {
 			"version": "0.1.1",
-			"resolved":
-				"https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
 			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
 			"dev": true
 		},
 		"path-exists": {
 			"version": "3.0.0",
-			"resolved":
-				"https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
 			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
 			"dev": true
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
-			"resolved":
-				"https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
 			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
 			"dev": true
 		},
@@ -6071,15 +5534,13 @@
 		},
 		"path-parse": {
 			"version": "1.0.5",
-			"resolved":
-				"https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
 			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
 			"dev": true
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
-			"resolved":
-				"https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
 			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
 			"dev": true
 		},
@@ -6096,8 +5557,7 @@
 		},
 		"performance-now": {
 			"version": "2.1.0",
-			"resolved":
-				"https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
 			"dev": true
 		},
@@ -6115,8 +5575,7 @@
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
-			"resolved":
-				"https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"dev": true,
 			"requires": {
@@ -6134,10 +5593,8 @@
 		},
 		"please-upgrade-node": {
 			"version": "3.0.2",
-			"resolved":
-				"https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.0.2.tgz",
-			"integrity":
-				"sha512-bslfSeW+ksUbB/sYZeEdKFyTG4YWU9YKRvqfSRvZKE675khAuBUPqV5RUwJZaGuWmVQLweK45Q+lPHFVnSlSug==",
+			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.0.2.tgz",
+			"integrity": "sha512-bslfSeW+ksUbB/sYZeEdKFyTG4YWU9YKRvqfSRvZKE675khAuBUPqV5RUwJZaGuWmVQLweK45Q+lPHFVnSlSug==",
 			"dev": true,
 			"requires": {
 				"semver-compare": "^1.0.0"
@@ -6146,28 +5603,24 @@
 		"pluralize": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity":
-				"sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
 			"dev": true
 		},
 		"pn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-			"integrity":
-				"sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
 			"dev": true
 		},
 		"posix-character-classes": {
 			"version": "0.1.1",
-			"resolved":
-				"https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
 			"dev": true
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
-			"resolved":
-				"https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
 			"dev": true
 		},
@@ -6178,18 +5631,15 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.11.1.tgz",
-			"integrity":
-				"sha512-T/KD65Ot0PB97xTrG8afQ46x3oiVhnfGjGESSI9NWYcG92+OUPZKkwHqGWXH2t9jK1crnQjubECW0FuOth+hxw==",
+			"version": "1.14.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.2.tgz",
+			"integrity": "sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg==",
 			"dev": true
 		},
 		"pretty-format": {
 			"version": "22.4.3",
-			"resolved":
-				"https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
-			"integrity":
-				"sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+			"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
 			"dev": true,
 			"requires": {
 				"ansi-regex": "^3.0.0",
@@ -6198,17 +5648,14 @@
 			"dependencies": {
 				"ansi-regex": {
 					"version": "3.0.0",
-					"resolved":
-						"https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
-					"resolved":
-						"https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity":
-						"sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
@@ -6219,16 +5666,13 @@
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity":
-				"sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
 			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
-			"resolved":
-				"https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity":
-				"sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 			"dev": true
 		},
 		"progress": {
@@ -6239,10 +5683,8 @@
 		},
 		"proxy-addr": {
 			"version": "2.0.3",
-			"resolved":
-				"https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
-			"integrity":
-				"sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+			"integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
 			"dev": true,
 			"requires": {
 				"forwarded": "~0.1.2",
@@ -6258,30 +5700,25 @@
 		"psl": {
 			"version": "1.1.28",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.28.tgz",
-			"integrity":
-				"sha512-+AqO1Ae+N/4r7Rvchrdm432afjT9hqJRyBN3DQv9At0tPz4hIFSGKbq64fN9dVoCow4oggIIax5/iONx0r9hZw==",
+			"integrity": "sha512-+AqO1Ae+N/4r7Rvchrdm432afjT9hqJRyBN3DQv9At0tPz4hIFSGKbq64fN9dVoCow4oggIIax5/iONx0r9hZw==",
 			"dev": true
 		},
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity":
-				"sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
 		"qs": {
 			"version": "6.5.1",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-			"integrity":
-				"sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
 			"dev": true
 		},
 		"randomatic": {
 			"version": "3.0.0",
-			"resolved":
-				"https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-			"integrity":
-				"sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+			"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
 			"dev": true,
 			"requires": {
 				"is-number": "^4.0.0",
@@ -6291,25 +5728,21 @@
 			"dependencies": {
 				"is-number": {
 					"version": "4.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity":
-						"sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
 					"dev": true
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity":
-						"sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
 					"dev": true
 				}
 			}
 		},
 		"range-parser": {
 			"version": "1.2.0",
-			"resolved":
-				"https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
 			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
 			"dev": true
 		},
@@ -6333,8 +5766,7 @@
 				},
 				"http-errors": {
 					"version": "1.6.2",
-					"resolved":
-						"https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
 					"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
 					"dev": true,
 					"requires": {
@@ -6346,16 +5778,13 @@
 				},
 				"iconv-lite": {
 					"version": "0.4.19",
-					"resolved":
-						"https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-					"integrity":
-						"sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
 					"dev": true
 				},
 				"setprototypeof": {
 					"version": "1.0.3",
-					"resolved":
-						"https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
 					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
 					"dev": true
 				}
@@ -6374,8 +5803,7 @@
 		},
 		"read-pkg-up": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"dev": true,
 			"requires": {
@@ -6395,8 +5823,7 @@
 				},
 				"path-exists": {
 					"version": "2.1.0",
-					"resolved":
-						"https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
@@ -6407,10 +5834,8 @@
 		},
 		"readable-stream": {
 			"version": "2.3.6",
-			"resolved":
-				"https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-			"integrity":
-				"sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
@@ -6424,10 +5849,8 @@
 		},
 		"realpath-native": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
-			"integrity":
-				"sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
+			"integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
 			"dev": true,
 			"requires": {
 				"util.promisify": "^1.0.0"
@@ -6435,18 +5858,14 @@
 		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
-			"resolved":
-				"https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity":
-				"sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
 			"dev": true
 		},
 		"regex-cache": {
 			"version": "0.4.4",
-			"resolved":
-				"https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-			"integrity":
-				"sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"dev": true,
 			"requires": {
 				"is-equal-shallow": "^0.1.3"
@@ -6455,8 +5874,7 @@
 		"regex-not": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-			"integrity":
-				"sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.2",
@@ -6466,28 +5884,24 @@
 		"regexpp": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-			"integrity":
-				"sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+			"integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
 			"dev": true
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
-			"resolved":
-				"https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
 			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
 			"dev": true
 		},
 		"repeat-element": {
 			"version": "1.1.2",
-			"resolved":
-				"https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
 			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
 			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
-			"resolved":
-				"https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
 			"dev": true
 		},
@@ -6503,8 +5917,7 @@
 		"request": {
 			"version": "2.87.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-			"integrity":
-				"sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
 			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
@@ -6531,17 +5944,14 @@
 			"dependencies": {
 				"punycode": {
 					"version": "1.4.1",
-					"resolved":
-						"https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
 					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
 					"dev": true
 				},
 				"tough-cookie": {
 					"version": "2.3.4",
-					"resolved":
-						"https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-					"integrity":
-						"sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+					"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 					"dev": true,
 					"requires": {
 						"punycode": "^1.4.1"
@@ -6551,8 +5961,7 @@
 		},
 		"request-promise-core": {
 			"version": "1.1.1",
-			"resolved":
-				"https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
 			"dev": true,
 			"requires": {
@@ -6561,8 +5970,7 @@
 		},
 		"request-promise-native": {
 			"version": "1.0.5",
-			"resolved":
-				"https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
 			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
 			"dev": true,
 			"requires": {
@@ -6573,22 +5981,19 @@
 		},
 		"require-directory": {
 			"version": "2.1.1",
-			"resolved":
-				"https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
 			"dev": true
 		},
 		"require-uncached": {
 			"version": "1.0.3",
-			"resolved":
-				"https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"dev": true,
 			"requires": {
@@ -6604,8 +6009,7 @@
 		},
 		"resolve-cwd": {
 			"version": "2.0.0",
-			"resolved":
-				"https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"dev": true,
 			"requires": {
@@ -6614,8 +6018,7 @@
 			"dependencies": {
 				"resolve-from": {
 					"version": "3.0.0",
-					"resolved":
-						"https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
 					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
 					"dev": true
 				}
@@ -6623,22 +6026,19 @@
 		},
 		"resolve-from": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
 			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
 			"dev": true
 		},
 		"resolve-url": {
 			"version": "0.2.1",
-			"resolved":
-				"https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 			"dev": true
 		},
 		"restore-cursor": {
 			"version": "2.0.0",
-			"resolved":
-				"https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"dev": true,
 			"requires": {
@@ -6649,14 +6049,12 @@
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity":
-				"sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
 			"dev": true
 		},
 		"right-align": {
 			"version": "0.1.3",
-			"resolved":
-				"https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
 			"dev": true,
 			"optional": true,
@@ -6667,8 +6065,7 @@
 		"rimraf": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-			"integrity":
-				"sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.0.5"
@@ -6677,8 +6074,7 @@
 		"rsvp": {
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-			"integrity":
-				"sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+			"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
 			"dev": true
 		},
 		"run-async": {
@@ -6698,8 +6094,7 @@
 		},
 		"rx-lite-aggregates": {
 			"version": "4.0.8",
-			"resolved":
-				"https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
 			"dev": true,
 			"requires": {
@@ -6709,8 +6104,7 @@
 		"rxjs": {
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.1.tgz",
-			"integrity":
-				"sha512-OwMxHxmnmHTUpgO+V7dZChf3Tixf4ih95cmXjzzadULziVl/FKhHScGLj4goEw9weePVOH2Q0+GcCBUhKCZc/g==",
+			"integrity": "sha512-OwMxHxmnmHTUpgO+V7dZChf3Tixf4ih95cmXjzzadULziVl/FKhHScGLj4goEw9weePVOH2Q0+GcCBUhKCZc/g==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
@@ -6718,16 +6112,13 @@
 		},
 		"safe-buffer": {
 			"version": "5.1.2",
-			"resolved":
-				"https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity":
-				"sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true
 		},
 		"safe-regex": {
 			"version": "1.1.0",
-			"resolved":
-				"https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
@@ -6736,10 +6127,8 @@
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
-			"resolved":
-				"https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity":
-				"sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
 		"sane": {
@@ -6761,23 +6150,20 @@
 			"dependencies": {
 				"arr-diff": {
 					"version": "4.0.0",
-					"resolved":
-						"https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
 					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
 					"dev": true
 				},
 				"array-unique": {
 					"version": "0.3.2",
-					"resolved":
-						"https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 					"dev": true
 				},
 				"braces": {
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity":
-						"sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.1.0",
@@ -6794,8 +6180,7 @@
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved":
-								"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
@@ -6807,8 +6192,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -6816,8 +6200,7 @@
 				},
 				"expand-brackets": {
 					"version": "2.1.4",
-					"resolved":
-						"https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
@@ -6832,8 +6215,7 @@
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
-							"resolved":
-								"https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
@@ -6842,8 +6224,7 @@
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved":
-								"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
@@ -6852,8 +6233,7 @@
 						},
 						"is-accessor-descriptor": {
 							"version": "0.1.6",
-							"resolved":
-								"https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
@@ -6862,8 +6242,7 @@
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
-									"resolved":
-										"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
@@ -6874,8 +6253,7 @@
 						},
 						"is-data-descriptor": {
 							"version": "0.1.4",
-							"resolved":
-								"https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
@@ -6884,8 +6262,7 @@
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
-									"resolved":
-										"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
@@ -6896,10 +6273,8 @@
 						},
 						"is-descriptor": {
 							"version": "0.1.6",
-							"resolved":
-								"https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity":
-								"sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^0.1.6",
@@ -6909,10 +6284,8 @@
 						},
 						"kind-of": {
 							"version": "5.1.0",
-							"resolved":
-								"https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity":
-								"sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
 							"dev": true
 						}
 					}
@@ -6920,8 +6293,7 @@
 				"extglob": {
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity":
-						"sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
 						"array-unique": "^0.3.2",
@@ -6936,8 +6308,7 @@
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
-							"resolved":
-								"https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
@@ -6946,8 +6317,7 @@
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved":
-								"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
@@ -6958,8 +6328,7 @@
 				},
 				"fill-range": {
 					"version": "4.0.0",
-					"resolved":
-						"https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
@@ -6971,8 +6340,7 @@
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved":
-								"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
@@ -6983,10 +6351,8 @@
 				},
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -6994,10 +6360,8 @@
 				},
 				"is-data-descriptor": {
 					"version": "1.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -7005,10 +6369,8 @@
 				},
 				"is-descriptor": {
 					"version": "1.0.2",
-					"resolved":
-						"https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity":
-						"sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -7018,8 +6380,7 @@
 				},
 				"is-number": {
 					"version": "3.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
@@ -7028,8 +6389,7 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "3.2.2",
-							"resolved":
-								"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
@@ -7040,24 +6400,20 @@
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"dev": true
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity":
-						"sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
 					"dev": true
 				},
 				"micromatch": {
 					"version": "3.1.10",
-					"resolved":
-						"https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity":
-						"sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
@@ -7077,8 +6433,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved":
-						"https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				}
@@ -7087,29 +6442,25 @@
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity":
-				"sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 			"dev": true
 		},
 		"semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity":
-				"sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
 			"dev": true
 		},
 		"semver-compare": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
 			"integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
 			"dev": true
 		},
 		"send": {
 			"version": "0.16.2",
 			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-			"integrity":
-				"sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
 			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
@@ -7130,8 +6481,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -7141,10 +6491,8 @@
 		},
 		"serve-static": {
 			"version": "1.13.2",
-			"resolved":
-				"https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-			"integrity":
-				"sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
 			"dev": true,
 			"requires": {
 				"encodeurl": "~1.0.2",
@@ -7155,16 +6503,14 @@
 		},
 		"set-blocking": {
 			"version": "2.0.0",
-			"resolved":
-				"https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 			"dev": true
 		},
 		"set-value": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-			"integrity":
-				"sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -7175,8 +6521,7 @@
 			"dependencies": {
 				"extend-shallow": {
 					"version": "2.0.1",
-					"resolved":
-						"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
@@ -7187,16 +6532,13 @@
 		},
 		"setprototypeof": {
 			"version": "1.1.0",
-			"resolved":
-				"https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-			"integrity":
-				"sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
 			"dev": true
 		},
 		"shebang-command": {
 			"version": "1.2.0",
-			"resolved":
-				"https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
@@ -7205,23 +6547,19 @@
 		},
 		"shebang-regex": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 			"dev": true
 		},
 		"shellwords": {
 			"version": "0.1.1",
-			"resolved":
-				"https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-			"integrity":
-				"sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
 			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.2",
-			"resolved":
-				"https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 			"dev": true
 		},
@@ -7233,10 +6571,8 @@
 		},
 		"slice-ansi": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-			"integrity":
-				"sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
 			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0"
@@ -7244,10 +6580,8 @@
 		},
 		"snapdragon": {
 			"version": "0.8.2",
-			"resolved":
-				"https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-			"integrity":
-				"sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"dev": true,
 			"requires": {
 				"base": "^0.11.1",
@@ -7263,8 +6597,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -7272,8 +6605,7 @@
 				},
 				"define-property": {
 					"version": "0.2.5",
-					"resolved":
-						"https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
@@ -7282,8 +6614,7 @@
 				},
 				"extend-shallow": {
 					"version": "2.0.1",
-					"resolved":
-						"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
@@ -7294,10 +6625,8 @@
 		},
 		"snapdragon-node": {
 			"version": "2.1.1",
-			"resolved":
-				"https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-			"integrity":
-				"sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"dev": true,
 			"requires": {
 				"define-property": "^1.0.0",
@@ -7307,8 +6636,7 @@
 			"dependencies": {
 				"define-property": {
 					"version": "1.0.0",
-					"resolved":
-						"https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
@@ -7317,10 +6645,8 @@
 				},
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -7328,10 +6654,8 @@
 				},
 				"is-data-descriptor": {
 					"version": "1.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -7339,10 +6663,8 @@
 				},
 				"is-descriptor": {
 					"version": "1.0.2",
-					"resolved":
-						"https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity":
-						"sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -7352,26 +6674,22 @@
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"dev": true
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity":
-						"sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
 					"dev": true
 				}
 			}
 		},
 		"snapdragon-util": {
 			"version": "3.0.1",
-			"resolved":
-				"https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-			"integrity":
-				"sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"dev": true,
 			"requires": {
 				"kind-of": "^3.2.0"
@@ -7379,17 +6697,14 @@
 		},
 		"source-map": {
 			"version": "0.5.7",
-			"resolved":
-				"https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
 			"dev": true
 		},
 		"source-map-resolve": {
 			"version": "0.5.2",
-			"resolved":
-				"https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-			"integrity":
-				"sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
 			"dev": true,
 			"requires": {
 				"atob": "^2.1.1",
@@ -7401,10 +6716,8 @@
 		},
 		"source-map-support": {
 			"version": "0.5.6",
-			"resolved":
-				"https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-			"integrity":
-				"sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+			"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -7413,27 +6726,22 @@
 			"dependencies": {
 				"source-map": {
 					"version": "0.6.1",
-					"resolved":
-						"https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity":
-						"sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				}
 			}
 		},
 		"source-map-url": {
 			"version": "0.4.0",
-			"resolved":
-				"https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
 			"dev": true
 		},
 		"spdx-correct": {
 			"version": "3.0.0",
-			"resolved":
-				"https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-			"integrity":
-				"sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
@@ -7442,18 +6750,14 @@
 		},
 		"spdx-exceptions": {
 			"version": "2.1.0",
-			"resolved":
-				"https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-			"integrity":
-				"sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
 			"dev": true
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.0",
-			"resolved":
-				"https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-			"integrity":
-				"sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
@@ -7462,18 +6766,14 @@
 		},
 		"spdx-license-ids": {
 			"version": "3.0.0",
-			"resolved":
-				"https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-			"integrity":
-				"sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
 			"dev": true
 		},
 		"split-string": {
 			"version": "3.1.0",
-			"resolved":
-				"https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-			"integrity":
-				"sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.0"
@@ -7481,8 +6781,7 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved":
-				"https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},
@@ -7505,23 +6804,19 @@
 		},
 		"stack-utils": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
 			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
 			"dev": true
 		},
 		"staged-git-files": {
 			"version": "1.1.1",
-			"resolved":
-				"https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.1.tgz",
-			"integrity":
-				"sha512-H89UNKr1rQJvI1c/PIR3kiAMBV23yvR7LItZiV74HWZwzt7f3YHuujJ9nJZlt58WlFox7XQsOahexwk7nTe69A==",
+			"resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.1.tgz",
+			"integrity": "sha512-H89UNKr1rQJvI1c/PIR3kiAMBV23yvR7LItZiV74HWZwzt7f3YHuujJ9nJZlt58WlFox7XQsOahexwk7nTe69A==",
 			"dev": true
 		},
 		"static-extend": {
 			"version": "0.1.2",
-			"resolved":
-				"https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"dev": true,
 			"requires": {
@@ -7531,8 +6826,7 @@
 			"dependencies": {
 				"define-property": {
 					"version": "0.2.5",
-					"resolved":
-						"https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
@@ -7544,28 +6838,24 @@
 		"statuses": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-			"integrity":
-				"sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
 			"dev": true
 		},
 		"stealthy-require": {
 			"version": "1.1.1",
-			"resolved":
-				"https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
 		},
 		"string-argv": {
 			"version": "0.0.2",
-			"resolved":
-				"https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
 			"integrity": "sha1-2sMECGkMIfPDYwo/86BYd73L1zY=",
 			"dev": true
 		},
 		"string-length": {
 			"version": "2.0.0",
-			"resolved":
-				"https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
 			"dev": true,
 			"requires": {
@@ -7575,10 +6865,8 @@
 		},
 		"string-width": {
 			"version": "2.1.1",
-			"resolved":
-				"https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity":
-				"sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
@@ -7587,10 +6875,8 @@
 		},
 		"string_decoder": {
 			"version": "1.1.1",
-			"resolved":
-				"https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity":
-				"sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
@@ -7598,10 +6884,8 @@
 		},
 		"stringify-object": {
 			"version": "3.2.2",
-			"resolved":
-				"https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.2.tgz",
-			"integrity":
-				"sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
+			"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.2.tgz",
+			"integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
 			"dev": true,
 			"requires": {
 				"get-own-enumerable-property-symbols": "^2.0.1",
@@ -7611,8 +6895,7 @@
 		},
 		"strip-ansi": {
 			"version": "4.0.0",
-			"resolved":
-				"https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 			"dev": true,
 			"requires": {
@@ -7621,8 +6904,7 @@
 			"dependencies": {
 				"ansi-regex": {
 					"version": "3.0.0",
-					"resolved":
-						"https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
 				}
@@ -7642,45 +6924,38 @@
 		},
 		"strip-indent": {
 			"version": "2.0.0",
-			"resolved":
-				"https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
 			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
 			"dev": true
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
-			"resolved":
-				"https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 			"dev": true
 		},
 		"supports-color": {
 			"version": "2.0.0",
-			"resolved":
-				"https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
 			"dev": true
 		},
 		"symbol-observable": {
 			"version": "1.2.0",
-			"resolved":
-				"https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity":
-				"sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
 			"dev": true
 		},
 		"symbol-tree": {
 			"version": "3.2.2",
-			"resolved":
-				"https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
 			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
 			"dev": true
 		},
 		"table": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-			"integrity":
-				"sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
 			"dev": true,
 			"requires": {
 				"ajv": "^5.2.3",
@@ -7701,10 +6976,8 @@
 		},
 		"test-exclude": {
 			"version": "4.2.1",
-			"resolved":
-				"https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
-			"integrity":
-				"sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
+			"integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
 			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
@@ -7716,23 +6989,20 @@
 			"dependencies": {
 				"arr-diff": {
 					"version": "4.0.0",
-					"resolved":
-						"https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
 					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
 					"dev": true
 				},
 				"array-unique": {
 					"version": "0.3.2",
-					"resolved":
-						"https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 					"dev": true
 				},
 				"braces": {
 					"version": "2.3.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity":
-						"sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.1.0",
@@ -7749,8 +7019,7 @@
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved":
-								"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
@@ -7762,8 +7031,7 @@
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity":
-						"sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -7771,8 +7039,7 @@
 				},
 				"expand-brackets": {
 					"version": "2.1.4",
-					"resolved":
-						"https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
@@ -7787,8 +7054,7 @@
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
-							"resolved":
-								"https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
@@ -7797,8 +7063,7 @@
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved":
-								"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
@@ -7807,8 +7072,7 @@
 						},
 						"is-accessor-descriptor": {
 							"version": "0.1.6",
-							"resolved":
-								"https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
@@ -7817,8 +7081,7 @@
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
-									"resolved":
-										"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
@@ -7829,8 +7092,7 @@
 						},
 						"is-data-descriptor": {
 							"version": "0.1.4",
-							"resolved":
-								"https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
@@ -7839,8 +7101,7 @@
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
-									"resolved":
-										"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
@@ -7851,10 +7112,8 @@
 						},
 						"is-descriptor": {
 							"version": "0.1.6",
-							"resolved":
-								"https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity":
-								"sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^0.1.6",
@@ -7864,10 +7123,8 @@
 						},
 						"kind-of": {
 							"version": "5.1.0",
-							"resolved":
-								"https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity":
-								"sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
 							"dev": true
 						}
 					}
@@ -7875,8 +7132,7 @@
 				"extglob": {
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity":
-						"sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
 						"array-unique": "^0.3.2",
@@ -7891,8 +7147,7 @@
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
-							"resolved":
-								"https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
@@ -7901,8 +7156,7 @@
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved":
-								"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
@@ -7913,8 +7167,7 @@
 				},
 				"fill-range": {
 					"version": "4.0.0",
-					"resolved":
-						"https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
@@ -7926,8 +7179,7 @@
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved":
-								"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
@@ -7938,10 +7190,8 @@
 				},
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -7949,10 +7199,8 @@
 				},
 				"is-data-descriptor": {
 					"version": "1.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity":
-						"sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -7960,10 +7208,8 @@
 				},
 				"is-descriptor": {
 					"version": "1.0.2",
-					"resolved":
-						"https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity":
-						"sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -7973,8 +7219,7 @@
 				},
 				"is-number": {
 					"version": "3.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
@@ -7983,8 +7228,7 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "3.2.2",
-							"resolved":
-								"https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
@@ -7995,24 +7239,20 @@
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"dev": true
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity":
-						"sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
 					"dev": true
 				},
 				"micromatch": {
 					"version": "3.1.10",
-					"resolved":
-						"https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity":
-						"sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
@@ -8034,8 +7274,7 @@
 		},
 		"text-table": {
 			"version": "0.2.0",
-			"resolved":
-				"https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 			"dev": true
 		},
@@ -8054,8 +7293,7 @@
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-			"integrity":
-				"sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
@@ -8069,15 +7307,13 @@
 		},
 		"to-fast-properties": {
 			"version": "1.0.3",
-			"resolved":
-				"https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
 			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
 			"dev": true
 		},
 		"to-object-path": {
 			"version": "0.3.0",
-			"resolved":
-				"https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"dev": true,
 			"requires": {
@@ -8087,8 +7323,7 @@
 		"to-regex": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-			"integrity":
-				"sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"dev": true,
 			"requires": {
 				"define-property": "^2.0.2",
@@ -8099,8 +7334,7 @@
 		},
 		"to-regex-range": {
 			"version": "2.1.1",
-			"resolved":
-				"https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"dev": true,
 			"requires": {
@@ -8110,8 +7344,7 @@
 			"dependencies": {
 				"is-number": {
 					"version": "3.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
@@ -8122,10 +7355,8 @@
 		},
 		"tough-cookie": {
 			"version": "2.4.3",
-			"resolved":
-				"https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-			"integrity":
-				"sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 			"dev": true,
 			"requires": {
 				"psl": "^1.1.24",
@@ -8134,8 +7365,7 @@
 			"dependencies": {
 				"punycode": {
 					"version": "1.4.1",
-					"resolved":
-						"https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
 					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
 					"dev": true
 				}
@@ -8152,22 +7382,19 @@
 		},
 		"trim-right": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
 			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
 			"dev": true
 		},
 		"tslib": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity":
-				"sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
 			"dev": true
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
-			"resolved":
-				"https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
@@ -8183,8 +7410,7 @@
 		},
 		"type-check": {
 			"version": "0.3.2",
-			"resolved":
-				"https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
@@ -8194,8 +7420,7 @@
 		"type-is": {
 			"version": "1.6.16",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-			"integrity":
-				"sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
 			"dev": true,
 			"requires": {
 				"media-typer": "0.3.0",
@@ -8204,17 +7429,14 @@
 		},
 		"typedarray": {
 			"version": "0.0.6",
-			"resolved":
-				"https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
 		},
 		"typescript": {
 			"version": "2.9.2",
-			"resolved":
-				"https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-			"integrity":
-				"sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
 			"dev": true
 		},
 		"uglify-js": {
@@ -8246,16 +7468,14 @@
 		},
 		"uglify-to-browserify": {
 			"version": "1.0.2",
-			"resolved":
-				"https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
 			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
 			"dev": true,
 			"optional": true
 		},
 		"union-value": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 			"dev": true,
 			"requires": {
@@ -8267,8 +7487,7 @@
 			"dependencies": {
 				"extend-shallow": {
 					"version": "2.0.1",
-					"resolved":
-						"https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
@@ -8277,8 +7496,7 @@
 				},
 				"set-value": {
 					"version": "0.4.3",
-					"resolved":
-						"https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 					"dev": true,
 					"requires": {
@@ -8298,8 +7516,7 @@
 		},
 		"unset-value": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"dev": true,
 			"requires": {
@@ -8309,8 +7526,7 @@
 			"dependencies": {
 				"has-value": {
 					"version": "0.3.1",
-					"resolved":
-						"https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"dev": true,
 					"requires": {
@@ -8321,8 +7537,7 @@
 					"dependencies": {
 						"isobject": {
 							"version": "2.1.0",
-							"resolved":
-								"https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
 							"dev": true,
 							"requires": {
@@ -8333,15 +7548,13 @@
 				},
 				"has-values": {
 					"version": "0.1.4",
-					"resolved":
-						"https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
 					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
 					"dev": true
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"dev": true
 				}
@@ -8356,8 +7569,7 @@
 		"use": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-			"integrity":
-				"sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
 			"dev": true,
 			"requires": {
 				"kind-of": "^6.0.2"
@@ -8366,25 +7578,21 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity":
-						"sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
 					"dev": true
 				}
 			}
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
-			"resolved":
-				"https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 			"dev": true
 		},
 		"util.promisify": {
 			"version": "1.0.0",
-			"resolved":
-				"https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-			"integrity":
-				"sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
 			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
@@ -8393,24 +7601,20 @@
 		},
 		"utils-merge": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
 			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
 			"dev": true
 		},
 		"uuid": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity":
-				"sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.3",
-			"resolved":
-				"https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-			"integrity":
-				"sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
 			"dev": true,
 			"requires": {
 				"spdx-correct": "^3.0.0",
@@ -8436,8 +7640,7 @@
 		},
 		"w3c-hr-time": {
 			"version": "1.0.1",
-			"resolved":
-				"https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
 			"dev": true,
 			"requires": {
@@ -8465,8 +7668,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved":
-						"https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				}
@@ -8474,18 +7676,14 @@
 		},
 		"webidl-conversions": {
 			"version": "4.0.2",
-			"resolved":
-				"https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity":
-				"sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
 			"dev": true
 		},
 		"whatwg-encoding": {
 			"version": "1.0.3",
-			"resolved":
-				"https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-			"integrity":
-				"sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
+			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
 			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.19"
@@ -8493,28 +7691,22 @@
 			"dependencies": {
 				"iconv-lite": {
 					"version": "0.4.19",
-					"resolved":
-						"https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-					"integrity":
-						"sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
 					"dev": true
 				}
 			}
 		},
 		"whatwg-mimetype": {
 			"version": "2.1.0",
-			"resolved":
-				"https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
-			"integrity":
-				"sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
+			"integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
 			"dev": true
 		},
 		"whatwg-url": {
 			"version": "6.5.0",
-			"resolved":
-				"https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
-			"integrity":
-				"sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+			"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
 			"dev": true,
 			"requires": {
 				"lodash.sortby": "^4.7.0",
@@ -8525,8 +7717,7 @@
 		"which": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity":
-				"sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
@@ -8534,15 +7725,13 @@
 		},
 		"which-module": {
 			"version": "2.0.0",
-			"resolved":
-				"https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
 		},
 		"window-size": {
 			"version": "0.1.0",
-			"resolved":
-				"https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
 			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
 			"dev": true,
 			"optional": true
@@ -8565,8 +7754,7 @@
 			"dependencies": {
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved":
-						"https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
@@ -8575,8 +7763,7 @@
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved":
-						"https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
@@ -8587,8 +7774,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved":
-						"https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
@@ -8614,10 +7800,8 @@
 		},
 		"write-file-atomic": {
 			"version": "2.3.0",
-			"resolved":
-				"https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-			"integrity":
-				"sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
@@ -8628,8 +7812,7 @@
 		"ws": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-			"integrity":
-				"sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
 			"dev": true,
 			"requires": {
 				"async-limiter": "~1.0.0",
@@ -8638,10 +7821,8 @@
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",
-			"resolved":
-				"https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-			"integrity":
-				"sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
 			"dev": true
 		},
 		"y18n": {
@@ -8659,8 +7840,7 @@
 		"yargs": {
 			"version": "10.1.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-			"integrity":
-				"sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+			"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
 			"dev": true,
 			"requires": {
 				"cliui": "^4.0.0",
@@ -8680,8 +7860,7 @@
 				"cliui": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-					"integrity":
-						"sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"dev": true,
 					"requires": {
 						"string-width": "^2.1.1",
@@ -8693,10 +7872,8 @@
 		},
 		"yargs-parser": {
 			"version": "8.1.0",
-			"resolved":
-				"https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-			"integrity":
-				"sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+			"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
 			"dev": true,
 			"requires": {
 				"camelcase": "^4.1.0"
@@ -8704,8 +7881,7 @@
 			"dependencies": {
 				"camelcase": {
 					"version": "4.1.0",
-					"resolved":
-						"https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
 					"dev": true
 				}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
 	"version": "11.1.1",
 	"description": "Client for prometheus",
 	"main": "index.js",
-	"files": ["lib/", "index.js", "index.d.ts"],
+	"files": [
+		"lib/",
+		"index.js",
+		"index.d.ts"
+	],
 	"engines": {
 		"node": ">=6"
 	},
@@ -18,7 +22,11 @@
 		"type": "git",
 		"url": "git@github.com:siimon/prom-client.git"
 	},
-	"keywords": ["Prometheus", "Metrics", "Client"],
+	"keywords": [
+		"Prometheus",
+		"Metrics",
+		"Client"
+	],
 	"author": "Simon Nyberg",
 	"license": "Apache-2.0",
 	"homepage": "https://github.com/siimon/prom-client",
@@ -30,7 +38,7 @@
 		"jest": "^22.4.2",
 		"lint-staged": "^7.0.0",
 		"lolex": "^2.1.3",
-		"prettier": "1.11.1",
+		"prettier": "1.14.2",
 		"typescript": "^2.5.2"
 	},
 	"dependencies": {
@@ -42,9 +50,18 @@
 		"testRegex": ".*Test\\.js$"
 	},
 	"lint-staged": {
-		"*.js": ["eslint --fix", "git add"],
-		"*.{ts,md,json}": ["prettier --write", "git add"],
-		".eslintrc": ["prettier --write", "git add"]
+		"*.js": [
+			"eslint --fix",
+			"git add"
+		],
+		"*.{ts,md,json,yml}": [
+			"prettier --write",
+			"git add"
+		],
+		".{eslintrc,travis.yml}": [
+			"prettier --write",
+			"git add"
+		]
 	},
 	"prettier": {
 		"singleQuote": true,


### PR DESCRIPTION
This adds support for yaml and removes the silly newlines in `package{-lock}.json` to avoid conflicts with npm