### PR TITLE
chore: drop support for Node.js 8.x (appveyor)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ init:
 
 environment:
   matrix:
-    - nodejs_version: 8
     - nodejs_version: 10
     - nodejs_version: 12
     - nodejs_version: 13


### PR DESCRIPTION
Drop 8.x from appveyor's supported platforms.

Travis was dropped in #315, but appveyor was overlooked.

See:
- https://github.com/siimon/prom-client/pull/315
- https://github.com/siimon/prom-client/pull/316#issuecomment-579440589