### PR TITLE
chore: add GH Actions CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Test on Node.js v${{ matrix.node-version }}
+    name: Test on Node.js v${{ matrix.node-version }} and OS ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,23 @@
+name: Node.js CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Test on Node.js v${{ matrix.node-version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [10.x, 12.x, 13.x]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install and test
+        run: npm it

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Prometheus client for node.js [![Build Status](https://travis-ci.org/siimon/prom-client.svg?branch=master)](https://travis-ci.org/siimon/prom-client) [![Build status](https://ci.appveyor.com/api/projects/status/k2e0gwonkcee3lp9/branch/master?svg=true)](https://ci.appveyor.com/project/siimon/prom-client/branch/master) ![Build Status](https://github.com/siimon/prom-client/workflows/Node.js%20CI/badge.svg?branch=master)
+# Prometheus client for node.js [![Build Status](https://travis-ci.org/siimon/prom-client.svg?branch=master)](https://travis-ci.org/siimon/prom-client) [![Build status](https://ci.appveyor.com/api/projects/status/k2e0gwonkcee3lp9/branch/master?svg=true)](https://ci.appveyor.com/project/siimon/prom-client/branch/master) [![Actions Status](https://github.com/siimon/prom-client/workflows/Node.js%20CI/badge.svg?branch=master)](https://github.com/siimon/prom-client/actions)
 
 A prometheus client for node.js that supports histogram, summaries, gauges and
 counters.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Prometheus client for node.js [![Build Status](https://travis-ci.org/siimon/prom-client.svg?branch=master)](https://travis-ci.org/siimon/prom-client) [![Build status](https://ci.appveyor.com/api/projects/status/k2e0gwonkcee3lp9/branch/master?svg=true)](https://ci.appveyor.com/project/siimon/prom-client/branch/master)
+# Prometheus client for node.js [![Build Status](https://travis-ci.org/siimon/prom-client.svg?branch=master)](https://travis-ci.org/siimon/prom-client) [![Build status](https://ci.appveyor.com/api/projects/status/k2e0gwonkcee3lp9/branch/master?svg=true)](https://ci.appveyor.com/project/siimon/prom-client/branch/master) ![Build Status](https://github.com/siimon/prom-client/workflows/Node.js%20CI/badge.svg?branch=master)
 
 A prometheus client for node.js that supports histogram, summaries, gauges and
 counters.

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
 		]
 	},
 	"prettier": {
+		"endOfLine": "auto",
 		"singleQuote": true,
 		"useTabs": true,
 		"overrides": [

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
 		]
 	},
 	"prettier": {
-		"endOfLine": "auto",
 		"singleQuote": true,
 		"useTabs": true,
 		"overrides": [


### PR DESCRIPTION
Sets up GH Actions. Can replace both travis and appveyor.

It's (way) faster and has better integration with GH itself, which might matter if we ever wanna do releases from CI or some such. It also automatically picks up typescript and eslint errors and adds inline annotations, which is nice 🙂 