### PR TITLE
chore: reindent package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Lazy-load Node.js Cluster module to fix Passenger support (#293)
 - fix: avoid mutation bug in `registry.getMetricsAsJSON()`
 - fix: improve performance of `registry.getMetrics*`
+- chore: reindent package.json
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,92 +1,92 @@
 {
-  "name": "prom-client",
-  "version": "11.5.3",
-  "description": "Client for prometheus",
-  "main": "index.js",
-  "files": [
-    "lib/",
-    "index.js",
-    "index.d.ts"
-  ],
-  "engines": {
-    "node": ">=8"
-  },
-  "scripts": {
-    "benchmarks": "node ./benchmarks/index.js",
-    "test": "npm run lint && npm run compile-typescript && npm run test-unit",
-    "lint": "eslint .",
-    "test-unit": "jest",
-    "compile-typescript": "tsc --project ."
-  },
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:siimon/prom-client.git"
-  },
-  "keywords": [
-    "Prometheus",
-    "Metrics",
-    "Client"
-  ],
-  "author": "Simon Nyberg",
-  "license": "Apache-2.0",
-  "homepage": "https://github.com/siimon/prom-client",
-  "devDependencies": {
-    "@clevernature/benchmark-regression": "^1.0.0",
-    "eslint": "^5.6.0",
-    "eslint-config-prettier": "^4.3.0",
-    "eslint-plugin-node": "^8.0.0",
-    "eslint-plugin-prettier": "^3.0.1",
-    "express": "^4.13.3",
-    "husky": "^1.3.1",
-    "jest": "^24.8.0",
-    "lint-staged": "^7.0.0",
-    "lolex": "^4.0.1",
-    "prettier": "1.17.1",
-    "typescript": "^3.0.3"
-  },
-  "dependencies": {
-    "tdigest": "^0.1.1"
-  },
-  "types": "./index.d.ts",
-  "jest": {
-    "testEnvironment": "node",
-    "testRegex": ".*Test\\.js$"
-  },
-  "lint-staged": {
-    "*.js": [
-      "eslint --fix",
-      "git add"
-    ],
-    "*.{ts,md,json,yml}": [
-      "prettier --write",
-      "git add"
-    ],
-    ".{eslintrc,travis.yml}": [
-      "prettier --write",
-      "git add"
-    ]
-  },
-  "prettier": {
-    "singleQuote": true,
-    "useTabs": true,
-    "overrides": [
-      {
-        "files": "*.md",
-        "options": {
-          "useTabs": false
-        }
-      },
-      {
-        "files": ".eslintrc",
-        "options": {
-          "parser": "json"
-        }
-      }
-    ]
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  }
+	"name": "prom-client",
+	"version": "11.5.3",
+	"description": "Client for prometheus",
+	"main": "index.js",
+	"files": [
+		"lib/",
+		"index.js",
+		"index.d.ts"
+	],
+	"engines": {
+		"node": ">=8"
+	},
+	"scripts": {
+		"benchmarks": "node ./benchmarks/index.js",
+		"test": "npm run lint && npm run compile-typescript && npm run test-unit",
+		"lint": "eslint .",
+		"test-unit": "jest",
+		"compile-typescript": "tsc --project ."
+	},
+	"repository": {
+		"type": "git",
+		"url": "git@github.com:siimon/prom-client.git"
+	},
+	"keywords": [
+		"Prometheus",
+		"Metrics",
+		"Client"
+	],
+	"author": "Simon Nyberg",
+	"license": "Apache-2.0",
+	"homepage": "https://github.com/siimon/prom-client",
+	"devDependencies": {
+		"@clevernature/benchmark-regression": "^1.0.0",
+		"eslint": "^5.6.0",
+		"eslint-config-prettier": "^4.3.0",
+		"eslint-plugin-node": "^8.0.0",
+		"eslint-plugin-prettier": "^3.0.1",
+		"express": "^4.13.3",
+		"husky": "^1.3.1",
+		"jest": "^24.8.0",
+		"lint-staged": "^7.0.0",
+		"lolex": "^4.0.1",
+		"prettier": "1.17.1",
+		"typescript": "^3.0.3"
+	},
+	"dependencies": {
+		"tdigest": "^0.1.1"
+	},
+	"types": "./index.d.ts",
+	"jest": {
+		"testEnvironment": "node",
+		"testRegex": ".*Test\\.js$"
+	},
+	"lint-staged": {
+		"*.js": [
+			"eslint --fix",
+			"git add"
+		],
+		"*.{ts,md,json,yml}": [
+			"prettier --write",
+			"git add"
+		],
+		".{eslintrc,travis.yml}": [
+			"prettier --write",
+			"git add"
+		]
+	},
+	"prettier": {
+		"singleQuote": true,
+		"useTabs": true,
+		"overrides": [
+			{
+				"files": "*.md",
+				"options": {
+					"useTabs": false
+				}
+			},
+			{
+				"files": ".eslintrc",
+				"options": {
+					"parser": "json"
+				}
+			}
+		]
+	},
+	"husky": {
+		"hooks": {
+			"pre-commit": "lint-staged"
+		}
+	}
 }


### PR DESCRIPTION
The husky pre-commit script enforces use of TAB in .json files, and
package.json is using SPC SPC. This isn't noticable until someone
changes one line in the package.json, at which point the entire file
gets reindented.

-----

I did this by adding a single TAB to the start of one line in package.json, then git commiting it, this triggered husky's git-commit hook to reformat the file, et voila, this is the result.