### PR TITLE
fix: avoid mutation bug in registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- fix: avoid mutation bug in registry
+
 ### Added
 
 ## [11.5.0] - 2019-06-04

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -36,6 +36,12 @@ class Registry {
 		let values = '';
 		for (const val of item.values || []) {
 			val.labels = val.labels || {};
+
+			if (defaultLabelNames.length > 0) {
+				// Make a copy before mutating
+				val.labels = Object.assign({}, val.labels);
+			}
+
 			for (const labelName of defaultLabelNames) {
 				val.labels[labelName] =
 					val.labels[labelName] || this._defaultLabels[labelName];

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -336,6 +336,46 @@ describe('register', () => {
 		});
 	});
 
+	describe('Registry with default labels', () => {
+		const Registry = require('../lib/registry');
+
+		it('should not throw with default labels', () => {
+			const r = new Registry();
+			r.setDefaultLabels({
+				env: 'development'
+			});
+
+			const hist = new Histogram({
+				name: 'my_histogram',
+				help: 'my histogram',
+				registers: [r],
+				labelNames: ['type']
+			});
+
+			const myHist = hist.labels('myType');
+
+			myHist.observe(1);
+
+			const metrics = r.metrics();
+			const lines = metrics.split('\n');
+			expect(
+				lines.indexOf(
+					'my_histogram_bucket{le="1",type="myType",env="development"} 1'
+				) >= 0
+			).toEqual(true);
+
+			myHist.observe(1);
+
+			const metrics2 = r.metrics();
+			const lines2 = metrics2.split('\n');
+			expect(
+				lines2.indexOf(
+					'my_histogram_bucket{le="1",type="myType",env="development"} 2'
+				) >= 0
+			).toEqual(true);
+		});
+	});
+
 	describe('merging', () => {
 		const Registry = require('../lib/registry');
 		let registryOne;


### PR DESCRIPTION
The defaultLabels feature is buggy when used in combination
with the `.labels()` sub counter feature.

We mutate the object in the serialization implementation which
means the next time you observe the value the labels object has
been incorrectly mutated.

The functionality of `.labels()` is supposed to be the caching
of the labels object itself instead of constantly re-using it.

I may actually be the only one using the caching feature of the
`.labels()` method which is why this bug was not caught earlier.

The `.labels()` method is not broken if you use it as

```
histogram.labels(...).observe(int)
```

But is broken if you do

```
class Foo {
    constructor() {
        this.myHistogram = histogram.labels(...)
    }

    method() {
        this.myHistogram.observe(int)
    }
}
```