### PR TITLE
chore: fix CI/drop support for Node.js 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - node
-  - 6
   - 8
   - 10
+  - 12
+  - node
 os:
   - linux
   - osx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking
 
+- Dropped support for Node.js v6
+
 ### Changed
 
 - Changed `Metric` labelNames & labelValues in TypeScript declaration to a generic type `T extends string`, instead of `string`

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,10 +3,10 @@ init:
 
 environment:
   matrix:
-    - nodejs_version: 6
     - nodejs_version: 8
     - nodejs_version: 10
-    - nodejs_version: 11
+    - nodejs_version: 12
+    - nodejs_version: 13
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "index.d.ts"
   ],
   "engines": {
-    "node": ">=6.1"
+    "node": ">=8"
   },
   "scripts": {
     "benchmarks": "node ./benchmarks/index.js",


### PR DESCRIPTION
v6 is consistently failing in Travis, and is also EOL. Added v12 and 13.