### PR TITLE
Fix histogram scrape performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Allow setting Gauge values to NaN, +Inf, and -Inf
+- Fixed `histogram` scrape performance by using `acc.push` instead of `acc.concat`. Fixes #216 with #219
 
 ### Added
 

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -288,7 +288,7 @@ function extractBucketValuesForExport(histogram) {
 
 function addSumAndCountForExport(histogram) {
 	return (acc, d) => {
-		acc.push.apply(acc, d.buckets);
+		acc.push(...d.buckets);
 
 		const infLabel = Object.assign({ le: '+Inf' }, d.data.labels);
 		acc.push(

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -288,7 +288,7 @@ function extractBucketValuesForExport(histogram) {
 
 function addSumAndCountForExport(histogram) {
 	return (acc, d) => {
-		acc = acc.concat(d.buckets);
+		acc.push.apply(acc, d.buckets);
 
 		const infLabel = Object.assign({ le: '+Inf' }, d.data.labels);
 		acc.push(


### PR DESCRIPTION
When profiling histogram scraping I discovered that the major bottleneck is creating a clone of the accumulator in reduce. We should not actually need to skip mutation.

You can see the benchmark of `concat` vs `push` here:  https://codeburst.io/jsnoob-push-vs-concat-basics-and-performance-comparison-7a4b55242fa9

This should address https://github.com/siimon/prom-client/issues/216

I used this test script to profile.

```js
const prom = require('prom-client');
const _ = require('lodash');

const histogram = new prom.Histogram({
    name: 'histogram',
    help: 'histogram',
    labelNames: ['a', 'b', 'c', 'd'],
});

_.times(2, a => {
    _.times(3, b => {
        _.times(10, c => {
            _.times(100, d => {
                const end = histogram.startTimer();

                end({a,b,c,d});
            });
        });
    });
});

console.log('Starting metrics');
const now = Date.now();
const metrics = prom.register.getMetricsAsJSON();

console.log(`${(Date.now() - now) / 1000}s`);
```

Which resulted in before this patch of `7.021s` and after of `0.501s`