### PR TITLE
fix: process_max_fds is process limit, not OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- fix: `process_max_fds` is process limit, not OS (#314)
 - Changed `Metric` labelNames & labelValues in TypeScript declaration to a generic type `T extends string`, instead of `string`
 - Lazy-load Node.js Cluster module to fix Passenger support (#293)
 - fix: avoid mutation bug in `registry.getMetricsAsJSON()`

--- a/lib/metrics/processMaxFileDescriptors.js
+++ b/lib/metrics/processMaxFileDescriptors.js
@@ -33,6 +33,12 @@ module.exports = (registry, config = {}) => {
 			isSet = true;
 
 			fileDescriptorsGauge.set(Number(maxFds));
+
+			// Only for interal use by tests, so they know when the
+			// value has been read.
+			if (config.ready) {
+				config.ready();
+			}
 		});
 	};
 };

--- a/lib/metrics/processMaxFileDescriptors.js
+++ b/lib/metrics/processMaxFileDescriptors.js
@@ -34,8 +34,8 @@ module.exports = (registry, config = {}) => {
 
 			let maxFds;
 			lines.find(line => {
-				const parts = line.split(/  +/);
-				if (parts[0] === 'Max open files') {
+				if (line.startsWith('Max open files')) {
+					const parts = line.split(/  +/);
 					maxFds = parts[1];
 					return true;
 				}

--- a/lib/metrics/processMaxFileDescriptors.js
+++ b/lib/metrics/processMaxFileDescriptors.js
@@ -25,10 +25,23 @@ module.exports = (registry, config = {}) => {
 			return;
 		}
 
-		fs.readFile('/proc/sys/fs/file-max', 'utf8', (err, maxFds) => {
+		fs.readFile('/proc/self/limits', 'utf8', (err, limits) => {
 			if (err) {
 				return;
 			}
+
+			const lines = limits.split('\n');
+
+			let maxFds;
+			lines.find(line => {
+				const parts = line.split(/  +/);
+				if (parts[0] === 'Max open files') {
+					maxFds = parts[1];
+					return true;
+				}
+			});
+
+			if (maxFds === undefined) return;
 
 			isSet = true;
 

--- a/test/metrics/maxFileDescriptorsTest.js
+++ b/test/metrics/maxFileDescriptorsTest.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const exec = require('child_process').execSync;
+
+describe('processMaxFileDescriptors', () => {
+	const register = require('../../index').register;
+	const processMaxFileDescriptors = require('../../lib/metrics/processMaxFileDescriptors');
+
+	beforeAll(() => {
+		register.clear();
+	});
+
+	afterEach(() => {
+		register.clear();
+	});
+
+	if (process.platform !== 'linux') {
+		it('should not add metric to the registry', () => {
+			expect(register.getMetricsAsJSON()).toHaveLength(0);
+
+			processMaxFileDescriptors()();
+
+			expect(register.getMetricsAsJSON()).toHaveLength(0);
+		});
+	} else {
+		it('should add metric to the registry', () => {
+			expect(register.getMetricsAsJSON()).toHaveLength(0);
+
+			processMaxFileDescriptors()();
+
+			const metrics = register.getMetricsAsJSON();
+
+			expect(metrics).toHaveLength(1);
+			expect(metrics[0].help).toEqual(
+				'Maximum number of open file descriptors.'
+			);
+			expect(metrics[0].type).toEqual('gauge');
+			expect(metrics[0].name).toEqual('process_max_fds');
+			expect(metrics[0].values).toHaveLength(1);
+		});
+
+		it('should have a reasonable metric value', done => {
+			const maxFiles = Number(exec('ulimit -Hn', { encoding: 'utf8' }));
+
+			expect(register.getMetricsAsJSON()).toHaveLength(0);
+			processMaxFileDescriptors(register, { ready })();
+
+			function ready() {
+				const metrics = register.getMetricsAsJSON();
+
+				expect(metrics).toHaveLength(1);
+				expect(metrics[0].values).toHaveLength(1);
+
+				expect(metrics[0].values[0].value).toBeLessThanOrEqual(maxFiles);
+				expect(metrics[0].values[0].value).toBeGreaterThan(0);
+
+				return done();
+			}
+		});
+	}
+});


### PR DESCRIPTION
Fix https://github.com/siimon/prom-client/issues/311

In case anyone is wondering why I don't check for a exact match against the ulimit output, instead of just for "reasonableness", its because there isn't really any way to check the ulimit for the current process other than reading `/proc/self/limits`. Shelling out to ulimit would gives the correct value, but for the child shell... but that ulimit will be the default for /bin/sh, which might not be the ulimit for the current jest process (and is not on my machine, my login /bin/zsh has a different ulimit than /bin/sh).