### PR TITLE
feat: add option to disable timestamps on defaultMetrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added `timestamps` toggle to `collectDefaultMetrics` options
+
 ## [11.3.0] - 2019-04-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ const collectDefaultMetrics = client.collectDefaultMetrics;
 collectDefaultMetrics({ prefix: 'my_application_' });
 ```
 
+To disable metric timstamps set `timestamps` to `false` (You can find the list of metrics that support this feature in `test/defaultMetricsTest.js`):
+
+```js
+const client = require('prom-client');
+
+const collectDefaultMetrics = client.collectDefaultMetrics;
+
+// Probe every 5th second.
+collectDefaultMetrics({ timestamps: false });
+```
+
 You can get the full list of metrics by inspecting
 `client.collectDefaultMetrics.metricsList`.
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ const collectDefaultMetrics = client.collectDefaultMetrics;
 collectDefaultMetrics({ prefix: 'my_application_' });
 ```
 
-To disable metric timstamps set `timestamps` to `false` (You can find the list of metrics that support this feature in `test/defaultMetricsTest.js`):
+To disable metric timestamps set `timestamps` to `false` (You can find the list of metrics that support this feature in `test/defaultMetricsTest.js`):
 
 ```js
 const client = require('prom-client');

--- a/index.d.ts
+++ b/index.d.ts
@@ -644,6 +644,7 @@ export function exponentialBuckets(
 
 export interface DefaultMetricsCollectorConfiguration {
 	timeout?: number;
+	timestamps?: boolean;
 	register?: Registry;
 	prefix?: string;
 }

--- a/lib/defaultMetrics.js
+++ b/lib/defaultMetrics.js
@@ -42,7 +42,13 @@ module.exports = function startDefaultMetrics(config) {
 		normalizedConfig = { timeout: config };
 	}
 
-	normalizedConfig = Object.assign({ timeout: 10000 }, normalizedConfig);
+	normalizedConfig = Object.assign(
+		{
+			timestamps: true,
+			timeout: 10000
+		},
+		normalizedConfig
+	);
 
 	if (existingInterval !== null) {
 		clearInterval(existingInterval);

--- a/lib/defaultMetrics.js
+++ b/lib/defaultMetrics.js
@@ -63,7 +63,7 @@ module.exports = function startDefaultMetrics(config) {
 			);
 		}
 
-		return defaultMetric(normalizedConfig.register, config);
+		return defaultMetric(normalizedConfig.register, normalizedConfig);
 	});
 
 	function updateAllMetrics() {

--- a/lib/metrics/heapSizeAndUsed.js
+++ b/lib/metrics/heapSizeAndUsed.js
@@ -40,11 +40,19 @@ module.exports = (registry, config = {}) => {
 		// process.memoryUsage() can throw EMFILE errors, see #67
 		const memUsage = safeMemoryUsage();
 		if (memUsage) {
-			const now = Date.now();
-			heapSizeTotal.set(memUsage.heapTotal, now);
-			heapSizeUsed.set(memUsage.heapUsed, now);
-			if (memUsage.external && externalMemUsed) {
-				externalMemUsed.set(memUsage.external, now);
+			if (config.timestamps) {
+				const now = Date.now();
+				heapSizeTotal.set(memUsage.heapTotal, now);
+				heapSizeUsed.set(memUsage.heapUsed, now);
+				if (memUsage.external && externalMemUsed) {
+					externalMemUsed.set(memUsage.external, now);
+				}
+			} else {
+				heapSizeTotal.set(memUsage.heapTotal);
+				heapSizeUsed.set(memUsage.heapUsed);
+				if (memUsage.external && externalMemUsed) {
+					externalMemUsed.set(memUsage.external);
+				}
 			}
 		}
 

--- a/lib/metrics/processHandles.js
+++ b/lib/metrics/processHandles.js
@@ -18,9 +18,11 @@ module.exports = (registry, config = {}) => {
 		registers: registry ? [registry] : undefined
 	});
 
-	return () => {
-		gauge.set(process._getActiveHandles().length, Date.now());
-	};
+	const updater = config.timestamps
+		? () => gauge.set(process._getActiveHandles().length, Date.now())
+		: () => gauge.set(process._getActiveHandles().length);
+
+	return updater;
 };
 
 module.exports.metricNames = [NODEJS_ACTIVE_HANDLES];

--- a/test/defaultMetricsTest.js
+++ b/test/defaultMetricsTest.js
@@ -71,6 +71,26 @@ describe('collectDefaultMetrics', () => {
 		});
 	});
 
+	it('should omit timestamp in certain metrics', () => {
+		const metricsWithToggableTimestamp = [
+			'nodejs_active_handles_total',
+			'nodejs_external_memory_bytes',
+			'nodejs_heap_size_total_bytes',
+			'nodejs_heap_size_used_bytes'
+		];
+		interval = collectDefaultMetrics({ timestamps: false });
+		expect(register.getMetricsAsJSON()).not.toHaveLength(0);
+		const testableMetrics = register
+			.getMetricsAsJSON()
+			.filter(
+				metrics => metricsWithToggableTimestamp.indexOf(metrics.name) !== -1
+			);
+		testableMetrics.forEach(metric => {
+			expect(metric.values).not.toHaveLength(0);
+			expect(metric.values[0].timestamp).not.toBeDefined();
+		});
+	});
+
 	describe('disabling', () => {
 		it('should not throw error', () => {
 			const fn = function() {


### PR DESCRIPTION
Some timestamps can now be turned off by the user.

We have a server that does not have the correct time set.
Prometheus ignores these metrics because timestamps are too far in the future.
We currently can not change the server time so we are not collecting these critical metrics.
