### PR TITLE
Add remove() method for handling dynamic labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added a `remove()` method on each metric type, based on [Prometheus "Writing Client Libraries" section on labels](https://prometheus.io/docs/instrumenting/writing_clientlibs/#labels)
+
 ## [11.2.1]
 
 ### Breaking

--- a/index.d.ts
+++ b/index.d.ts
@@ -200,6 +200,12 @@ export class Counter {
 	 * Reset counter values
 	 */
 	reset(): void;
+
+	/**
+	 * Remove metrics for the given label values
+	 * @param values Label values
+	 */
+	remove(...values: string[]): void;
 }
 
 export namespace Counter {
@@ -307,6 +313,12 @@ export class Gauge {
 	 * Reset gauge values
 	 */
 	reset(): void;
+
+	/**
+	 * Remove metrics for the given label values
+	 * @param values Label values
+	 */
+	remove(...values: string[]): void;
 }
 
 export namespace Gauge {
@@ -413,6 +425,12 @@ export class Histogram {
 	 * @return Configured histogram with given labels
 	 */
 	labels(...values: string[]): Histogram.Internal;
+
+	/**
+	 * Remove metrics for the given label values
+	 * @param values Label values
+	 */
+	remove(...values: string[]): void;
 }
 
 export namespace Histogram {
@@ -509,6 +527,12 @@ export class Summary {
 	 * @return Configured summary with given labels
 	 */
 	labels(...values: string[]): Summary.Internal;
+
+	/**
+	 * Remove metrics for the given label values
+	 * @param values Label values
+	 */
+	remove(...values: string[]): void;
 }
 
 export namespace Summary {

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -12,7 +12,8 @@ const {
 	hashObject,
 	isObject,
 	printDeprecationObjectConstructor,
-	getLabels
+	getLabels,
+	removeLabels
 } = require('./util');
 
 const {
@@ -121,6 +122,11 @@ class Counter {
 		return {
 			inc: inc.call(this, labels, hash)
 		};
+	}
+
+	remove() {
+		const labels = getLabels(this.labelNames, arguments) || {};
+		return removeLabels.call(this, this.hashMap, labels);
 	}
 }
 

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -14,7 +14,8 @@ const {
 	getLabels,
 	hashObject,
 	isObject,
-	printDeprecationObjectConstructor
+	printDeprecationObjectConstructor,
+	removeLabels
 } = require('./util');
 const {
 	validateMetricName,
@@ -167,6 +168,11 @@ class Gauge {
 			setToCurrentTime: setToCurrentTime.call(this, labels),
 			startTimer: startTimer.call(this, labels)
 		};
+	}
+
+	remove() {
+		const labels = getLabels(this.labelNames, arguments);
+		removeLabels.call(this, this.hashMap, labels);
 	}
 }
 

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -11,7 +11,8 @@ const {
 	getLabels,
 	hashObject,
 	isObject,
-	printDeprecationObjectConstructor
+	printDeprecationObjectConstructor,
+	removeLabels
 } = require('./util');
 const {
 	validateMetricName,
@@ -148,6 +149,11 @@ class Histogram {
 			observe: observe.call(this, labels),
 			startTimer: startTimer.call(this, labels)
 		};
+	}
+
+	remove() {
+		const labels = getLabels(this.labelNames, arguments);
+		removeLabels.call(this, this.hashMap, labels);
 	}
 }
 

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -11,7 +11,8 @@ const {
 	getLabels,
 	hashObject,
 	isObject,
-	printDeprecationObjectConstructor
+	printDeprecationObjectConstructor,
+	removeLabels
 } = require('./util');
 const {
 	validateLabel,
@@ -154,6 +155,11 @@ class Summary {
 			observe: observe.call(this, labels),
 			startTimer: startTimer.call(this, labels)
 		};
+	}
+
+	remove() {
+		const labels = getLabels(this.labelNames, arguments);
+		removeLabels.call(this, this.hashMap, labels);
 	}
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -23,6 +23,11 @@ exports.getValueAsString = function getValueString(value) {
 	}
 };
 
+exports.removeLabels = function removeLabels(hashMap, labels) {
+	const hash = hashObject(labels);
+	delete hashMap[hash];
+};
+
 exports.setValue = function setValue(hashMap, value, labels, timestamp) {
 	const hash = hashObject(labels);
 	hashMap[hash] = {

--- a/test/__snapshots__/counterTest.js.snap
+++ b/test/__snapshots__/counterTest.js.snap
@@ -4,6 +4,8 @@ exports[`counter global registry with a parameter for each variable labels shoul
 
 exports[`counter global registry with a parameter for each variable labels should throw error if one of lables isn't in labelNames list provided to constructor 1`] = `"Added label \\"status\\" is not included in initial labelset: [ 'method', 'endpoint' ]"`;
 
+exports[`counter global registry with a parameter for each variable remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+
 exports[`counter global registry with a parameter for each variable should not allow invalid date as timestamp 1`] = `"Timestamp is not a valid date or number: Invalid Date"`;
 
 exports[`counter global registry with a parameter for each variable should not allow non number as timestamp 1`] = `"Timestamp is not a valid date or number: blah"`;
@@ -11,6 +13,8 @@ exports[`counter global registry with a parameter for each variable should not a
 exports[`counter global registry with a parameter for each variable should not be possible to decrease a counter 1`] = `"It is not possible to decrease a counter"`;
 
 exports[`counter global registry with a parameter for each variable should throw an error when the value is not a number 1`] = `"Value is not a valid number: 3ms"`;
+
+exports[`counter remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
 
 exports[`counter with params as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
 

--- a/test/__snapshots__/gaugeTest.js.snap
+++ b/test/__snapshots__/gaugeTest.js.snap
@@ -2,6 +2,8 @@
 
 exports[`gauge global registry with a parameter for each variable should not allow non numbers 1`] = `"Value is not a valid number: asd"`;
 
+exports[`gauge global registry with a parameter for each variable with remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+
 exports[`gauge global registry with a parameter for each variable with timestamp should not allow invalid dates 1`] = `"Timestamp is not a valid date or number: Invalid Date"`;
 
 exports[`gauge global registry with a parameter for each variable with timestamp should not allow non numbers 1`] = `"Timestamp is not a valid date or number: blah"`;

--- a/test/__snapshots__/histogramTest.js.snap
+++ b/test/__snapshots__/histogramTest.js.snap
@@ -2,11 +2,15 @@
 
 exports[`histogram with a parameter for each variable labels should not allow different number of labels 1`] = `"Invalid number of arguments"`;
 
+exports[`histogram with a parameter for each variable remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+
 exports[`histogram with a parameter for each variable should not allow le as a custom label 1`] = `"le is a reserved label keyword"`;
 
 exports[`histogram with a parameter for each variable should not allow non numbers 1`] = `"Value is not a valid number: asd"`;
 
 exports[`histogram with object as params with global registry labels should not allow different number of labels 1`] = `"Invalid number of arguments"`;
+
+exports[`histogram with object as params with global registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
 
 exports[`histogram with object as params with global registry should not allow le as a custom label 1`] = `"le is a reserved label keyword"`;
 

--- a/test/__snapshots__/summaryTest.js.snap
+++ b/test/__snapshots__/summaryTest.js.snap
@@ -2,6 +2,10 @@
 
 exports[`summary global registry with a parameter for each variable labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
 
+exports[`summary global registry with a parameter for each variable remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+
 exports[`summary global registry with a parameter for each variable should throw an error when the value is not a number 1`] = `"Value is not a valid number: 3ms"`;
 
 exports[`summary global registry with param as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+
+exports[`summary global registry with param as object remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;

--- a/test/counterTest.js
+++ b/test/counterTest.js
@@ -109,6 +109,46 @@ describe('counter', () => {
 				});
 			});
 
+			describe('remove', () => {
+				beforeEach(() => {
+					instance = new Counter('gauge_test_3', 'help', [
+						'method',
+						'endpoint'
+					]);
+					instance.labels('GET', '/test').inc();
+					instance.labels('POST', '/test').inc();
+				});
+
+				afterEach(() => {
+					globalRegistry.clear();
+				});
+
+				it('should remove matching label', () => {
+					instance.remove('POST', '/test');
+
+					const values = instance.get().values;
+					expect(values).toHaveLength(1);
+					expect(values[0].value).toEqual(1);
+					expect(values[0].labels.method).toEqual('GET');
+					expect(values[0].labels.endpoint).toEqual('/test');
+					expect(values[0].timestamp).toEqual(undefined);
+				});
+
+				it('should remove all labels', () => {
+					instance.remove('GET', '/test');
+					instance.remove('POST', '/test');
+
+					expect(instance.get().values).toHaveLength(0);
+				});
+
+				it('should throw error if label lengths does not match', () => {
+					const fn = function() {
+						instance.remove('GET');
+					};
+					expect(fn).toThrowErrorMatchingSnapshot();
+				});
+			});
+
 			describe('empty labels', () => {
 				beforeEach(() => {
 					instance = new Counter('gauge_test_3', 'test');
@@ -232,6 +272,48 @@ describe('counter', () => {
 			});
 		});
 	});
+
+	describe('remove', () => {
+		beforeEach(() => {
+			instance = new Counter({
+				name: 'gauge_test_3',
+				help: 'help',
+				labelNames: ['method', 'endpoint']
+			});
+			instance.inc({ method: 'GET', endpoint: '/test' });
+			instance.inc({ method: 'POST', endpoint: '/test' });
+		});
+
+		afterEach(() => {
+			globalRegistry.clear();
+		});
+
+		it('should remove matching label', () => {
+			instance.remove('POST', '/test');
+
+			const values = instance.get().values;
+			expect(values).toHaveLength(1);
+			expect(values[0].value).toEqual(1);
+			expect(values[0].labels.method).toEqual('GET');
+			expect(values[0].labels.endpoint).toEqual('/test');
+			expect(values[0].timestamp).toEqual(undefined);
+		});
+
+		it('should remove all labels', () => {
+			instance.remove('GET', '/test');
+			instance.remove('POST', '/test');
+
+			expect(instance.get().values).toHaveLength(0);
+		});
+
+		it('should throw error if label lengths does not match', () => {
+			const fn = function() {
+				instance.remove('GET');
+			};
+			expect(fn).toThrowErrorMatchingSnapshot();
+		});
+	});
+
 	describe('without registry', () => {
 		beforeEach(() => {
 			instance = new Counter({

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -135,6 +135,32 @@ describe('gauge', () => {
 				});
 			});
 
+			describe('with remove', () => {
+				beforeEach(() => {
+					instance = new Gauge('name', 'help', ['code']);
+					instance.set({ code: '200' }, 20);
+					instance.set({ code: '400' }, 0);
+				});
+				it('should be able to remove matching label', () => {
+					instance.remove('200');
+					const values = instance.get().values;
+					expect(values.length).toEqual(1);
+					expect(values[0].labels.code).toEqual('400');
+					expect(values[0].value).toEqual(0);
+				});
+				it('should be able to remove all labels', () => {
+					instance.remove('200');
+					instance.remove('400');
+					expect(instance.get().values.length).toEqual(0);
+				});
+				it('should throw error if label lengths does not match', () => {
+					const fn = function() {
+						instance.remove('200', 'GET');
+					};
+					expect(fn).toThrowErrorMatchingSnapshot();
+				});
+			});
+
 			describe('with timestamp', () => {
 				beforeEach(() => {
 					instance = new Gauge('name', 'help', ['code']);
@@ -293,6 +319,30 @@ describe('gauge', () => {
 					const end = instance.startTimer(startLabels);
 					end({ code: '400' });
 					expect(startLabels).toEqual({ code: '200' });
+				});
+			});
+
+			describe('with remove', () => {
+				beforeEach(() => {
+					instance = new Gauge({
+						name: 'name',
+						help: 'help',
+						labelNames: ['code']
+					});
+					instance.set({ code: '200' }, 20);
+					instance.set({ code: '400' }, 0);
+				});
+				it('should be able to remove matching label', () => {
+					instance.remove('200');
+					const values = instance.get().values;
+					expect(values.length).toEqual(1);
+					expect(values[0].labels.code).toEqual('400');
+					expect(values[0].value).toEqual(0);
+				});
+				it('should be able to remove all labels', () => {
+					instance.remove('200');
+					instance.remove('400');
+					expect(instance.get().values.length).toEqual(0);
 				});
 			});
 


### PR DESCRIPTION
This addresses #187

This implements a `remove()` method on each metric type, based on [Prometheus "Writing Client Libraries" section on labels](https://prometheus.io/docs/instrumenting/writing_clientlibs/#labels)