### PR TITLE
Added metrics for master in cluster mode

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -172,7 +172,9 @@ function addListeners() {
 					requests.delete(message.requestId);
 					clearTimeout(request.errorTimeout);
 
-					if (request.failed) return; // Callback already run with Error.
+                    if (request.failed) return; // Callback already run with Error.
+                    
+                    request.responses.push(Registry.globalRegistry.getMetricsAsJSON()); //add metrics of master
 
 					const registry = AggregatorRegistry.aggregate(request.responses);
 					const promString = registry.metrics();


### PR DESCRIPTION
In cluster mode, only metrics from workers are aggregated, and if you use metrics i master also this isn't shown in aggregated metrics. This fix adds master metrics also.