### PR TITLE
chore: add windows to CI platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ node_js:
 os:
   - linux
   - osx
+  - windows
 osx_image: xcode7.3


### PR DESCRIPTION
This increases CI coverage to all the "big three" (Windows, OSX, Linux).
prom-client support for Windows and OS X is incomplete, but it shouldn't
break for users who have it installed on their apps in development on
those platforms.


-----

I don't have Windows, but lets see if CI passes.