### PR TITLE
chore: drop support for Node.js 8.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 8
   - 10
   - 12
   - node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking
 
-- Dropped support for Node.js v6
+- Dropped support for end-of-life Node.js versions 6.x and 8.x
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "index.d.ts"
   ],
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "scripts": {
     "benchmarks": "node ./benchmarks/index.js",


### PR DESCRIPTION
Node.js 8.x is EOL. Since dropping support for a Node.js release line is
semver-major, might as well drop 8.x at the same time as 6.x.

cf. 32920d0e1d946197b