### PR TITLE
Add validateMetricName() to the public interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -671,3 +671,10 @@ export interface defaultMetrics {
 	 */
 	metricsList: string[];
 }
+
+/**
+ * Validate a metric name
+ * @param name The name to validate
+ * @return True if the metric name is valid, false if not
+ */
+export function validateMetricName(name: string): boolean;

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@
 exports.register = require('./lib/registry').globalRegistry;
 exports.Registry = require('./lib/registry');
 exports.contentType = require('./lib/registry').globalRegistry.contentType;
+exports.validateMetricName = require('./lib/validation').validateMetricName;
 
 exports.Counter = require('./lib/counter');
 exports.Gauge = require('./lib/gauge');


### PR DESCRIPTION
Hi! Thanks so much for this useful library!

We're using it in https://github.com/badges/shields, which is a moderately complex project that hosts the application for https://shields.io/, which can also be used for self-hosting and in a bunch of other ways. We have Prometheus enabled in production, however it's turned off for unit testing.

We have almost 300 contributors, so there are a lot of different people working on the codebase. We also have about 300 services, which are the integrations we provide for various badges.

I'm auto-generating a prometheus metric name from one of these class names and since I'm discovering it's really easy to accidentally generate one that isn't valid, I'd like to add a check to our service validator that the class names are valid – and to do this without having to actually register the counters.

I could paste the regex into our project, which is probably what I will do to get started, though it would be great to keep our code in sync with this code in case the validation rules change.

Thanks for considering!