### PR TITLE
Performance improvement

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -9,6 +9,7 @@ const benchmarks = createRegressionBenchmark(currentClient, [
 
 benchmarks.suite('registry', require('./registry'));
 benchmarks.suite('histogram', require('./histogram'));
+benchmarks.suite('summary', require('./summary'));
 benchmarks.run().catch(err => {
 	console.error(err.stack);
 	// eslint-disable-next-line no-process-exit

--- a/benchmarks/summary.js
+++ b/benchmarks/summary.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const { getLabelNames, labelCombinationFactory } = require('./utils/labels');
+
+module.exports = setupSummarySuite;
+
+function setupSummarySuite(suite) {
+	suite.add(
+		'observe#1 with 64',
+		labelCombinationFactory([64], (client, { summary }, labels) =>
+			summary.observe(labels, 1)
+		),
+		{ teardown, setup: setup(1) }
+	);
+
+	suite.add(
+		'observe#2 with 8',
+		labelCombinationFactory([8, 8], (client, { summary }, labels) =>
+			summary.observe(labels, 1)
+		),
+		{ teardown, setup: setup(2) }
+	);
+
+	suite.add(
+		'observe#2 with 4 and 2 with 2',
+		labelCombinationFactory([4, 4, 2, 2], (client, { summary }, labels) =>
+			summary.observe(labels, 1)
+		),
+		{ teardown, setup: setup(4) }
+	);
+
+	suite.add(
+		'observe#2 with 2 and 2 with 4',
+		labelCombinationFactory([2, 2, 4, 4], (client, { summary }, labels) =>
+			summary.observe(labels, 1)
+		),
+		{ teardown, setup: setup(4) }
+	);
+
+	suite.add(
+		'observe#6 with 2',
+		labelCombinationFactory([2, 2, 2, 2, 2, 2], (client, { summary }, labels) =>
+			summary.observe(labels, 1)
+		),
+		{ teardown, setup: setup(6) }
+	);
+}
+
+function setup(labelCount) {
+	return client => {
+		const registry = new client.Registry();
+
+		const summary = new client.Summary({
+			name: 'summary',
+			help: 'summary',
+			labelNames: getLabelNames(labelCount),
+			registers: [registry]
+		});
+
+		return { registry, summary };
+	};
+}
+
+function teardown(client, { registry }) {
+	registry.clear();
+}

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -48,7 +48,7 @@ class Registry {
 
 			let metricName = val.metricName || item.name;
 			if (labels) {
-				metricName += `{${labels.replace(/,$/, '')}}`;
+				metricName += `{${labels.substring(0, labels.length - 1)}}`;
 			}
 
 			let line = `${metricName} ${getValueAsString(val.value)}`;
@@ -68,7 +68,7 @@ class Registry {
 			metrics += `${this.getMetricAsPrometheusString(metric, opts)}\n\n`;
 		}
 
-		return metrics.replace(/\n$/, '');
+		return metrics.substring(0, metrics.length - 1);
 	}
 
 	registerMetric(metricFn) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -63,11 +63,15 @@ function hashObject(labels) {
 		keys = keys.sort(); // need consistency across calls
 	}
 
-	const elems = [];
-	for (let i = 0; i < keys.length; i++) {
-		elems.push(`${keys[i]}:${labels[keys[i]]}`);
+	let hash = '';
+	const size = keys.length;
+	for (let i = 0; i < size; i++) {
+		hash += `${keys[i]}:${labels[keys[i]]}`;
+		if (i !== size - 1) {
+			hash += ',';
+		}
 	}
-	return elems.join(',');
+	return hash;
 }
 exports.hashObject = hashObject;
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,13 +64,12 @@ function hashObject(labels) {
 	}
 
 	let hash = '';
+	let i = 0;
 	const size = keys.length;
-	for (let i = 0; i < size; i++) {
-		hash += `${keys[i]}:${labels[keys[i]]}`;
-		if (i !== size - 1) {
-			hash += ',';
-		}
+	for (; i < size - 1; i++) {
+		hash += `${keys[i]}:${labels[keys[i]]},`;
 	}
+	hash += `${keys[i]}:${labels[keys[i]]}`;
 	return hash;
 }
 exports.hashObject = hashObject;


### PR DESCRIPTION
This improves the performance of `hashObject()` and `getMetricAsPrometheusString()`.

I also added a benchmark for the metric type Summary.

Here is the benchmark result:

```bash
### Summary:

⚠ registry ➭ getMetricsAsJSON#1 with 64 is 0.5266% acceptably slower.
⚠ registry ➭ getMetricsAsJSON#2 with 8 is 1.965% acceptably slower.
⚠ registry ➭ getMetricsAsJSON#2 with 4 and 2 with 2 is 0.4088% acceptably slower.
⚠ registry ➭ getMetricsAsJSON#2 with 2 and 2 with 4 is 1.382% acceptably slower.
✓ registry ➭ getMetricsAsJSON#6 with 2 is 2.998% faster.
✓ registry ➭ metrics#1 with 64 is 10.60% faster.
✓ registry ➭ metrics#2 with 8 is 13.43% faster.
✓ registry ➭ metrics#2 with 4 and 2 with 2 is 8.662% faster.
✓ registry ➭ metrics#2 with 2 and 2 with 4 is 8.565% faster.
✓ registry ➭ metrics#6 with 2 is 4.454% faster.
✓ histogram ➭ observe#1 with 64 is 10.07% faster.
✓ histogram ➭ observe#2 with 8 is 27.06% faster.
✓ histogram ➭ observe#2 with 4 and 2 with 2 is 24.47% faster.
✓ histogram ➭ observe#2 with 2 and 2 with 4 is 22.92% faster.
✓ histogram ➭ observe#6 with 2 is 18.33% faster.
✓ summary ➭ observe#1 with 64 is 2.374% faster.
✓ summary ➭ observe#2 with 8 is 22.51% faster.
✓ summary ➭ observe#2 with 4 and 2 with 2 is 27.86% faster.
✓ summary ➭ observe#2 with 2 and 2 with 4 is 25.46% faster.
✓ summary ➭ observe#6 with 2 is 17.03% faster.
```