### PR TITLE
Compress t-digest to prevent memory leakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Compress t-digest in Summaries
+
 ### Added
+
+- Parameter `compressCount` in Summaries to control compression of data in t-digest.
 
 ## [11.2.1]
 
@@ -21,58 +25,58 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-* Updated types for Summary in typescript definition file
+- Updated types for Summary in typescript definition file
 
 ## [11.2.0]
 
 ### Changed
 
-* Updated child dependency `merge` patch version to remove vulnerability.
+- Updated child dependency `merge` patch version to remove vulnerability.
 
 ### Added
 
-* Added an initial `benchmark` suite which can be run with `npm run benchmarks`.
-* Add support for sliding windows in Summaries
+- Added an initial `benchmark` suite which can be run with `npm run benchmarks`.
+- Add support for sliding windows in Summaries
 
 ## [11.1.3] - 2018-09-22
 
 ### Changed
 
-* Fixed performance by avoiding `Object.assign` on hot paths, as well as
+- Fixed performance by avoiding `Object.assign` on hot paths, as well as
   mutating objects when appropriate.
 
 ## [11.1.2] - 2018-09-19
 
 ### Changed
 
-* Allow setting Gauge values to NaN, +Inf, and -Inf
-* Fixed `histogram` scrape performance by using `acc.push` instead of `acc.concat`. Fixes #216 with #219
+- Allow setting Gauge values to NaN, +Inf, and -Inf
+- Fixed `histogram` scrape performance by using `acc.push` instead of `acc.concat`. Fixes #216 with #219
 
 ## [11.1.1] - 2018-06-29
 
 ### Changed
 
-* Fixed `processOpenFileDescriptors` metric when no custom config was set
+- Fixed `processOpenFileDescriptors` metric when no custom config was set
 
 ## [11.1.0] - 2018-06-29
 
-* Added ability to set a name prefix in the default metrics
+- Added ability to set a name prefix in the default metrics
 
 ### Changed
 
-* Fixed `startTimer` utility to not mutate objects passed as `startLabels`
-* Fixed `Counter` to validate labels parameter of `inc()` against initial
+- Fixed `startTimer` utility to not mutate objects passed as `startLabels`
+- Fixed `Counter` to validate labels parameter of `inc()` against initial
   labelset
-* Fixed `AggregatorFactory` losing the aggregator method of metrics
+- Fixed `AggregatorFactory` losing the aggregator method of metrics
 
 ## [11.0.0] - 2018-03-10
 
 ### Breaking
 
-* Fixed `gauge.setToCurrentTime()` to use seconds instead of milliseconds
-  * This conforms to Prometheus
+- Fixed `gauge.setToCurrentTime()` to use seconds instead of milliseconds
+  - This conforms to Prometheus
     [best practices](https://prometheus.io/docs/practices/naming/#base-units)
-* Dropped support for node 4
+- Dropped support for node 4
 
 ## [10.2.3] - 2018-02-28
 
@@ -80,7 +84,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-* Fixed issue that `registry.getMetricsAsJSON()` ignores registry default labels
+- Fixed issue that `registry.getMetricsAsJSON()` ignores registry default labels
 
 ### Added
 
@@ -88,123 +92,123 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-* Fixed invalid `process_virtual_memory_bytes` reported under linux
+- Fixed invalid `process_virtual_memory_bytes` reported under linux
 
 ## [10.2.1] - 2017-10-27
 
 ### Changed
 
-* Only resolve/reject `clusterMetrics` promise if no callback is provided
+- Only resolve/reject `clusterMetrics` promise if no callback is provided
 
 ## [10.2.0] - 2017-10-16
 
 ### Changed
 
-* Don't add event listeners if cluster module is not used.
-* Fixed issue with counters having extra records when using empty labels
+- Don't add event listeners if cluster module is not used.
+- Fixed issue with counters having extra records when using empty labels
 
 ### Added
 
-* Added `reset` to Counter and Gauge
-* Added `resetMetrics` to register to calling `reset` of all metric instances
+- Added `reset` to Counter and Gauge
+- Added `resetMetrics` to register to calling `reset` of all metric instances
 
 ## [10.1.1] - 2017-09-26
 
 ### Changed
 
-* Update TypeScript definitions and JSDoc comments to match JavaScript sources
-* Fix lexical scope of `arguments` in cluster code
+- Update TypeScript definitions and JSDoc comments to match JavaScript sources
+- Fix lexical scope of `arguments` in cluster code
 
 ## [10.1.0] - 2017-09-04
 
 ### Added
 
-* Support aggregating metrics across workers in a Node.js cluster.
+- Support aggregating metrics across workers in a Node.js cluster.
 
 ## [10.0.4] - 2017-08-22
 
 ### Changed
 
-* Include invalid values in the error messages
+- Include invalid values in the error messages
 
 ## [10.0.3] - 2017-08-07
 
 ### Added
 
-* Added registerMetric to definitions file
+- Added registerMetric to definitions file
 
 ### Changed
 
-* Fixed typing of DefaultMetricsCollectorConfiguration in definitions file
-* Don't pass timestamps through to pushgateway by default
+- Fixed typing of DefaultMetricsCollectorConfiguration in definitions file
+- Don't pass timestamps through to pushgateway by default
 
 ## [10.0.2] - 2017-07-07
 
 ### Changed
 
-* Don't poll default metrics every single tick
+- Don't poll default metrics every single tick
 
 ## [10.0.1] - 2017-07-06
 
 ### Added
 
-* Metrics should be initialized to 0 when there are no labels
+- Metrics should be initialized to 0 when there are no labels
 
 ## [10.0.0] - 2017-07-04
 
 ### Breaking
 
-* Print deprecation warning when metrics are constructed using non-objects
-* Print deprecation warning when `collectDefaultMetrics` is called with a number
+- Print deprecation warning when metrics are constructed using non-objects
+- Print deprecation warning when `collectDefaultMetrics` is called with a number
 
 ### Added
 
-* Ability to set default labels by registry
-* Allow passing in `registry` as second argument to `collectDefaultMetrics` to
+- Ability to set default labels by registry
+- Allow passing in `registry` as second argument to `collectDefaultMetrics` to
   use that instead of the default registry
 
 ### Changed
 
-* Convert code base to ES2015 code (node 4)
-  * add engines field to package.json
-  * Use object shorthand
-  * Remove `util-extend` in favor of `Object.assign`
-  * Arrow functions over binding or putting `this` in a variable
-  * Use template strings
-  * `prototype` -> `class`
+- Convert code base to ES2015 code (node 4)
+  - add engines field to package.json
+  - Use object shorthand
+  - Remove `util-extend` in favor of `Object.assign`
+  - Arrow functions over binding or putting `this` in a variable
+  - Use template strings
+  - `prototype` -> `class`
 
 ## [9.1.1] - 2017-06-17
 
 ### Changed
 
-* Don't set timestamps for metrics that are never updated
+- Don't set timestamps for metrics that are never updated
 
 ## [9.1.0] - 2017-06-07
 
 ### Added
 
-* Ability to merge registries
+- Ability to merge registries
 
 ### Changed
 
-* Correct typedefs for object constructor of metrics
+- Correct typedefs for object constructor of metrics
 
 ## [9.0.0] - 2017-05-06
 
 ### Added
 
-* Support for multiple registers
-* Support for object literals in metric constructors
-* Timestamp support
+- Support for multiple registers
+- Support for object literals in metric constructors
+- Timestamp support
 
 ### Changed
 
-* Collection of default metrics is now disabled by default. Start collection by
+- Collection of default metrics is now disabled by default. Start collection by
   running `collectDefaultMetrics()`.
 
 ### Deprecated
 
-* Creating metrics with one argument per parameter - use object literals
+- Creating metrics with one argument per parameter - use object literals
   instead.
 
 [unreleased]: https://github.com/siimon/prom-client/compare/v10.2.2...HEAD

--- a/index.d.ts
+++ b/index.d.ts
@@ -448,6 +448,7 @@ export interface SummaryConfiguration {
 	aggregator?: Aggregator;
 	maxAgeSeconds?: number;
 	ageBuckets?: number;
+	compressCount?: number;
 }
 
 /**

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -20,6 +20,8 @@ const {
 } = require('./validation');
 const timeWindowQuantiles = require('./timeWindowQuantiles');
 
+const DEFAULT_COMPRESS_COUNT = 1000; // every 1000 measurements
+
 class Summary {
 	/**
 	 * Summary
@@ -78,6 +80,8 @@ class Summary {
 		this.percentiles = config.percentiles;
 		this.hashMap = {};
 		this.labelNames = config.labelNames || [];
+
+		this.compressCount = config.compressCount || DEFAULT_COMPRESS_COUNT;
 
 		if (this.labelNames.length === 0) {
 			this.hashMap = {
@@ -256,6 +260,9 @@ function observe(labels) {
 
 		summaryOfLabel.td.push(labelValuePair.value);
 		summaryOfLabel.count++;
+		if (summaryOfLabel.count % this.compressCount === 0) {
+			summaryOfLabel.td.compress();
+		}
 		summaryOfLabel.sum += labelValuePair.value;
 		this.hashMap[hash] = summaryOfLabel;
 	};


### PR DESCRIPTION
As already described in #142 the Summary is leaking memory. This fix will call the compress method of t-digist. To prevent compressing a too small set of measurements and increasing performance, it will call the compress method every 1000 measurements by default. You can also specify another count with option `compressCount` in the Summary options.
