### PR TITLE
Improve performance of registry.metrics()

### DIFF
--- a/lib/counter.js
+++ b/lib/counter.js
@@ -21,8 +21,9 @@ const {
 	validateMetricName,
 	validateLabelName
 } = require('./validation');
+const Metric = require('./metric');
 
-class Counter {
+class Counter extends Metric {
 	/**
 	 * Counter
 	 * @param {string} name - Name of the metric
@@ -30,55 +31,8 @@ class Counter {
 	 * @param {Array.<string>} labels - Labels
 	 */
 	constructor(name, help, labels) {
-		let config;
-		if (isObject(name)) {
-			config = Object.assign(
-				{
-					labelNames: []
-				},
-				name
-			);
-
-			if (!config.registers) {
-				config.registers = [globalRegistry];
-			}
-		} else {
-			printDeprecationObjectConstructor();
-
-			config = {
-				name,
-				help,
-				labelNames: labels,
-				registers: [globalRegistry]
-			};
-		}
-
-		if (!config.help) {
-			throw new Error('Missing mandatory help parameter');
-		}
-		if (!config.name) {
-			throw new Error('Missing mandatory name parameter');
-		}
-		if (!validateMetricName(config.name)) {
-			throw new Error('Invalid metric name');
-		}
-
-		if (!validateLabelName(config.labelNames)) {
-			throw new Error('Invalid label name');
-		}
-
-		this.name = config.name;
-
-		this.labelNames = config.labelNames || [];
-
+		super(getConfig(name, help, labels), type);
 		this.reset();
-
-		this.help = config.help;
-		this.aggregator = config.aggregator || 'sum';
-
-		config.registers.forEach(registryInstance =>
-			registryInstance.registerMetric(this)
-		);
 	}
 
 	/**
@@ -175,6 +129,42 @@ function setValue(hashMap, value, timestamp, labels, hash) {
 		hashMap[hash] = { value, labels: labels || {}, timestamp };
 	}
 	return hashMap;
+}
+
+function getConfig(name, help, labels) {
+	let config;
+	if (isObject(name)) {
+		config = Object.assign(
+			{
+				labelNames: []
+			},
+			name
+		);
+		if (!config.registers) {
+			config.registers = [globalRegistry];
+		}
+	} else {
+		printDeprecationObjectConstructor();
+		config = {
+			name,
+			help,
+			labelNames: labels,
+			registers: [globalRegistry]
+		};
+	}
+	if (!config.help) {
+		throw new Error('Missing mandatory help parameter');
+	}
+	if (!config.name) {
+		throw new Error('Missing mandatory name parameter');
+	}
+	if (!validateMetricName(config.name)) {
+		throw new Error('Invalid metric name');
+	}
+	if (!validateLabelName(config.labelNames)) {
+		throw new Error('Invalid label name');
+	}
+	return config;
 }
 
 module.exports = Counter;

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const generateFunction = require('generate-function');
+
+function getFormatter(metric, defaultLabels) {
+	const defaultLabelNames = Object.keys(defaultLabels);
+	const name = escapeString(metric.name);
+	const help = escapeString(metric.help);
+	const type = metric.type;
+	const labelsCode = getLabelsCode(metric, defaultLabelNames, defaultLabels);
+
+	const gen = generateFunction();
+	gen(`
+  function format(item, escapeLabelValue, getValueAsString, timestamps) {
+    const info = '# HELP ${name} ${help}\\n# TYPE ${name} ${type}\\n';
+    let values = '';
+    for (const val of item.values || []) {
+      val.labels = val.labels || {};
+      let metricName = val.metricName || '${name}';
+      const labels = \`${labelsCode}\`;
+      const hasLabels = labels.length > 0;
+      metricName += \`\${hasLabels ? '{' : ''}\${labels}\${hasLabels ? '}' : ''}\`;
+      let line = \`\${metricName} \${getValueAsString(val.value)}\`;
+      if (timestamps && val.timestamp) line += \` \${val.timestamp}\`;
+      values += \`\${line}\\n\`;
+    }
+    return info + values;
+  }`);
+	return gen.toFunction();
+}
+
+function getLabelsCode(metric, defaultLabelNames, defaultLabels) {
+	let labelString = '';
+	const labelNames = getLabelNames(metric, defaultLabelNames);
+	for (let index = 0; index < labelNames.length; index++) {
+		const labelName = labelNames[index];
+		if (labelName === 'quantile') {
+			labelString += `\${val.labels.quantile != null ? \`quantile="\${escapeLabelValue(val.labels.quantile)}"\` : ''}`;
+		} else if (labelName === 'le') {
+			labelString += `\${val.labels.le != null ? \`le="\${escapeLabelValue(val.labels.le)}"\` : ''}`;
+		} else {
+			labelString += `${labelName}="\${val.labels['${labelName}'] ? escapeLabelValue(val.labels['${labelName}']) : '${
+				defaultLabels[labelName]
+			}'}"`;
+		}
+		if (index !== labelNames.length - 1 && labelString.length > 0) {
+			labelString += ',';
+		}
+	}
+	return labelString;
+}
+
+function getLabelNames(metric, defaultLabelNames) {
+	const labelNames = [...metric.labelNames];
+	for (const labelName of defaultLabelNames) {
+		if (!labelNames.includes(labelName)) {
+			labelNames.push(labelName);
+		}
+	}
+	if (metric.type === 'summary') {
+		labelNames.push('quantile');
+	}
+	if (metric.type === 'histogram') {
+		labelNames.push('le');
+	}
+	return labelNames;
+}
+
+function escapeString(str) {
+	return str.replace(/\n/g, '\\\\n').replace(/\\(?!n)/g, '\\\\\\\\');
+}
+
+module.exports = {
+	getFormatter
+};

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -22,8 +22,9 @@ const {
 	validateLabel,
 	validateLabelName
 } = require('./validation');
+const Metric = require('./metric');
 
-class Gauge {
+class Gauge extends Metric {
 	/**
 	 * Gauge
 	 * @param {string} name - Name of the metric
@@ -31,50 +32,8 @@ class Gauge {
 	 * @param {Array.<string>} labels - Array with strings, all label keywords supported
 	 */
 	constructor(name, help, labels) {
-		let config;
-		if (isObject(name)) {
-			config = Object.assign(
-				{
-					labelNames: []
-				},
-				name
-			);
-
-			if (!config.registers) {
-				config.registers = [globalRegistry];
-			}
-		} else {
-			printDeprecationObjectConstructor();
-			config = {
-				name,
-				help,
-				labelNames: labels,
-				registers: [globalRegistry]
-			};
-		}
-
-		if (!config.help) {
-			throw new Error('Missing mandatory help parameter');
-		}
-		if (!config.name) {
-			throw new Error('Missing mandatory name parameter');
-		}
-		if (!validateMetricName(config.name)) {
-			throw new Error('Invalid metric name');
-		}
-		if (!validateLabelName(config.labelNames)) {
-			throw new Error('Invalid label name');
-		}
-
-		this.name = config.name;
-		this.labelNames = config.labelNames || [];
+		super(getConfig(name, help, labels), type);
 		this.reset();
-		this.help = config.help;
-		this.aggregator = config.aggregator || 'sum';
-
-		config.registers.forEach(registryInstance =>
-			registryInstance.registerMetric(this)
-		);
 	}
 
 	/**
@@ -259,6 +218,42 @@ function convertLabelsAndValues(labels, value) {
 		labels,
 		value
 	};
+}
+
+function getConfig(name, help, labels) {
+	let config;
+	if (isObject(name)) {
+		config = Object.assign(
+			{
+				labelNames: []
+			},
+			name
+		);
+		if (!config.registers) {
+			config.registers = [globalRegistry];
+		}
+	} else {
+		printDeprecationObjectConstructor();
+		config = {
+			name,
+			help,
+			labelNames: labels,
+			registers: [globalRegistry]
+		};
+	}
+	if (!config.help) {
+		throw new Error('Missing mandatory help parameter');
+	}
+	if (!config.name) {
+		throw new Error('Missing mandatory name parameter');
+	}
+	if (!validateMetricName(config.name)) {
+		throw new Error('Invalid metric name');
+	}
+	if (!validateLabelName(config.labelNames)) {
+		throw new Error('Invalid label name');
+	}
+	return config;
 }
 
 module.exports = Gauge;

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -19,8 +19,9 @@ const {
 	validateLabel,
 	validateLabelName
 } = require('./validation');
+const Metric = require('./metric');
 
-class Histogram {
+class Histogram extends Metric {
 	/**
 	 * Histogram
 	 * @param {string} name - Name of the metric
@@ -29,48 +30,9 @@ class Histogram {
 	 * @param {object} conf - Configuration object
 	 */
 	constructor(name, help, labelsOrConf, conf) {
-		let config;
+		super(getConfig(name, labelsOrConf, conf, help), type);
 
-		if (isObject(name)) {
-			config = Object.assign(
-				{
-					buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
-					labelNames: []
-				},
-				name
-			);
-
-			if (!config.registers) {
-				config.registers = [globalRegistry];
-			}
-		} else {
-			let obj;
-			let labels = [];
-
-			if (Array.isArray(labelsOrConf)) {
-				obj = conf || {};
-				labels = labelsOrConf;
-			} else {
-				obj = labelsOrConf || {};
-			}
-
-			printDeprecationObjectConstructor();
-
-			config = {
-				name,
-				labelNames: labels,
-				help,
-				buckets: configureUpperbounds(obj.buckets),
-				registers: [globalRegistry]
-			};
-		}
-		validateInput(config.name, config.help, config.labelNames);
-
-		this.name = config.name;
-		this.help = config.help;
-		this.aggregator = config.aggregator || 'sum';
-
-		this.upperBounds = config.buckets;
+		this.upperBounds = this.config.buckets;
 		this.bucketValues = this.upperBounds.reduce((acc, upperBound) => {
 			acc[upperBound] = 0;
 			return acc;
@@ -82,7 +44,6 @@ class Histogram {
 		this.count = 0;
 
 		this.hashMap = {};
-		this.labelNames = config.labelNames || [];
 
 		if (this.labelNames.length === 0) {
 			this.hashMap = {
@@ -92,10 +53,6 @@ class Histogram {
 				)
 			};
 		}
-
-		config.registers.forEach(registryInstance =>
-			registryInstance.registerMetric(this)
-		);
 	}
 
 	/**
@@ -318,6 +275,41 @@ function addSumAndCountForExport(histogram) {
 		);
 		return acc;
 	};
+}
+
+function getConfig(name, labelsOrConf, conf, help) {
+	let config;
+	if (isObject(name)) {
+		config = Object.assign(
+			{
+				buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+				labelNames: []
+			},
+			name
+		);
+		if (!config.registers) {
+			config.registers = [globalRegistry];
+		}
+	} else {
+		let obj;
+		let labels = [];
+		if (Array.isArray(labelsOrConf)) {
+			obj = conf || {};
+			labels = labelsOrConf;
+		} else {
+			obj = labelsOrConf || {};
+		}
+		printDeprecationObjectConstructor();
+		config = {
+			name,
+			labelNames: labels,
+			help,
+			buckets: configureUpperbounds(obj.buckets),
+			registers: [globalRegistry]
+		};
+	}
+	validateInput(config.name, config.help, config.labelNames);
+	return config;
 }
 
 module.exports = Histogram;

--- a/lib/metric.js
+++ b/lib/metric.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const { getValueAsString, escapeLabelValue } = require('./util');
+const { getFormatter } = require('./formatter');
+
+module.exports = class Metric {
+	constructor(config, type) {
+		this.config = config;
+		this.type = type;
+		this.name = config.name;
+		this.help = config.help;
+		this.labelNames = this.config.labelNames || [];
+		this.aggregator = this.config.aggregator || 'sum';
+
+		this.config.registers.forEach(registryInstance =>
+			registryInstance.registerMetric(this)
+		);
+	}
+
+	getPrometheusString(timestamps, defaultLabels) {
+		const item = this.get();
+		if (!this.formatter) {
+			this.formatter = getFormatter(this, defaultLabels);
+		}
+		return this.formatter(item, escapeLabelValue, getValueAsString, timestamps);
+	}
+};

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,15 +1,6 @@
 'use strict';
-const { getValueAsString } = require('./util');
 
-function escapeString(str) {
-	return str.replace(/\n/g, '\\n').replace(/\\(?!n)/g, '\\\\');
-}
-function escapeLabelValue(str) {
-	if (typeof str !== 'string') {
-		return str;
-	}
-	return escapeString(str).replace(/"/g, '\\"');
-}
+const { escapeLabelValue } = require('./util');
 
 const defaultMetricsOpts = {
 	timestamps: true
@@ -25,47 +16,17 @@ class Registry {
 		return Object.keys(this._metrics).map(this.getSingleMetric, this);
 	}
 
-	getMetricAsPrometheusString(metric, conf) {
-		const opts = Object.assign({}, defaultMetricsOpts, conf);
-		const item = metric.get();
-		const name = escapeString(item.name);
-		const help = `# HELP ${name} ${escapeString(item.help)}`;
-		const type = `# TYPE ${name} ${item.type}`;
-		const defaultLabelNames = Object.keys(this._defaultLabels);
-
-		let values = '';
-		for (const val of item.values || []) {
-			val.labels = val.labels || {};
-			for (const labelName of defaultLabelNames) {
-				val.labels[labelName] =
-					val.labels[labelName] || this._defaultLabels[labelName];
-			}
-
-			let labels = '';
-			for (const key of Object.keys(val.labels)) {
-				labels += `${key}="${escapeLabelValue(val.labels[key])}",`;
-			}
-
-			let metricName = val.metricName || item.name;
-			if (labels) {
-				metricName += `{${labels.substring(0, labels.length - 1)}}`;
-			}
-
-			let line = `${metricName} ${getValueAsString(val.value)}`;
-			if (opts.timestamps && val.timestamp) {
-				line += ` ${val.timestamp}`;
-			}
-			values += `${line.trim()}\n`;
-		}
-
-		return `${help}\n${type}\n${values}`.trim();
+	getMetricAsPrometheusString(metric, conf = {}) {
+		const timestamps =
+			conf.timestamps === undefined ? defaultMetricsOpts : conf.timestamps;
+		return metric.getPrometheusString(timestamps, this._defaultLabels);
 	}
 
 	metrics(opts) {
 		let metrics = '';
 
 		for (const metric of this.getMetricsAsArray()) {
-			metrics += `${this.getMetricAsPrometheusString(metric, opts)}\n\n`;
+			metrics += `${this.getMetricAsPrometheusString(metric, opts)}\n`;
 		}
 
 		return metrics.substring(0, metrics.length - 1);
@@ -125,6 +86,9 @@ class Registry {
 
 	setDefaultLabels(labels) {
 		this._defaultLabels = labels;
+		for (const name of Object.keys(this._defaultLabels)) {
+			this._defaultLabels[name] = escapeLabelValue(this._defaultLabels[name]);
+		}
 	}
 
 	resetMetrics() {

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -20,8 +20,9 @@ const {
 	validateLabelName
 } = require('./validation');
 const timeWindowQuantiles = require('./timeWindowQuantiles');
+const Metric = require('./metric');
 
-class Summary {
+class Summary extends Metric {
 	/**
 	 * Summary
 	 * @param {string} name - Name of the metric
@@ -30,55 +31,13 @@ class Summary {
 	 * @param {object} conf - Configuration object
 	 */
 	constructor(name, help, labelsOrConf, conf) {
-		let config;
-		if (isObject(name)) {
-			config = Object.assign(
-				{
-					percentiles: [0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999],
-					labelNames: []
-				},
-				name
-			);
+		super(getConfig(name, labelsOrConf, conf, help), type);
 
-			if (!config.registers) {
-				config.registers = [globalRegistry];
-			}
-		} else {
-			let obj;
-			let labels = [];
+		this.maxAgeSeconds = this.config.maxAgeSeconds;
+		this.ageBuckets = this.config.ageBuckets;
 
-			if (Array.isArray(labelsOrConf)) {
-				obj = conf || {};
-				labels = labelsOrConf;
-			} else {
-				obj = labelsOrConf || {};
-			}
-
-			printDeprecationObjectConstructor();
-
-			config = {
-				name,
-				help,
-				labelNames: labels,
-				percentiles: configurePercentiles(obj.percentiles),
-				registers: [globalRegistry],
-				maxAgeSeconds: obj.maxAgeSeconds,
-				ageBuckets: obj.ageBuckets
-			};
-		}
-
-		validateInput(config.name, config.help, config.labelNames);
-
-		this.maxAgeSeconds = config.maxAgeSeconds;
-		this.ageBuckets = config.ageBuckets;
-
-		this.name = config.name;
-		this.help = config.help;
-		this.aggregator = config.aggregator || 'sum';
-
-		this.percentiles = config.percentiles;
+		this.percentiles = this.config.percentiles;
 		this.hashMap = {};
-		this.labelNames = config.labelNames || [];
 
 		if (this.labelNames.length === 0) {
 			this.hashMap = {
@@ -90,10 +49,6 @@ class Summary {
 				}
 			};
 		}
-
-		config.registers.forEach(registryInstance =>
-			registryInstance.registerMetric(this)
-		);
 	}
 
 	/**
@@ -279,6 +234,44 @@ function convertLabelsAndValues(labels, value) {
 		labels,
 		value
 	};
+}
+
+function getConfig(name, labelsOrConf, conf, help) {
+	let config;
+	if (isObject(name)) {
+		config = Object.assign(
+			{
+				percentiles: [0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999],
+				labelNames: []
+			},
+			name
+		);
+		if (!config.registers) {
+			config.registers = [globalRegistry];
+		}
+	} else {
+		let obj;
+		let labels = [];
+		if (Array.isArray(labelsOrConf)) {
+			obj = conf || {};
+			labels = labelsOrConf;
+		} else {
+			obj = labelsOrConf || {};
+		}
+		printDeprecationObjectConstructor();
+		config = {
+			name,
+			help,
+			labelNames: labels,
+			percentiles: configurePercentiles(obj.percentiles),
+			registers: [globalRegistry],
+			maxAgeSeconds: obj.maxAgeSeconds,
+			ageBuckets: obj.ageBuckets
+		};
+	}
+
+	validateInput(config.name, config.help, config.labelNames);
+	return config;
 }
 
 module.exports = Summary;

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,6 +4,17 @@ const deprecationsEmitted = {};
 
 exports.isDate = isDate;
 
+exports.escapeString = function(str) {
+	return str.replace(/\n/g, '\\n').replace(/\\(?!n)/g, '\\\\');
+};
+
+exports.escapeLabelValue = function(str) {
+	if (typeof str !== 'string') {
+		return str;
+	}
+	return exports.escapeString(str).replace(/"/g, '\\"');
+};
+
 exports.getPropertiesFromObj = function(hashMap) {
 	const obj = Object.keys(hashMap).map(x => hashMap[x]);
 	return obj;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3169,6 +3169,14 @@
 				"wide-align": "^1.1.0"
 			}
 		},
+		"generate-function": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+			"integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+			"requires": {
+				"is-property": "^1.0.2"
+			}
+		},
 		"genfun": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
@@ -3828,6 +3836,11 @@
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
 			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
 			"dev": true
+		},
+		"is-property": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
 		},
 		"is-regex": {
 			"version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"typescript": "^3.0.3"
 	},
 	"dependencies": {
+		"generate-function": "^2.3.1",
 		"tdigest": "^0.1.1"
 	},
 	"types": "./index.d.ts",


### PR DESCRIPTION
This improves the performance of `registry.metrics()` by approximately 40%.
This is achieved by creating a specific formatter for each metric.

Here are the benchmark results:

```
### Summary:

⚠ registry ➭ getMetricsAsJSON#1 with 64 is 2.343% acceptably slower.
✓ registry ➭ getMetricsAsJSON#2 with 8 is 0.8804% faster.
⚠ registry ➭ getMetricsAsJSON#2 with 4 and 2 with 2 is 1.183% acceptably slower.
✓ registry ➭ getMetricsAsJSON#2 with 2 and 2 with 4 is 0.2041% faster.
✓ registry ➭ getMetricsAsJSON#6 with 2 is 0.7355% faster.
✓ registry ➭ metrics#1 with 64 is 40.57% faster.
✓ registry ➭ metrics#2 with 8 is 38.32% faster.
✓ registry ➭ metrics#2 with 4 and 2 with 2 is 41.24% faster.
✓ registry ➭ metrics#2 with 2 and 2 with 4 is 43.03% faster.
✓ registry ➭ metrics#6 with 2 is 41.95% faster.
✓ histogram ➭ observe#1 with 64 is 4.848% faster.
✓ histogram ➭ observe#2 with 8 is 3.919% faster.
⚠ histogram ➭ observe#2 with 4 and 2 with 2 is 0.5036% acceptably slower.
✓ histogram ➭ observe#2 with 2 and 2 with 4 is 1.179% faster.
✓ histogram ➭ observe#6 with 2 is 11.81% faster.
⚠ summary ➭ observe#1 with 64 is 2.889% acceptably slower.
⚠ summary ➭ observe#2 with 8 is 2.747% acceptably slower.
✓ summary ➭ observe#2 with 4 and 2 with 2 is 2.210% faster.
✓ summary ➭ observe#2 with 2 and 2 with 4 is 0.1158% faster.
⚠ summary ➭ observe#6 with 2 is 3.125% acceptably slower.
```