### PR TITLE
Fix rare ERR_IPC_CHANNEL_CLOSED bug in cluster mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Check that cluster worker is still connected before attempting to query it for
+  metrics. (#244)
+
 ### Added
 
 ## [11.2.1]

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -38,8 +38,6 @@ class AggregatorRegistry extends Registry {
 		const requestId = requestCtr++;
 
 		return new Promise((resolve, reject) => {
-			const nWorkers = Object.keys(cluster.workers).length;
-
 			function done(err, result) {
 				// Don't resolve/reject the promise if a callback is provided
 				if (typeof callback === 'function') {
@@ -50,13 +48,9 @@ class AggregatorRegistry extends Registry {
 				}
 			}
 
-			if (nWorkers === 0) {
-				return process.nextTick(() => done(null, ''));
-			}
-
 			const request = {
 				responses: [],
-				pending: nWorkers,
+				pending: 0,
 				done,
 				errorTimeout: setTimeout(() => {
 					request.failed = true;
@@ -71,7 +65,21 @@ class AggregatorRegistry extends Registry {
 				type: GET_METRICS_REQ,
 				requestId
 			};
-			for (const id in cluster.workers) cluster.workers[id].send(message);
+
+			for (const id in cluster.workers) {
+				// If the worker exits abruptly, it may still be in the workers
+				// list but not able to communicate.
+				if (cluster.workers[id].isConnected()) {
+					cluster.workers[id].send(message);
+					request.pending++;
+				}
+			}
+
+			if (request.pending === 0) {
+				// No workers were up
+				clearTimeout(request.errorTimeout);
+				process.nextTick(() => done(null, ''));
+			}
 		});
 	}
 

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -155,13 +155,7 @@ function addListeners() {
 
 	if (cluster.isMaster) {
 		// Listen for worker responses to requests for local metrics
-		cluster.on('message', function(worker, message) {
-			if (arguments.length === 2) {
-				// pre-Node.js v6.0
-				message = worker;
-				worker = undefined;
-			}
-
+		cluster.on('message', (worker, message) => {
 			if (message.type === GET_METRICS_RES) {
 				const request = requests.get(message.requestId);
 				message.metrics.forEach(registry => request.responses.push(registry));


### PR DESCRIPTION
A cluster worker can still be in the list of workers even if its IPC channel has closed (e.g. when the worker exits abruptly). Fix by checking that its IPC channel is open before sending a message.

This happens extremely infrequently (less than once a month for us, running several hundred VMs scraping every 10 seconds), but I've tested in an artificial situation that this makes communication safe:

```js
const cluster = require("cluster");

if (cluster.isMaster) {
	for (let i = 0; i < 4; i++) {
		const worker = cluster.fork();
		// THIS SHOULDN'T LOG WITH THE FIX
		worker.on("error", err => console.log("worker error", err));
	}

	cluster.on("exit", (worker, code, signal) => {
		setTimeout(() => cluster.fork(), 500);
	});

	setInterval(() => {
		for (const id in cluster.workers) {
			if (cluster.workers[id].isConnected()) // TOGGLE THIS LINE
				cluster.workers[id].send({type: "hi!"});
		}
	}, 5);
} else {
	setTimeout(() => process.exit(1), 500);
}
```

Also removes some code that was for compat with Node.js pre-v6, since v11 of this lib dropped support for pre-v6.