### PR TITLE
Split process request and process handles by type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- nodejs_active_handles metric to the collectDefaultMetrics(). Unlike nodejs_active_handles_total it split count of active handles by type.
+- nodejs_active_requests metric to the collectDefaultMetrics(). Unlike nodejs_active_requests_total it split count of active requests by type.
+
 ## [11.3.0] - 2019-04-02
 
 ### Changed

--- a/lib/metrics/helpers/processMetricsHelpers.js
+++ b/lib/metrics/helpers/processMetricsHelpers.js
@@ -16,11 +16,11 @@ function aggregateByObjectName(list) {
 function updateMetrics(gauge, data) {
 	gauge.reset();
 	for (const key in data) {
-		gauge.set({type: key}, data[key], Date.now());
+		gauge.set({ type: key }, data[key], Date.now());
 	}
 }
 
 module.exports = {
-  aggregateByObjectName: aggregateByObjectName,
-  updateMetrics: updateMetrics
-}
+	aggregateByObjectName,
+	updateMetrics
+};

--- a/lib/metrics/helpers/processMetricsHelpers.js
+++ b/lib/metrics/helpers/processMetricsHelpers.js
@@ -1,0 +1,26 @@
+'use strict';
+
+function aggregateByObjectName(list) {
+	const data = {};
+
+	for (const key in list) {
+		if (data.hasOwnProperty(list[key].constructor.name)) {
+			data[list[key].constructor.name] += 1;
+		} else {
+			data[list[key].constructor.name] = 1;
+		}
+	}
+	return data;
+}
+
+function updateMetrics(gauge, data) {
+	gauge.reset();
+	for (const key in data) {
+		gauge.set({type: key}, data[key], Date.now());
+	}
+}
+
+module.exports = {
+  aggregateByObjectName: aggregateByObjectName,
+  updateMetrics: updateMetrics
+}

--- a/lib/metrics/processHandles.js
+++ b/lib/metrics/processHandles.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const {aggregateByObjectName} = require("./helpers/processMetricsHelpers");
-const {updateMetrics} = require("./helpers/processMetricsHelpers");
+const { aggregateByObjectName } = require('./helpers/processMetricsHelpers');
+const { updateMetrics } = require('./helpers/processMetricsHelpers');
 const Gauge = require('../gauge');
 
 const NODEJS_ACTIVE_HANDLES = 'nodejs_active_handles';

--- a/lib/metrics/processHandles.js
+++ b/lib/metrics/processHandles.js
@@ -28,7 +28,7 @@ module.exports = (registry, config = {}) => {
 	});
 
 	return () => {
-		let handles = process._getActiveHandles();
+		const handles = process._getActiveHandles();
 		updateMetrics(gauge, aggregateByObjectName(handles));
 		totalGauge.set(handles.length, Date.now());
 	};

--- a/lib/metrics/processHandles.js
+++ b/lib/metrics/processHandles.js
@@ -1,8 +1,11 @@
 'use strict';
 
+const {aggregateByObjectName} = require("./helpers/processMetricsHelpers");
+const {updateMetrics} = require("./helpers/processMetricsHelpers");
 const Gauge = require('../gauge');
 
-const NODEJS_ACTIVE_HANDLES = 'nodejs_active_handles_total';
+const NODEJS_ACTIVE_HANDLES = 'nodejs_active_handles';
+const NODEJS_ACTIVE_HANDLES_TOTAL = 'nodejs_active_handles_total';
 
 module.exports = (registry, config = {}) => {
 	// Don't do anything if the function is removed in later nodes (exists in node@6)
@@ -14,12 +17,20 @@ module.exports = (registry, config = {}) => {
 
 	const gauge = new Gauge({
 		name: namePrefix + NODEJS_ACTIVE_HANDLES,
-		help: 'Number of active handles.',
+		help: 'Number of active handles grouped by handle type.',
+		labelNames: ['type'],
+		registers: registry ? [registry] : undefined
+	});
+	const totalGauge = new Gauge({
+		name: namePrefix + NODEJS_ACTIVE_HANDLES_TOTAL,
+		help: 'Total number of active handles.',
 		registers: registry ? [registry] : undefined
 	});
 
 	return () => {
-		gauge.set(process._getActiveHandles().length, Date.now());
+		let handles = process._getActiveHandles();
+		updateMetrics(gauge, aggregateByObjectName(handles));
+		totalGauge.set(handles.length, Date.now());
 	};
 };
 

--- a/lib/metrics/processHandles.js
+++ b/lib/metrics/processHandles.js
@@ -34,4 +34,7 @@ module.exports = (registry, config = {}) => {
 	};
 };
 
-module.exports.metricNames = [NODEJS_ACTIVE_HANDLES];
+module.exports.metricNames = [
+	NODEJS_ACTIVE_HANDLES,
+	NODEJS_ACTIVE_HANDLES_TOTAL
+];

--- a/lib/metrics/processHandles.js
+++ b/lib/metrics/processHandles.js
@@ -17,7 +17,8 @@ module.exports = (registry, config = {}) => {
 
 	const gauge = new Gauge({
 		name: namePrefix + NODEJS_ACTIVE_HANDLES,
-		help: 'Number of active handles grouped by handle type.',
+		help:
+			'Number of active libuv handles grouped by handle type. Every handle type is C++ class name.',
 		labelNames: ['type'],
 		registers: registry ? [registry] : undefined
 	});

--- a/lib/metrics/processRequests.js
+++ b/lib/metrics/processRequests.js
@@ -16,7 +16,8 @@ module.exports = (registry, config = {}) => {
 
 	const gauge = new Gauge({
 		name: namePrefix + NODEJS_ACTIVE_REQUESTS,
-		help: 'Number of active requests grouped by request type.',
+		help:
+			'Number of active libuv requests grouped by request type. Every request type is C++ class name.',
 		labelNames: ['type'],
 		registers: registry ? [registry] : undefined
 	});

--- a/lib/metrics/processRequests.js
+++ b/lib/metrics/processRequests.js
@@ -1,8 +1,7 @@
 'use strict';
 const Gauge = require('../gauge');
-const {aggregateByObjectName} = require("./helpers/processMetricsHelpers");
-const {updateMetrics} = require("./helpers/processMetricsHelpers");
-
+const { aggregateByObjectName } = require('./helpers/processMetricsHelpers');
+const { updateMetrics } = require('./helpers/processMetricsHelpers');
 
 const NODEJS_ACTIVE_REQUESTS = 'nodejs_active_requests';
 const NODEJS_ACTIVE_REQUESTS_TOTAL = 'nodejs_active_requests_total';
@@ -36,6 +35,6 @@ module.exports = (registry, config = {}) => {
 };
 
 module.exports.metricNames = [
-	NODEJS_ACTIVE_REQUESTS, 
+	NODEJS_ACTIVE_REQUESTS,
 	NODEJS_ACTIVE_REQUESTS_TOTAL
 ];

--- a/lib/metrics/processRequests.js
+++ b/lib/metrics/processRequests.js
@@ -35,4 +35,7 @@ module.exports = (registry, config = {}) => {
 	};
 };
 
-module.exports.metricNames = [NODEJS_ACTIVE_REQUESTS];
+module.exports.metricNames = [
+	NODEJS_ACTIVE_REQUESTS, 
+	NODEJS_ACTIVE_REQUESTS_TOTAL
+];

--- a/lib/metrics/processRequests.js
+++ b/lib/metrics/processRequests.js
@@ -1,8 +1,11 @@
 'use strict';
-
 const Gauge = require('../gauge');
+const {aggregateByObjectName} = require("./helpers/processMetricsHelpers");
+const {updateMetrics} = require("./helpers/processMetricsHelpers");
 
-const NODEJS_ACTIVE_REQUESTS = 'nodejs_active_requests_total';
+
+const NODEJS_ACTIVE_REQUESTS = 'nodejs_active_requests';
+const NODEJS_ACTIVE_REQUESTS_TOTAL = 'nodejs_active_requests_total';
 
 module.exports = (registry, config = {}) => {
 	// Don't do anything if the function is removed in later nodes (exists in node@6)
@@ -14,12 +17,21 @@ module.exports = (registry, config = {}) => {
 
 	const gauge = new Gauge({
 		name: namePrefix + NODEJS_ACTIVE_REQUESTS,
-		help: 'Number of active requests.',
+		help: 'Number of active requests grouped by request type.',
+		labelNames: ['type'],
+		registers: registry ? [registry] : undefined
+	});
+
+	const totalGauge = new Gauge({
+		name: namePrefix + NODEJS_ACTIVE_REQUESTS_TOTAL,
+		help: 'Total number of active requests.',
 		registers: registry ? [registry] : undefined
 	});
 
 	return () => {
-		gauge.set(process._getActiveRequests().length, Date.now());
+		let requests = process._getActiveRequests();
+		updateMetrics(gauge, aggregateByObjectName(requests));
+		totalGauge.set(requests.length, Date.now());
 	};
 };
 

--- a/lib/metrics/processRequests.js
+++ b/lib/metrics/processRequests.js
@@ -29,7 +29,7 @@ module.exports = (registry, config = {}) => {
 	});
 
 	return () => {
-		let requests = process._getActiveRequests();
+		const requests = process._getActiveRequests();
 		updateMetrics(gauge, aggregateByObjectName(requests));
 		totalGauge.set(requests.length, Date.now());
 	};

--- a/test/metrics/processHandlesTest.js
+++ b/test/metrics/processHandlesTest.js
@@ -22,7 +22,7 @@ describe('processHandles', () => {
 		expect(metrics).toHaveLength(2);
 
 		expect(metrics[0].help).toEqual(
-			'Number of active handles grouped by handle type.'
+			'Number of active libuv handles grouped by handle type. Every handle type is C++ class name.'
 		);
 		expect(metrics[0].type).toEqual('gauge');
 		expect(metrics[0].name).toEqual('nodejs_active_handles');

--- a/test/metrics/processHandlesTest.js
+++ b/test/metrics/processHandlesTest.js
@@ -19,9 +19,16 @@ describe('processHandles', () => {
 
 		const metrics = register.getMetricsAsJSON();
 
-		expect(metrics).toHaveLength(1);
-		expect(metrics[0].help).toEqual('Number of active handles.');
+		expect(metrics).toHaveLength(2);
+
+		expect(metrics[0].help).toEqual(
+			'Number of active handles grouped by handle type.'
+		);
 		expect(metrics[0].type).toEqual('gauge');
-		expect(metrics[0].name).toEqual('nodejs_active_handles_total');
+		expect(metrics[0].name).toEqual('nodejs_active_handles');
+
+		expect(metrics[1].help).toEqual('Total number of active handles.');
+		expect(metrics[1].type).toEqual('gauge');
+		expect(metrics[1].name).toEqual('nodejs_active_handles_total');
 	});
 });

--- a/test/metrics/processRequestsTest.js
+++ b/test/metrics/processRequestsTest.js
@@ -19,9 +19,15 @@ describe('processRequests', () => {
 
 		const metrics = register.getMetricsAsJSON();
 
-		expect(metrics).toHaveLength(1);
-		expect(metrics[0].help).toEqual('Number of active requests.');
+		expect(metrics).toHaveLength(2);
+		expect(metrics[0].help).toEqual(
+			'Number of active requests grouped by request type.'
+		);
 		expect(metrics[0].type).toEqual('gauge');
-		expect(metrics[0].name).toEqual('nodejs_active_requests_total');
+		expect(metrics[0].name).toEqual('nodejs_active_requests');
+
+		expect(metrics[1].help).toEqual('Total number of active requests.');
+		expect(metrics[1].type).toEqual('gauge');
+		expect(metrics[1].name).toEqual('nodejs_active_requests_total');
 	});
 });

--- a/test/metrics/processRequestsTest.js
+++ b/test/metrics/processRequestsTest.js
@@ -21,7 +21,7 @@ describe('processRequests', () => {
 
 		expect(metrics).toHaveLength(2);
 		expect(metrics[0].help).toEqual(
-			'Number of active requests grouped by request type.'
+			'Number of active libuv requests grouped by request type. Every request type is C++ class name.'
 		);
 		expect(metrics[0].type).toEqual('gauge');
 		expect(metrics[0].name).toEqual('nodejs_active_requests');


### PR DESCRIPTION
Hello @siimon 
In my project I found it quite useful to monitor not only total number of active requests and handles(process._getActiveRequests()/process._getActiveHandles()), but also split them by type.

If you see that number of active handles is growing but you dont know the handle type - it did not help you much track down the problem.
```
# HELP nodejs_active_handles Number of active handles grouped by handle type.
# TYPE nodejs_active_handles gauge
nodejs_active_handles{type="WriteStream"} 2 1556027670456
nodejs_active_handles{type="Server"} 2 1556027670456
nodejs_active_handles{type="Socket"} 2 1556027670456
```

With this patch you will  see what exactly is going wrong with your node js app.
I kept original nodejs_active_handles_total/nodejs_active_requests_total metrics for backward compatibility. So there is no breaking changes in this pull request
