### PR TITLE
fix: guard against missing constructor

### DIFF
--- a/lib/metrics/helpers/processMetricsHelpers.js
+++ b/lib/metrics/helpers/processMetricsHelpers.js
@@ -6,7 +6,7 @@ function aggregateByObjectName(list) {
 	for (let i = 0; i < list.length; i++) {
 		const listElement = list[i];
 
-		if (!listElement || typeof listElement.constructor !== 'undefined') {
+		if (!listElement || typeof listElement.constructor === 'undefined') {
 			continue;
 		}
 

--- a/lib/metrics/helpers/processMetricsHelpers.js
+++ b/lib/metrics/helpers/processMetricsHelpers.js
@@ -3,11 +3,17 @@
 function aggregateByObjectName(list) {
 	const data = {};
 
-	for (const key in list) {
-		if (data.hasOwnProperty(list[key].constructor.name)) {
-			data[list[key].constructor.name] += 1;
+	for (let i = 0; i < list.length; i++) {
+		const listElement = list[i];
+
+		if (!listElement || typeof listElement.constructor !== 'undefined') {
+			continue;
+		}
+
+		if (data.hasOwnProperty(listElement.constructor.name)) {
+			data[listElement.constructor.name] += 1;
 		} else {
-			data[list[key].constructor.name] = 1;
+			data[listElement.constructor.name] = 1;
 		}
 	}
 	return data;


### PR DESCRIPTION
Fix for #270 
I can not reproduce this  bug in my environment, but I suppose that it can happen due to the null values returned by process._getActiveHandles().  