### PR TITLE
fix: avoid mutation bug in registry.getMetricsAsJSON()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Changed `Metric` labelNames & labelValues in TypeScript declaration to a generic type `T extends string`, instead of `string`
 - Lazy-load Node.js Cluster module to fix Passenger support (#293)
+- fix: avoid mutation bug in `registry.getMetricsAsJSON()`
+- fix: improve performance of `registry.getMetrics*`
 
 ### Added
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -104,6 +104,11 @@ class Registry {
 
 			if (item.values) {
 				for (const val of item.values) {
+					if (defaultLabelNames.length > 0) {
+						// Make a copy before mutating
+						val.labels = Object.assign({}, val.labels);
+					}
+
 					for (const labelName of defaultLabelNames) {
 						val.labels[labelName] =
 							val.labels[labelName] || this._defaultLabels[labelName];

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -40,11 +40,11 @@ class Registry {
 			if (defaultLabelNames.length > 0) {
 				// Make a copy before mutating
 				val.labels = Object.assign({}, val.labels);
-			}
 
-			for (const labelName of defaultLabelNames) {
-				val.labels[labelName] =
-					val.labels[labelName] || this._defaultLabels[labelName];
+				for (const labelName of defaultLabelNames) {
+					val.labels[labelName] =
+						val.labels[labelName] || this._defaultLabels[labelName];
+				}
 			}
 
 			let labels = '';
@@ -102,12 +102,10 @@ class Registry {
 		for (const metric of this.getMetricsAsArray()) {
 			const item = metric.get();
 
-			if (item.values) {
+			if (item.values && defaultLabelNames.length > 0) {
 				for (const val of item.values) {
-					if (defaultLabelNames.length > 0) {
-						// Make a copy before mutating
-						val.labels = Object.assign({}, val.labels);
-					}
+					// Make a copy before mutating
+					val.labels = Object.assign({}, val.labels);
 
 					for (const labelName of defaultLabelNames) {
 						val.labels[labelName] =


### PR DESCRIPTION
Bug introduced at #220 and fixed for .getMetricAsPrometheusString() at #273.
Fixes #287