### PR TITLE
chore: use trailing commas

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Counters go up, and reset when the process restarts.
 const client = require('prom-client');
 const counter = new client.Counter({
   name: 'metric_name',
-  help: 'metric_help'
+  help: 'metric_help',
 });
 counter.inc(); // Inc with 1
 counter.inc(10); // Inc with 10
@@ -136,7 +136,7 @@ There are some utilities for common use cases:
 gauge.setToCurrentTime(); // Sets value to current time
 
 const end = gauge.startTimer();
-xhrRequest(function(err, res) {
+xhrRequest(function (err, res) {
   end(); // Sets value to xhrRequests duration in seconds
 });
 ```
@@ -155,7 +155,7 @@ const client = require('prom-client');
 new client.Histogram({
   name: 'metric_name',
   help: 'metric_help',
-  buckets: [0.1, 5, 15, 50, 100, 500]
+  buckets: [0.1, 5, 15, 50, 100, 500],
 });
 ```
 
@@ -167,7 +167,7 @@ new client.Histogram({
   name: 'metric_name',
   help: 'metric_help',
   labelNames: ['status_code'],
-  buckets: [0.1, 5, 15, 50, 100, 500]
+  buckets: [0.1, 5, 15, 50, 100, 500],
 });
 ```
 
@@ -177,7 +177,7 @@ Examples
 const client = require('prom-client');
 const histogram = new client.Histogram({
   name: 'metric_name',
-  help: 'metric_help'
+  help: 'metric_help',
 });
 histogram.observe(10); // Observe value in histogram
 ```
@@ -186,7 +186,7 @@ Utility to observe request durations
 
 ```js
 const end = histogram.startTimer();
-xhrRequest(function(err, res) {
+xhrRequest(function (err, res) {
   const seconds = end(); // Observes and returns the value to xhrRequests duration in seconds
 });
 ```
@@ -205,7 +205,7 @@ const client = require('prom-client');
 new client.Summary({
   name: 'metric_name',
   help: 'metric_help',
-  percentiles: [0.01, 0.1, 0.9, 0.99]
+  percentiles: [0.01, 0.1, 0.9, 0.99],
 });
 ```
 
@@ -218,7 +218,7 @@ new client.Summary({
   name: 'metric_name',
   help: 'metric_help',
   maxAgeSeconds: 600,
-  ageBuckets: 5
+  ageBuckets: 5,
 });
 ```
 
@@ -232,7 +232,7 @@ Usage example
 const client = require('prom-client');
 const summary = new client.Summary({
   name: 'metric_name',
-  help: 'metric_help'
+  help: 'metric_help',
 });
 summary.observe(10);
 ```
@@ -241,7 +241,7 @@ Utility to observe request durations
 
 ```js
 const end = summary.startTimer();
-xhrRequest(function(err, res) {
+xhrRequest(function (err, res) {
   end(); // Observes the value to xhrRequests duration in seconds
 });
 ```
@@ -257,7 +257,7 @@ const client = require('prom-client');
 const gauge = new client.Gauge({
   name: 'metric_name',
   help: 'metric_help',
-  labelNames: ['method', 'statusCode']
+  labelNames: ['method', 'statusCode'],
 });
 
 gauge.set({ method: 'GET', statusCode: '200' }, 100); // 1st version, Set value 100 with method set to GET and statusCode to 200
@@ -269,7 +269,7 @@ is created:
 
 ```js
 const end = startTimer({ method: 'GET' }); // Set method to GET, we don't know statusCode yet
-xhrRequest(function(err, res) {
+xhrRequest(function (err, res) {
   if (err) {
     end({ statusCode: '500' }); // Sets value to xhrRequest duration in seconds with statusCode 500
   } else {
@@ -321,12 +321,12 @@ const registry = new client.Registry();
 const counter = new client.Counter({
   name: 'metric_name',
   help: 'metric_help',
-  registers: [registry]
+  registers: [registry],
 });
 const histogram = new client.Histogram({
   name: 'metric_name',
   help: 'metric_help',
-  registers: []
+  registers: [],
 });
 registry.registerMetric(histogram);
 counter.inc();
@@ -404,15 +404,15 @@ It is possible to push metrics via a
 const client = require('prom-client');
 let gateway = new client.Pushgateway('http://127.0.0.1:9091');
 
-gateway.pushAdd({ jobName: 'test' }, function(err, resp, body) {}); //Add metric and overwrite old ones
-gateway.push({ jobName: 'test' }, function(err, resp, body) {}); //Overwrite all metrics (use PUT)
-gateway.delete({ jobName: 'test' }, function(err, resp, body) {}); //Delete all metrics for jobName
+gateway.pushAdd({ jobName: 'test' }, function (err, resp, body) {}); //Add metric and overwrite old ones
+gateway.push({ jobName: 'test' }, function (err, resp, body) {}); //Overwrite all metrics (use PUT)
+gateway.delete({ jobName: 'test' }, function (err, resp, body) {}); //Delete all metrics for jobName
 
 //All gateway requests can have groupings on it
-gateway.pushAdd({ jobName: 'test', groupings: { key: 'value' } }, function(
+gateway.pushAdd({ jobName: 'test', groupings: { key: 'value' } }, function (
   err,
   resp,
-  body
+  body,
 ) {});
 
 //It's possible to extend the Pushgateway with request options from nodes core http/https library
@@ -429,13 +429,13 @@ const client = require('prom-client');
 new client.Histogram({
   name: 'metric_name',
   help: 'metric_help',
-  buckets: client.linearBuckets(0, 10, 20) //Create 20 buckets, starting on 0 and a width of 10
+  buckets: client.linearBuckets(0, 10, 20), //Create 20 buckets, starting on 0 and a width of 10
 });
 
 new client.Histogram({
   name: 'metric_name',
   help: 'metric_help',
-  buckets: client.exponentialBuckets(1, 2, 5) //Create 5 buckets, starting on 1 and with a factor of 2
+  buckets: client.exponentialBuckets(1, 2, 5), //Create 5 buckets, starting on 1 and with a factor of 2
 });
 ```
 

--- a/benchmarks/histogram.js
+++ b/benchmarks/histogram.js
@@ -8,42 +8,42 @@ function setupHistogramSuite(suite) {
 	suite.add(
 		'observe#1 with 64',
 		labelCombinationFactory([64], (client, { histogram }, labels) =>
-			histogram.observe(labels, 1)
+			histogram.observe(labels, 1),
 		),
-		{ teardown, setup: setup(1) }
+		{ teardown, setup: setup(1) },
 	);
 
 	suite.add(
 		'observe#2 with 8',
 		labelCombinationFactory([8, 8], (client, { histogram }, labels) =>
-			histogram.observe(labels, 1)
+			histogram.observe(labels, 1),
 		),
-		{ teardown, setup: setup(2) }
+		{ teardown, setup: setup(2) },
 	);
 
 	suite.add(
 		'observe#2 with 4 and 2 with 2',
 		labelCombinationFactory([4, 4, 2, 2], (client, { histogram }, labels) =>
-			histogram.observe(labels, 1)
+			histogram.observe(labels, 1),
 		),
-		{ teardown, setup: setup(4) }
+		{ teardown, setup: setup(4) },
 	);
 
 	suite.add(
 		'observe#2 with 2 and 2 with 4',
 		labelCombinationFactory([2, 2, 4, 4], (client, { histogram }, labels) =>
-			histogram.observe(labels, 1)
+			histogram.observe(labels, 1),
 		),
-		{ teardown, setup: setup(4) }
+		{ teardown, setup: setup(4) },
 	);
 
 	suite.add(
 		'observe#6 with 2',
 		labelCombinationFactory(
 			[2, 2, 2, 2, 2, 2],
-			(client, { histogram }, labels) => histogram.observe(labels, 1)
+			(client, { histogram }, labels) => histogram.observe(labels, 1),
 		),
-		{ teardown, setup: setup(6) }
+		{ teardown, setup: setup(6) },
 	);
 }
 
@@ -55,7 +55,7 @@ function setup(labelCount) {
 			name: 'histogram',
 			help: 'histogram',
 			labelNames: getLabelNames(labelCount),
-			registers: [registry]
+			registers: [registry],
 		});
 
 		return { registry, histogram };

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -4,7 +4,7 @@ const createRegressionBenchmark = require('@clevernature/benchmark-regression');
 
 const currentClient = require('..');
 const benchmarks = createRegressionBenchmark(currentClient, [
-	'prom-client@latest'
+	'prom-client@latest',
 ]);
 
 benchmarks.suite('registry', require('./registry'));

--- a/benchmarks/registry.js
+++ b/benchmarks/registry.js
@@ -10,20 +10,20 @@ function setupRegistrySuite(suite) {
 		{ name: '2 with 8', counts: [8, 8] },
 		{ name: '2 with 4 and 2 with 2', counts: [4, 4, 2, 2] },
 		{ name: '2 with 2 and 2 with 4', counts: [2, 2, 4, 4] },
-		{ name: '6 with 2', counts: [2, 2, 2, 2, 2, 2] }
+		{ name: '6 with 2', counts: [2, 2, 2, 2, 2, 2] },
 	];
 
 	labelSetups.forEach(({ name, counts }) => {
 		suite.add(
 			`getMetricsAsJSON#${name}`,
 			(client, registry) => registry.getMetricsAsJSON(),
-			{ setup: setup(counts) }
+			{ setup: setup(counts) },
 		);
 	});
 
 	labelSetups.forEach(({ name, counts }) => {
 		suite.add(`metrics#${name}`, (client, registry) => registry.metrics(), {
-			setup: setup(counts)
+			setup: setup(counts),
 		});
 	});
 }
@@ -36,7 +36,7 @@ function setup(labelCounts) {
 			name: 'histogram',
 			help: 'histogram',
 			labelNames: getLabelNames(labelCounts.length),
-			registers: [registry]
+			registers: [registry],
 		});
 
 		const labelCombinations = getLabelCombinations(labelCounts);

--- a/benchmarks/summary.js
+++ b/benchmarks/summary.js
@@ -8,41 +8,41 @@ function setupSummarySuite(suite) {
 	suite.add(
 		'observe#1 with 64',
 		labelCombinationFactory([64], (client, { summary }, labels) =>
-			summary.observe(labels, 1)
+			summary.observe(labels, 1),
 		),
-		{ teardown, setup: setup(1) }
+		{ teardown, setup: setup(1) },
 	);
 
 	suite.add(
 		'observe#2 with 8',
 		labelCombinationFactory([8, 8], (client, { summary }, labels) =>
-			summary.observe(labels, 1)
+			summary.observe(labels, 1),
 		),
-		{ teardown, setup: setup(2) }
+		{ teardown, setup: setup(2) },
 	);
 
 	suite.add(
 		'observe#2 with 4 and 2 with 2',
 		labelCombinationFactory([4, 4, 2, 2], (client, { summary }, labels) =>
-			summary.observe(labels, 1)
+			summary.observe(labels, 1),
 		),
-		{ teardown, setup: setup(4) }
+		{ teardown, setup: setup(4) },
 	);
 
 	suite.add(
 		'observe#2 with 2 and 2 with 4',
 		labelCombinationFactory([2, 2, 4, 4], (client, { summary }, labels) =>
-			summary.observe(labels, 1)
+			summary.observe(labels, 1),
 		),
-		{ teardown, setup: setup(4) }
+		{ teardown, setup: setup(4) },
 	);
 
 	suite.add(
 		'observe#6 with 2',
 		labelCombinationFactory([2, 2, 2, 2, 2, 2], (client, { summary }, labels) =>
-			summary.observe(labels, 1)
+			summary.observe(labels, 1),
 		),
-		{ teardown, setup: setup(6) }
+		{ teardown, setup: setup(6) },
 	);
 }
 
@@ -54,7 +54,7 @@ function setup(labelCount) {
 			name: 'summary',
 			help: 'summary',
 			labelNames: getLabelNames(labelCount),
-			registers: [registry]
+			registers: [registry],
 		});
 
 		return { registry, summary };

--- a/benchmarks/utils/labels.js
+++ b/benchmarks/utils/labels.js
@@ -5,7 +5,7 @@ const letters = 'abcdefghijklmnopqrstuvwxyz'.split('');
 module.exports = {
 	getLabelNames,
 	getLabelCombinations,
-	labelCombinationFactory
+	labelCombinationFactory,
 };
 
 function getLabelNames(count) {
@@ -26,7 +26,7 @@ function getLabelCombinations(labelValues) {
 		labelNames.reduce((acc, label, i) => {
 			acc[label] = values[i];
 			return acc;
-		}, {})
+		}, {}),
 	);
 }
 

--- a/example/cluster.js
+++ b/example/cluster.js
@@ -21,7 +21,7 @@ if (cluster.isMaster) {
 
 	metricsServer.listen(3001);
 	console.log(
-		'Cluster metrics server listening to 3001, metrics exposed on /cluster_metrics'
+		'Cluster metrics server listening to 3001, metrics exposed on /cluster_metrics',
 	);
 } else {
 	require('./server.js');

--- a/example/server.js
+++ b/example/server.js
@@ -9,21 +9,21 @@ const Histogram = require('../').Histogram;
 const h = new Histogram({
 	name: 'test_histogram',
 	help: 'Example of a histogram',
-	labelNames: ['code']
+	labelNames: ['code'],
 });
 
 const Counter = require('../').Counter;
 const c = new Counter({
 	name: 'test_counter',
 	help: 'Example of a counter',
-	labelNames: ['code']
+	labelNames: ['code'],
 });
 
 const Gauge = require('../').Gauge;
 const g = new Gauge({
 	name: 'test_gauge',
 	help: 'Example of a gauge',
-	labelNames: ['method', 'code']
+	labelNames: ['method', 'code'],
 });
 
 setTimeout(() => {
@@ -82,11 +82,11 @@ server.get('/metrics/counter', (req, res) => {
 // Enable collection of default metrics
 require('../').collectDefaultMetrics({
 	timeout: 10000,
-	gcDurationBuckets: [0.001, 0.01, 0.1, 1, 2, 5] // These are the default buckets.
+	gcDurationBuckets: [0.001, 0.01, 0.1, 1, 2, 5], // These are the default buckets.
 });
 
 const port = process.env.PORT || 3000;
 console.log(
-	`Server listening to ${port}, metrics exposed on /metrics endpoint`
+	`Server listening to ${port}, metrics exposed on /metrics endpoint`,
 );
 server.listen(port);

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,7 @@ export class Registry {
 	/**
 	 * Get all registered collector functions
 	 */
-	collectors(): Collector[]
+	collectors(): Collector[];
 
 	/**
 	 * Get all metrics as objects
@@ -98,7 +98,7 @@ export class AggregatorRegistry extends Registry {
 	 *   metrics.
 	 */
 	clusterMetrics(
-		cb?: (err: Error | null, metrics?: string) => any
+		cb?: (err: Error | null, metrics?: string) => any,
 	): Promise<string>;
 
 	/**
@@ -140,7 +140,7 @@ export enum MetricType {
 	Counter,
 	Gauge,
 	Histogram,
-	Summary
+	Summary,
 }
 
 interface metric {
@@ -161,8 +161,7 @@ interface MetricConfiguration<T extends string> {
 }
 
 export interface CounterConfiguration<T extends string>
-	extends MetricConfiguration<T> {
-}
+	extends MetricConfiguration<T> {}
 
 /**
  * A counter is a cumulative metric that represents a single numerical value that only ever goes up
@@ -216,8 +215,7 @@ export namespace Counter {
 }
 
 export interface GaugeConfiguration<T extends string>
-	extends MetricConfiguration<T> {
-}
+	extends MetricConfiguration<T> {}
 
 /**
  * A gauge is a metric that represents a single numerical value that can arbitrarily go up and down.
@@ -505,7 +503,7 @@ export class Pushgateway {
 	 */
 	pushAdd(
 		params: Pushgateway.Parameters,
-		callback: (error?: Error, httpResponse?: any, body?: any) => void
+		callback: (error?: Error, httpResponse?: any, body?: any) => void,
 	): void;
 
 	/**
@@ -515,7 +513,7 @@ export class Pushgateway {
 	 */
 	push(
 		params: Pushgateway.Parameters,
-		callback: (error?: Error, httpResponse?: any, body?: any) => void
+		callback: (error?: Error, httpResponse?: any, body?: any) => void,
 	): void;
 
 	/**
@@ -525,7 +523,7 @@ export class Pushgateway {
 	 */
 	delete(
 		params: Pushgateway.Parameters,
-		callback: (error?: Error, httpResponse?: any, body?: any) => void
+		callback: (error?: Error, httpResponse?: any, body?: any) => void,
 	): void;
 }
 
@@ -554,7 +552,7 @@ export namespace Pushgateway {
 export function linearBuckets(
 	start: number,
 	width: number,
-	count: number
+	count: number,
 ): number[];
 
 /**
@@ -567,7 +565,7 @@ export function linearBuckets(
 export function exponentialBuckets(
 	start: number,
 	factor: number,
-	count: number
+	count: number,
 ): number[];
 
 export interface DefaultMetricsCollectorConfiguration {
@@ -582,7 +580,7 @@ export interface DefaultMetricsCollectorConfiguration {
  * @param config Configuration object for default metrics collector
  */
 export function collectDefaultMetrics(
-	config?: DefaultMetricsCollectorConfiguration
+	config?: DefaultMetricsCollectorConfiguration,
 ): void;
 
 export interface defaultMetrics {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -63,13 +63,13 @@ class AggregatorRegistry extends Registry {
 					const err = new Error('Operation timed out.');
 					request.done(err);
 				}, 5000),
-				failed: false
+				failed: false,
 			};
 			requests.set(requestId, request);
 
 			const message = {
 				type: GET_METRICS_REQ,
-				requestId
+				requestId,
 			};
 
 			for (const id in cluster().workers) {
@@ -121,9 +121,9 @@ class AggregatorRegistry extends Registry {
 			if (aggregatedMetric) {
 				const aggregatedMetricWrapper = Object.assign(
 					{
-						get: () => aggregatedMetric
+						get: () => aggregatedMetric,
 					},
-					aggregatedMetric
+					aggregatedMetric,
 				);
 				aggregatedRegistry.registerMetric(aggregatedMetricWrapper);
 			}
@@ -189,7 +189,7 @@ process.on('message', message => {
 		process.send({
 			type: GET_METRICS_RES,
 			requestId: message.requestId,
-			metrics: registries.map(r => r.getMetricsAsJSON())
+			metrics: registries.map(r => r.getMetricsAsJSON()),
 		});
 	}
 });

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -39,7 +39,7 @@ class Counter extends Metric {
 			name: this.name,
 			type,
 			values: Object.values(this.hashMap),
-			aggregator: this.aggregator
+			aggregator: this.aggregator,
 		};
 	}
 
@@ -48,7 +48,7 @@ class Counter extends Metric {
 		const hash = hashObject(labels);
 		validateLabel(this.labelNames, labels);
 		return {
-			inc: inc.call(this, labels, hash)
+			inc: inc.call(this, labels, hash),
 		};
 	}
 

--- a/lib/defaultMetrics.js
+++ b/lib/defaultMetrics.js
@@ -29,7 +29,7 @@ const metrics = {
 	heapSizeAndUsed,
 	heapSpacesSizeAndUsed,
 	version,
-	gc
+	gc,
 };
 const metricsList = Object.keys(metrics);
 
@@ -47,7 +47,7 @@ module.exports = function collectDefaultMetrics(config) {
 
 	if (last) {
 		throw new Error(
-			'Cannot add the default metrics twice to the same registry'
+			'Cannot add the default metrics twice to the same registry',
 		);
 	}
 

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -11,7 +11,7 @@ const {
 	getLabels,
 	hashObject,
 	isObject,
-	removeLabels
+	removeLabels,
 } = require('./util');
 const { validateLabel } = require('./validation');
 const { Metric } = require('./metric');
@@ -87,7 +87,7 @@ class Gauge extends Metric {
 			name: this.name,
 			type,
 			values: Object.values(this.hashMap),
-			aggregator: this.aggregator
+			aggregator: this.aggregator,
 		};
 	}
 
@@ -103,7 +103,7 @@ class Gauge extends Metric {
 			dec: dec.call(this, labels),
 			set: set.call(this, labels),
 			setToCurrentTime: setToCurrentTime.call(this, labels),
-			startTimer: startTimer.call(this, labels)
+			startTimer: startTimer.call(this, labels),
 		};
 	}
 
@@ -131,7 +131,7 @@ function startTimer(startLabels) {
 			const delta = process.hrtime(start);
 			this.set(
 				Object.assign({}, startLabels, endLabels),
-				delta[0] + delta[1] / 1e9
+				delta[0] + delta[1] / 1e9,
 			);
 		};
 	};
@@ -176,12 +176,12 @@ function convertLabelsAndValues(labels, value) {
 	if (!isObject(labels)) {
 		return {
 			value: labels,
-			labels: {}
+			labels: {},
 		};
 	}
 	return {
 		labels,
-		value
+		value,
 	};
 }
 

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -12,7 +12,7 @@ const { Metric } = require('./metric');
 class Histogram extends Metric {
 	constructor(config) {
 		super(config, {
-			buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
+			buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
 		});
 
 		for (const label of this.labelNames) {
@@ -34,8 +34,8 @@ class Histogram extends Metric {
 			this.hashMap = {
 				[hashObject({})]: createBaseValues(
 					{},
-					Object.assign({}, this.bucketValues)
-				)
+					Object.assign({}, this.bucketValues),
+				),
 			};
 		}
 	}
@@ -61,7 +61,7 @@ class Histogram extends Metric {
 			help: this.help,
 			type,
 			values,
-			aggregator: this.aggregator
+			aggregator: this.aggregator,
 		};
 	}
 
@@ -90,7 +90,7 @@ class Histogram extends Metric {
 		const labels = getLabels(this.labelNames, arguments);
 		return {
 			observe: observe.call(this, labels),
-			startTimer: startTimer.call(this, labels)
+			startTimer: startTimer.call(this, labels),
 		};
 	}
 
@@ -116,7 +116,7 @@ function setValuePair(labels, value, metricName) {
 	return {
 		labels,
 		value,
-		metricName
+		metricName,
 	};
 }
 
@@ -137,7 +137,7 @@ function observe(labels) {
 		validateLabel(this.labelNames, labelValuePair.labels);
 		if (!Number.isFinite(labelValuePair.value)) {
 			throw new TypeError(
-				`Value is not a valid number: ${util.format(labelValuePair.value)}`
+				`Value is not a valid number: ${util.format(labelValuePair.value)}`,
 			);
 		}
 
@@ -146,7 +146,7 @@ function observe(labels) {
 		if (!valueFromMap) {
 			valueFromMap = createBaseValues(
 				labelValuePair.labels,
-				Object.assign({}, this.bucketValues)
+				Object.assign({}, this.bucketValues),
 			);
 		}
 
@@ -168,7 +168,7 @@ function createBaseValues(labels, bucketValues) {
 		labels,
 		bucketValues,
 		sum: 0,
-		count: 0
+		count: 0,
 	};
 }
 
@@ -176,12 +176,12 @@ function convertLabelsAndValues(labels, value) {
 	if (!isObject(labels)) {
 		return {
 			value: labels,
-			labels: {}
+			labels: {},
 		};
 	}
 	return {
 		labels,
-		value
+		value,
 	};
 }
 
@@ -213,7 +213,7 @@ function addSumAndCountForExport(histogram) {
 		acc.push(
 			setValuePair(infLabel, d.data.count, `${histogram.name}_bucket`),
 			setValuePair(d.data.labels, d.data.sum, `${histogram.name}_sum`),
-			setValuePair(d.data.labels, d.data.count, `${histogram.name}_count`)
+			setValuePair(d.data.labels, d.data.count, `${histogram.name}_count`),
 		);
 		return acc;
 	};

--- a/lib/metric.js
+++ b/lib/metric.js
@@ -17,10 +17,10 @@ class Metric {
 			{
 				labelNames: [],
 				registers: [globalRegistry],
-				aggregator: 'sum'
+				aggregator: 'sum',
 			},
 			defaults,
-			config
+			config,
 		);
 		if (!this.registers) {
 			// in case config.registers is `undefined`

--- a/lib/metricAggregators.js
+++ b/lib/metricAggregators.js
@@ -15,7 +15,7 @@ function AggregatorFactory(aggregatorFn) {
 			name: metrics[0].name,
 			type: metrics[0].type,
 			values: [],
-			aggregator: metrics[0].aggregator
+			aggregator: metrics[0].aggregator,
 		};
 		// Gather metrics by metricName and labels.
 		const byLabels = new Grouper();
@@ -30,7 +30,7 @@ function AggregatorFactory(aggregatorFn) {
 			if (values.length === 0) return;
 			const valObj = {
 				value: aggregatorFn(values),
-				labels: values[0].labels
+				labels: values[0].labels,
 			};
 			if (values[0].metricName) {
 				valObj.metricName = values[0].metricName;
@@ -64,18 +64,18 @@ exports.aggregators = {
 	 * @return The arithmetic mean of the values.
 	 */
 	average: AggregatorFactory(
-		v => v.reduce((p, c) => p + c.value, 0) / v.length
+		v => v.reduce((p, c) => p + c.value, 0) / v.length,
 	),
 	/**
 	 * @return The minimum of the values.
 	 */
 	min: AggregatorFactory(v =>
-		v.reduce((p, c) => Math.min(p, c.value), Infinity)
+		v.reduce((p, c) => Math.min(p, c.value), Infinity),
 	),
 	/**
 	 * @return The maximum of the values.
 	 */
 	max: AggregatorFactory(v =>
-		v.reduce((p, c) => Math.max(p, c.value), -Infinity)
-	)
+		v.reduce((p, c) => Math.max(p, c.value), -Infinity),
+	),
 };

--- a/lib/metrics/eventLoopLag.js
+++ b/lib/metrics/eventLoopLag.js
@@ -39,42 +39,42 @@ module.exports = (registry, config = {}) => {
 		name: namePrefix + NODEJS_EVENTLOOP_LAG,
 		help: 'Lag of event loop in seconds.',
 		registers: registry ? [registry] : undefined,
-		aggregator: 'average'
+		aggregator: 'average',
 	});
 	const lagMin = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_MIN,
 		help: 'The minimum recorded event loop delay.',
-		registers: registry ? [registry] : undefined
+		registers: registry ? [registry] : undefined,
 	});
 	const lagMax = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_MAX,
 		help: 'The maximum recorded event loop delay.',
-		registers: registry ? [registry] : undefined
+		registers: registry ? [registry] : undefined,
 	});
 	const lagMean = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_MEAN,
 		help: 'The mean of the recorded event loop delays.',
-		registers: registry ? [registry] : undefined
+		registers: registry ? [registry] : undefined,
 	});
 	const lagStddev = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_STDDEV,
 		help: 'The standard deviation of the recorded event loop delays.',
-		registers: registry ? [registry] : undefined
+		registers: registry ? [registry] : undefined,
 	});
 	const lagP50 = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_P50,
 		help: 'The 50th percentile of the recorded event loop delays.',
-		registers: registry ? [registry] : undefined
+		registers: registry ? [registry] : undefined,
 	});
 	const lagP90 = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_P90,
 		help: 'The 90th percentile of the recorded event loop delays.',
-		registers: registry ? [registry] : undefined
+		registers: registry ? [registry] : undefined,
 	});
 	const lagP99 = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_P99,
 		help: 'The 99th percentile of the recorded event loop delays.',
-		registers: registry ? [registry] : undefined
+		registers: registry ? [registry] : undefined,
 	});
 
 	if (!perf_hooks || !perf_hooks.monitorEventLoopDelay) {
@@ -85,7 +85,7 @@ module.exports = (registry, config = {}) => {
 	}
 
 	const histogram = perf_hooks.monitorEventLoopDelay({
-		resolution: config.eventLoopMonitoringPrecision
+		resolution: config.eventLoopMonitoringPrecision,
 	});
 	histogram.enable();
 
@@ -111,5 +111,5 @@ module.exports.metricNames = [
 	NODEJS_EVENTLOOP_LAG_STDDEV,
 	NODEJS_EVENTLOOP_LAG_P50,
 	NODEJS_EVENTLOOP_LAG_P90,
-	NODEJS_EVENTLOOP_LAG_P99
+	NODEJS_EVENTLOOP_LAG_P99,
 ];

--- a/lib/metrics/gc.js
+++ b/lib/metrics/gc.js
@@ -34,7 +34,7 @@ module.exports = (registry, config = {}) => {
 			'Garbage collection duration by kind, one of major, minor, incremental or weakcb.',
 		labelNames: ['kind'],
 		buckets,
-		registers: registry ? [registry] : undefined
+		registers: registry ? [registry] : undefined,
 	});
 
 	const obs = new perf_hooks.PerformanceObserver(list => {

--- a/lib/metrics/heapSizeAndUsed.js
+++ b/lib/metrics/heapSizeAndUsed.js
@@ -18,17 +18,17 @@ module.exports = (registry, config = {}) => {
 	const heapSizeTotal = new Gauge({
 		name: namePrefix + NODEJS_HEAP_SIZE_TOTAL,
 		help: 'Process heap size from Node.js in bytes.',
-		registers
+		registers,
 	});
 	const heapSizeUsed = new Gauge({
 		name: namePrefix + NODEJS_HEAP_SIZE_USED,
 		help: 'Process heap size used from Node.js in bytes.',
-		registers
+		registers,
 	});
 	const externalMemUsed = new Gauge({
 		name: namePrefix + NODEJS_EXTERNAL_MEMORY,
 		help: 'Node.js external memory size in bytes.',
-		registers
+		registers,
 	});
 
 	return () => {
@@ -45,7 +45,7 @@ module.exports = (registry, config = {}) => {
 		return {
 			total: heapSizeTotal,
 			used: heapSizeUsed,
-			external: externalMemUsed
+			external: externalMemUsed,
 		};
 	};
 };
@@ -53,5 +53,5 @@ module.exports = (registry, config = {}) => {
 module.exports.metricNames = [
 	NODEJS_HEAP_SIZE_TOTAL,
 	NODEJS_HEAP_SIZE_USED,
-	NODEJS_EXTERNAL_MEMORY
+	NODEJS_EXTERNAL_MEMORY,
 ];

--- a/lib/metrics/heapSpacesSizeAndUsed.js
+++ b/lib/metrics/heapSpacesSizeAndUsed.js
@@ -21,7 +21,7 @@ module.exports = (registry, config = {}) => {
 			name: namePrefix + NODEJS_HEAP_SIZE[metricType],
 			help: `Process heap space size ${metricType} from Node.js in bytes.`,
 			labelNames: ['space'],
-			registers
+			registers,
 		});
 	});
 
@@ -29,13 +29,13 @@ module.exports = (registry, config = {}) => {
 		const data = {
 			total: {},
 			used: {},
-			available: {}
+			available: {},
 		};
 
 		v8.getHeapSpaceStatistics().forEach(space => {
 			const spaceName = space.space_name.substr(
 				0,
-				space.space_name.indexOf('_space')
+				space.space_name.indexOf('_space'),
 			);
 
 			data.total[spaceName] = space.space_size;

--- a/lib/metrics/helpers/processMetricsHelpers.js
+++ b/lib/metrics/helpers/processMetricsHelpers.js
@@ -28,5 +28,5 @@ function updateMetrics(gauge, data) {
 
 module.exports = {
 	aggregateByObjectName,
-	updateMetrics
+	updateMetrics,
 };

--- a/lib/metrics/osMemoryHeap.js
+++ b/lib/metrics/osMemoryHeap.js
@@ -12,7 +12,7 @@ function notLinuxVariant(registry, config = {}) {
 	const residentMemGauge = new Gauge({
 		name: namePrefix + PROCESS_RESIDENT_MEMORY,
 		help: 'Resident memory size in bytes.',
-		registers: registry ? [registry] : undefined
+		registers: registry ? [registry] : undefined,
 	});
 
 	return () => {

--- a/lib/metrics/osMemoryHeapLinux.js
+++ b/lib/metrics/osMemoryHeapLinux.js
@@ -38,17 +38,17 @@ module.exports = (registry, config = {}) => {
 	const residentMemGauge = new Gauge({
 		name: namePrefix + PROCESS_RESIDENT_MEMORY,
 		help: 'Resident memory size in bytes.',
-		registers
+		registers,
 	});
 	const virtualMemGauge = new Gauge({
 		name: namePrefix + PROCESS_VIRTUAL_MEMORY,
 		help: 'Virtual memory size in bytes.',
-		registers
+		registers,
 	});
 	const heapSizeMemGauge = new Gauge({
 		name: namePrefix + PROCESS_HEAP,
 		help: 'Process heap size in bytes.',
-		registers
+		registers,
 	});
 
 	// Sync I/O is often problematic, but /proc isn't really I/O, it a
@@ -74,5 +74,5 @@ module.exports = (registry, config = {}) => {
 module.exports.metricNames = [
 	PROCESS_RESIDENT_MEMORY,
 	PROCESS_VIRTUAL_MEMORY,
-	PROCESS_HEAP
+	PROCESS_HEAP,
 ];

--- a/lib/metrics/processCpuTotal.js
+++ b/lib/metrics/processCpuTotal.js
@@ -12,17 +12,17 @@ module.exports = (registry, config = {}) => {
 	const cpuUserUsageCounter = new Counter({
 		name: namePrefix + PROCESS_CPU_USER_SECONDS,
 		help: 'Total user CPU time spent in seconds.',
-		registers
+		registers,
 	});
 	const cpuSystemUsageCounter = new Counter({
 		name: namePrefix + PROCESS_CPU_SYSTEM_SECONDS,
 		help: 'Total system CPU time spent in seconds.',
-		registers
+		registers,
 	});
 	const cpuUsageCounter = new Counter({
 		name: namePrefix + PROCESS_CPU_SECONDS,
 		help: 'Total user and system CPU time spent in seconds.',
-		registers
+		registers,
 	});
 
 	let lastCpuUsage = process.cpuUsage();
@@ -44,5 +44,5 @@ module.exports = (registry, config = {}) => {
 module.exports.metricNames = [
 	PROCESS_CPU_USER_SECONDS,
 	PROCESS_CPU_SYSTEM_SECONDS,
-	PROCESS_CPU_SECONDS
+	PROCESS_CPU_SECONDS,
 ];

--- a/lib/metrics/processHandles.js
+++ b/lib/metrics/processHandles.js
@@ -20,12 +20,12 @@ module.exports = (registry, config = {}) => {
 		help:
 			'Number of active libuv handles grouped by handle type. Every handle type is C++ class name.',
 		labelNames: ['type'],
-		registers: registry ? [registry] : undefined
+		registers: registry ? [registry] : undefined,
 	});
 	const totalGauge = new Gauge({
 		name: namePrefix + NODEJS_ACTIVE_HANDLES_TOTAL,
 		help: 'Total number of active handles.',
-		registers: registry ? [registry] : undefined
+		registers: registry ? [registry] : undefined,
 	});
 
 	return () => {
@@ -37,5 +37,5 @@ module.exports = (registry, config = {}) => {
 
 module.exports.metricNames = [
 	NODEJS_ACTIVE_HANDLES,
-	NODEJS_ACTIVE_HANDLES_TOTAL
+	NODEJS_ACTIVE_HANDLES_TOTAL,
 ];

--- a/lib/metrics/processMaxFileDescriptors.js
+++ b/lib/metrics/processMaxFileDescriptors.js
@@ -31,7 +31,7 @@ module.exports = (registry, config = {}) => {
 	const fileDescriptorsGauge = new Gauge({
 		name: namePrefix + PROCESS_MAX_FDS,
 		help: 'Maximum number of open file descriptors.',
-		registers: registry ? [registry] : undefined
+		registers: registry ? [registry] : undefined,
 	});
 
 	fileDescriptorsGauge.set(Number(maxFds));

--- a/lib/metrics/processOpenFileDescriptors.js
+++ b/lib/metrics/processOpenFileDescriptors.js
@@ -16,7 +16,7 @@ module.exports = (registry, config = {}) => {
 	const fileDescriptorsGauge = new Gauge({
 		name: namePrefix + PROCESS_OPEN_FDS,
 		help: 'Number of open file descriptors.',
-		registers: registry ? [registry] : undefined
+		registers: registry ? [registry] : undefined,
 	});
 
 	return () => {

--- a/lib/metrics/processRequests.js
+++ b/lib/metrics/processRequests.js
@@ -19,13 +19,13 @@ module.exports = (registry, config = {}) => {
 		help:
 			'Number of active libuv requests grouped by request type. Every request type is C++ class name.',
 		labelNames: ['type'],
-		registers: registry ? [registry] : undefined
+		registers: registry ? [registry] : undefined,
 	});
 
 	const totalGauge = new Gauge({
 		name: namePrefix + NODEJS_ACTIVE_REQUESTS_TOTAL,
 		help: 'Total number of active requests.',
-		registers: registry ? [registry] : undefined
+		registers: registry ? [registry] : undefined,
 	});
 
 	return () => {
@@ -37,5 +37,5 @@ module.exports = (registry, config = {}) => {
 
 module.exports.metricNames = [
 	NODEJS_ACTIVE_REQUESTS,
-	NODEJS_ACTIVE_REQUESTS_TOTAL
+	NODEJS_ACTIVE_REQUESTS_TOTAL,
 ];

--- a/lib/metrics/processStartTime.js
+++ b/lib/metrics/processStartTime.js
@@ -12,7 +12,7 @@ module.exports = (registry, config = {}) => {
 		name: namePrefix + PROCESS_START_TIME,
 		help: 'Start time of the process since unix epoch in seconds.',
 		registers: registry ? [registry] : undefined,
-		aggregator: 'omit'
+		aggregator: 'omit',
 	});
 	cpuUserGauge.set(startInSeconds);
 

--- a/lib/metrics/version.js
+++ b/lib/metrics/version.js
@@ -14,7 +14,7 @@ module.exports = (registry, config = {}) => {
 		help: 'Node.js version info.',
 		labelNames: ['version', 'major', 'minor', 'patch'],
 		registers: registry ? [registry] : undefined,
-		aggregator: 'first'
+		aggregator: 'first',
 	});
 
 	return () => {
@@ -23,7 +23,7 @@ module.exports = (registry, config = {}) => {
 				version,
 				versionSegments[0],
 				versionSegments[1],
-				versionSegments[2]
+				versionSegments[2],
 			)
 			.set(1);
 	};

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -48,7 +48,7 @@ function useGateway(method, job, groupings, callback) {
 			? gatewayUrlParsed.pathname
 			: '';
 	const path = `${gatewayUrlPath}/metrics/job/${encodeURIComponent(
-		job
+		job,
 	)}${generateGroupings(groupings)}`;
 
 	// eslint-disable-next-line node/no-deprecated-api
@@ -57,7 +57,7 @@ function useGateway(method, job, groupings, callback) {
 	const requestParams = url.parse(target);
 	const httpModule = isHttps(requestParams.href) ? https : http;
 	const options = Object.assign(requestParams, this.requestOptions, {
-		method
+		method,
 	});
 
 	const req = httpModule.request(options, res => {
@@ -86,7 +86,8 @@ function generateGroupings(groupings) {
 	}
 	return Object.keys(groupings)
 		.map(
-			key => `/${encodeURIComponent(key)}/${encodeURIComponent(groupings[key])}`
+			key =>
+				`/${encodeURIComponent(key)}/${encodeURIComponent(groupings[key])}`,
 		)
 		.join('');
 }

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -78,7 +78,7 @@ class Registry {
 	registerMetric(metric) {
 		if (this._metrics[metric.name] && this._metrics[metric.name] !== metric) {
 			throw new Error(
-				`A metric with the name ${metric.name} has already been registered.`
+				`A metric with the name ${metric.name} has already been registered.`,
 			);
 		}
 
@@ -164,7 +164,7 @@ class Registry {
 
 		const metricsToMerge = registers.reduce(
 			(acc, reg) => acc.concat(reg.getMetricsAsArray()),
-			[]
+			[],
 		);
 
 		metricsToMerge.forEach(mergedRegistry.registerMetric, mergedRegistry);

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -17,7 +17,7 @@ class Summary extends Metric {
 		super(config, {
 			percentiles: [0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999],
 			compressCount: DEFAULT_COMPRESS_COUNT,
-			hashMap: {}
+			hashMap: {},
 		});
 
 		for (const label of this.labelNames) {
@@ -31,8 +31,8 @@ class Summary extends Metric {
 					labels: {},
 					td: new timeWindowQuantiles(this.maxAgeSeconds, this.ageBuckets),
 					count: 0,
-					sum: 0
-				}
+					sum: 0,
+				},
 			};
 		}
 	}
@@ -63,7 +63,7 @@ class Summary extends Metric {
 			help: this.help,
 			type,
 			values,
-			aggregator: this.aggregator
+			aggregator: this.aggregator,
 		};
 	}
 
@@ -94,7 +94,7 @@ class Summary extends Metric {
 		const labels = getLabels(this.labelNames, arguments);
 		return {
 			observe: observe.call(this, labels),
-			startTimer: startTimer.call(this, labels)
+			startTimer: startTimer.call(this, labels),
 		};
 	}
 
@@ -111,7 +111,7 @@ function extractSummariesForExport(summaryOfLabels, percentiles) {
 		const percentileValue = summaryOfLabels.td.percentile(percentile);
 		return {
 			labels: Object.assign({ quantile: percentile }, summaryOfLabels.labels),
-			value: percentileValue ? percentileValue : 0
+			value: percentileValue ? percentileValue : 0,
 		};
 	});
 }
@@ -120,7 +120,7 @@ function getCountForExport(value, summary) {
 	return {
 		metricName: `${summary.name}_count`,
 		labels: value.labels,
-		value: value.count
+		value: value.count,
 	};
 }
 
@@ -128,7 +128,7 @@ function getSumForExport(value, summary) {
 	return {
 		metricName: `${summary.name}_sum`,
 		labels: value.labels,
-		value: value.sum
+		value: value.sum,
 	};
 }
 
@@ -139,7 +139,7 @@ function startTimer(startLabels) {
 			const delta = process.hrtime(start);
 			this.observe(
 				Object.assign({}, startLabels, endLabels),
-				delta[0] + delta[1] / 1e9
+				delta[0] + delta[1] / 1e9,
 			);
 		};
 	};
@@ -152,7 +152,7 @@ function observe(labels) {
 		validateLabel(this.labelNames, this.labels);
 		if (!Number.isFinite(labelValuePair.value)) {
 			throw new TypeError(
-				`Value is not a valid number: ${util.format(labelValuePair.value)}`
+				`Value is not a valid number: ${util.format(labelValuePair.value)}`,
 			);
 		}
 
@@ -163,7 +163,7 @@ function observe(labels) {
 				labels: labelValuePair.labels,
 				td: new timeWindowQuantiles(this.maxAgeSeconds, this.ageBuckets),
 				count: 0,
-				sum: 0
+				sum: 0,
 			};
 		}
 
@@ -181,13 +181,13 @@ function convertLabelsAndValues(labels, value) {
 	if (value === undefined) {
 		return {
 			value: labels,
-			labels: {}
+			labels: {},
 		};
 	}
 
 	return {
 		labels,
-		value
+		value,
 	};
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -23,7 +23,7 @@ exports.setValue = function setValue(hashMap, value, labels) {
 	const hash = hashObject(labels);
 	hashMap[hash] = {
 		value: typeof value === 'number' ? value : 0,
-		labels: labels || {}
+		labels: labels || {},
 	};
 	return hashMap;
 };

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -25,8 +25,8 @@ exports.validateLabel = function validateLabel(savedLabels, labels) {
 		if (savedLabels.indexOf(label) === -1) {
 			throw new Error(
 				`Added label "${label}" is not included in initial labelset: ${util.inspect(
-					savedLabels
-				)}`
+					savedLabels,
+				)}`,
 			);
 		}
 	});

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"singleQuote": true,
 		"useTabs": true,
 		"arrowParens": "avoid",
-		"trailingComma": "none",
+		"trailingComma": "all",
 		"overrides": [
 			{
 				"files": "*.md",

--- a/test/aggregatorsTest.js
+++ b/test/aggregatorsTest.js
@@ -9,8 +9,8 @@ describe('aggregators', () => {
 			type: 'does not matter',
 			values: [
 				{ labels: [], value: 1 },
-				{ labels: ['label1'], value: 2 }
-			]
+				{ labels: ['label1'], value: 2 },
+			],
 		},
 		{
 			help: 'metric_help',
@@ -18,9 +18,9 @@ describe('aggregators', () => {
 			type: 'does not matter',
 			values: [
 				{ labels: [], value: 3 },
-				{ labels: ['label1'], value: 4 }
-			]
-		}
+				{ labels: ['label1'], value: 4 },
+			],
+		},
 	];
 
 	describe('sum', () => {
@@ -31,7 +31,7 @@ describe('aggregators', () => {
 			expect(result.type).toBe('does not matter');
 			expect(result.values).toEqual([
 				{ value: 4, labels: [] },
-				{ value: 6, labels: ['label1'] }
+				{ value: 6, labels: ['label1'] },
 			]);
 		});
 	});
@@ -44,7 +44,7 @@ describe('aggregators', () => {
 			expect(result.type).toBe('does not matter');
 			expect(result.values).toEqual([
 				{ value: 1, labels: [] },
-				{ value: 2, labels: ['label1'] }
+				{ value: 2, labels: ['label1'] },
 			]);
 		});
 	});
@@ -64,7 +64,7 @@ describe('aggregators', () => {
 			expect(result.type).toBe('does not matter');
 			expect(result.values).toEqual([
 				{ value: 2, labels: [] },
-				{ value: 3, labels: ['label1'] }
+				{ value: 3, labels: ['label1'] },
 			]);
 		});
 	});
@@ -77,7 +77,7 @@ describe('aggregators', () => {
 			expect(result.type).toBe('does not matter');
 			expect(result.values).toEqual([
 				{ value: 1, labels: [] },
-				{ value: 2, labels: ['label1'] }
+				{ value: 2, labels: ['label1'] },
 			]);
 		});
 	});
@@ -90,7 +90,7 @@ describe('aggregators', () => {
 			expect(result.type).toBe('does not matter');
 			expect(result.values).toEqual([
 				{ value: 3, labels: [] },
-				{ value: 4, labels: ['label1'] }
+				{ value: 4, labels: ['label1'] },
 			]);
 		});
 	});
@@ -102,25 +102,25 @@ describe('aggregators', () => {
 					help: 'metric_help',
 					name: 'metric_name',
 					type: 'does not matter',
-					values: [{ labels: [], value: 1, metricName: 'abc' }]
+					values: [{ labels: [], value: 1, metricName: 'abc' }],
 				},
 				{
 					help: 'metric_help',
 					name: 'metric_name',
 					type: 'does not matter',
-					values: [{ labels: [], value: 3, metricName: 'abc' }]
+					values: [{ labels: [], value: 3, metricName: 'abc' }],
 				},
 				{
 					help: 'metric_help',
 					name: 'metric_name',
 					type: 'does not matter',
-					values: [{ labels: [], value: 5, metricName: 'def' }]
-				}
+					values: [{ labels: [], value: 5, metricName: 'def' }],
+				},
 			];
 			const result = aggregators.sum(metrics2);
 			expect(result.values).toEqual([
 				{ value: 4, labels: [], metricName: 'abc' },
-				{ value: 5, labels: [], metricName: 'def' }
+				{ value: 5, labels: [], metricName: 'def' },
 			]);
 		});
 	});

--- a/test/clusterTest.js
+++ b/test/clusterTest.js
@@ -46,15 +46,15 @@ describe('AggregatorRegistry', () => {
 					{
 						labels: { le: 0.1, code: '300' },
 						value: 0,
-						metricName: 'test_histogram_bucket'
+						metricName: 'test_histogram_bucket',
 					},
 					{
 						labels: { le: 10, code: '300' },
 						value: 1.6486727018068046,
-						metricName: 'test_histogram_bucket'
-					}
+						metricName: 'test_histogram_bucket',
+					},
 				],
-				aggregator: 'sum'
+				aggregator: 'sum',
 			},
 			{
 				help: 'Example of a gauge',
@@ -63,23 +63,23 @@ describe('AggregatorRegistry', () => {
 				values: [
 					{ value: 0.47, labels: { method: 'get', code: 200 } },
 					{ value: 0.64, labels: {} },
-					{ value: 23, labels: { method: 'post', code: '300' } }
+					{ value: 23, labels: { method: 'post', code: '300' } },
 				],
-				aggregator: 'sum'
+				aggregator: 'sum',
 			},
 			{
 				help: 'Start time of the process since unix epoch in seconds.',
 				name: 'process_start_time_seconds',
 				type: 'gauge',
 				values: [{ value: 1502075832, labels: {} }],
-				aggregator: 'omit'
+				aggregator: 'omit',
 			},
 			{
 				help: 'Lag of event loop in seconds.',
 				name: 'nodejs_eventloop_lag_seconds',
 				type: 'gauge',
 				values: [{ value: 0.009, labels: {} }],
-				aggregator: 'average'
+				aggregator: 'average',
 			},
 			{
 				help: 'Node.js version info.',
@@ -88,11 +88,11 @@ describe('AggregatorRegistry', () => {
 				values: [
 					{
 						value: 1,
-						labels: { version: 'v6.11.1', major: 6, minor: 11, patch: 1 }
-					}
+						labels: { version: 'v6.11.1', major: 6, minor: 11, patch: 1 },
+					},
 				],
-				aggregator: 'first'
-			}
+				aggregator: 'first',
+			},
 		];
 		const metricsArr2 = [
 			{
@@ -103,15 +103,15 @@ describe('AggregatorRegistry', () => {
 					{
 						labels: { le: 0.1, code: '300' },
 						value: 0.235151,
-						metricName: 'test_histogram_bucket'
+						metricName: 'test_histogram_bucket',
 					},
 					{
 						labels: { le: 10, code: '300' },
 						value: 1.192591,
-						metricName: 'test_histogram_bucket'
-					}
+						metricName: 'test_histogram_bucket',
+					},
 				],
-				aggregator: 'sum'
+				aggregator: 'sum',
 			},
 			{
 				help: 'Example of a gauge',
@@ -120,23 +120,23 @@ describe('AggregatorRegistry', () => {
 				values: [
 					{ value: 0.02, labels: { method: 'get', code: 200 } },
 					{ value: 0.24, labels: {} },
-					{ value: 51, labels: { method: 'post', code: '300' } }
+					{ value: 51, labels: { method: 'post', code: '300' } },
 				],
-				aggregator: 'sum'
+				aggregator: 'sum',
 			},
 			{
 				help: 'Start time of the process since unix epoch in seconds.',
 				name: 'process_start_time_seconds',
 				type: 'gauge',
 				values: [{ value: 1502075849, labels: {} }],
-				aggregator: 'omit'
+				aggregator: 'omit',
 			},
 			{
 				help: 'Lag of event loop in seconds.',
 				name: 'nodejs_eventloop_lag_seconds',
 				type: 'gauge',
 				values: [{ value: 0.008, labels: {} }],
-				aggregator: 'average'
+				aggregator: 'average',
 			},
 			{
 				help: 'Node.js version info.',
@@ -145,11 +145,11 @@ describe('AggregatorRegistry', () => {
 				values: [
 					{
 						value: 1,
-						labels: { version: 'v6.11.1', major: 6, minor: 11, patch: 1 }
-					}
+						labels: { version: 'v6.11.1', major: 6, minor: 11, patch: 1 },
+					},
 				],
-				aggregator: 'first'
-			}
+				aggregator: 'first',
+			},
 		];
 
 		const aggregated = Registry.aggregate([metricsArr1, metricsArr2]);
@@ -164,15 +164,15 @@ describe('AggregatorRegistry', () => {
 					{
 						labels: { le: 0.1, code: '300' },
 						value: 0.235151,
-						metricName: 'test_histogram_bucket'
+						metricName: 'test_histogram_bucket',
 					},
 					{
 						labels: { le: 10, code: '300' },
 						value: 2.8412637018068043,
-						metricName: 'test_histogram_bucket'
-					}
+						metricName: 'test_histogram_bucket',
+					},
 				],
-				aggregator: 'sum'
+				aggregator: 'sum',
 			});
 		});
 
@@ -185,15 +185,15 @@ describe('AggregatorRegistry', () => {
 				values: [
 					{ value: 0.49, labels: { method: 'get', code: 200 } },
 					{ value: 0.88, labels: {} },
-					{ value: 74, labels: { method: 'post', code: '300' } }
+					{ value: 74, labels: { method: 'post', code: '300' } },
 				],
-				aggregator: 'sum'
+				aggregator: 'sum',
 			});
 		});
 
 		it('uses `aggregate` method defined for process_start_time', () => {
 			const procStartTime = aggregated.getSingleMetric(
-				'process_start_time_seconds'
+				'process_start_time_seconds',
 			);
 			expect(procStartTime).toBeUndefined();
 		});
@@ -207,7 +207,7 @@ describe('AggregatorRegistry', () => {
 				name: 'nodejs_eventloop_lag_seconds',
 				type: 'gauge',
 				values: [{ value: 0.0085, labels: {} }],
-				aggregator: 'average'
+				aggregator: 'average',
 			});
 		});
 
@@ -220,7 +220,7 @@ describe('AggregatorRegistry', () => {
 				name: 'nodejs_eventloop_lag_seconds',
 				type: 'gauge',
 				values: [{ value: 0.0085, labels: {} }],
-				aggregator: 'average'
+				aggregator: 'average',
 			});
 		});
 
@@ -233,10 +233,10 @@ describe('AggregatorRegistry', () => {
 				values: [
 					{
 						value: 1,
-						labels: { version: 'v6.11.1', major: 6, minor: 11, patch: 1 }
-					}
+						labels: { version: 'v6.11.1', major: 6, minor: 11, patch: 1 },
+					},
 				],
-				aggregator: 'first'
+				aggregator: 'first',
 			});
 		});
 	});

--- a/test/counterTest.js
+++ b/test/counterTest.js
@@ -53,7 +53,7 @@ describe('counter', () => {
 				instance = new Counter({
 					name: 'gauge_test_2',
 					help: 'help',
-					labelNames: ['method', 'endpoint']
+					labelNames: ['method', 'endpoint'],
 				});
 			});
 
@@ -100,7 +100,7 @@ describe('counter', () => {
 			instance = new Counter({
 				name: 'gauge_test_3',
 				help: 'help',
-				labelNames: ['method', 'endpoint']
+				labelNames: ['method', 'endpoint'],
 			});
 			instance.inc({ method: 'GET', endpoint: '/test' });
 			instance.inc({ method: 'POST', endpoint: '/test' });
@@ -141,7 +141,7 @@ describe('counter', () => {
 			instance = new Counter({
 				name: 'gauge_test',
 				help: 'test',
-				registers: []
+				registers: [],
 			});
 		});
 		it('should increment counter', () => {
@@ -158,7 +158,7 @@ describe('counter', () => {
 			instance = new Counter({
 				name: 'gauge_test',
 				help: 'test',
-				registers: [registryInstance]
+				registers: [registryInstance],
 			});
 		});
 		it('should increment counter', () => {
@@ -176,7 +176,7 @@ describe('counter', () => {
 		it('should reset labelless counter', () => {
 			const instance = new Counter({
 				name: 'test_metric',
-				help: 'Another test metric'
+				help: 'Another test metric',
 			});
 
 			instance.inc(12);
@@ -192,7 +192,7 @@ describe('counter', () => {
 			const instance = new Counter({
 				name: 'test_metric',
 				help: 'Another test metric',
-				labelNames: ['serial', 'active']
+				labelNames: ['serial', 'active'],
 			});
 
 			instance.inc({ serial: '12345', active: 'yes' }, 12);

--- a/test/defaultMetricsTest.js
+++ b/test/defaultMetricsTest.js
@@ -13,14 +13,14 @@ describe('collectDefaultMetrics', () => {
 		cpuUsage = process.cpuUsage;
 
 		Object.defineProperty(process, 'platform', {
-			value: 'my-bogus-platform'
+			value: 'my-bogus-platform',
 		});
 
 		if (cpuUsage) {
 			Object.defineProperty(process, 'cpuUsage', {
 				value() {
 					return { user: 1000, system: 10 };
-				}
+				},
 			});
 		} else {
 			process.cpuUsage = function () {
@@ -33,12 +33,12 @@ describe('collectDefaultMetrics', () => {
 
 	afterAll(() => {
 		Object.defineProperty(process, 'platform', {
-			value: platform
+			value: platform,
 		});
 
 		if (cpuUsage) {
 			Object.defineProperty(process, 'cpuUsage', {
-				value: cpuUsage
+				value: cpuUsage,
 			});
 		} else {
 			delete process.cpuUsage;

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -68,7 +68,7 @@ describe('gauge', () => {
 			it('should init to 0', () => {
 				instance = new Gauge({
 					name: 'init_gauge',
-					help: 'somehelp'
+					help: 'somehelp',
 				});
 				expectValue(0);
 			});
@@ -78,7 +78,7 @@ describe('gauge', () => {
 					instance = new Gauge({
 						name: 'name',
 						help: 'help',
-						labelNames: ['code']
+						labelNames: ['code'],
 					});
 					instance.set({ code: '200' }, 20);
 				});
@@ -120,7 +120,7 @@ describe('gauge', () => {
 					instance = new Gauge({
 						name: 'name_2',
 						help: 'help',
-						labelNames: ['code', 'success']
+						labelNames: ['code', 'success'],
 					});
 					const clock = lolex.install();
 					const end = instance.startTimer({ code: 200 });
@@ -142,7 +142,7 @@ describe('gauge', () => {
 					instance = new Gauge({
 						name: 'name',
 						help: 'help',
-						labelNames: ['code']
+						labelNames: ['code'],
 					});
 					instance.set({ code: '200' }, 20);
 					instance.set({ code: '400' }, 0);
@@ -182,7 +182,7 @@ describe('gauge', () => {
 			instance = new Gauge({
 				name: 'gauge_test',
 				help: 'help',
-				registers: [registryInstance]
+				registers: [registryInstance],
 			});
 			instance.set(10);
 		});
@@ -199,7 +199,7 @@ describe('gauge', () => {
 		it('should reset labelless gauge', () => {
 			const instance = new Gauge({
 				name: 'test_metric',
-				help: 'Another test metric'
+				help: 'Another test metric',
 			});
 
 			instance.set(12);
@@ -215,7 +215,7 @@ describe('gauge', () => {
 			const instance = new Gauge({
 				name: 'test_metric',
 				help: 'Another test metric',
-				labelNames: ['serial', 'active']
+				labelNames: ['serial', 'active'],
 			});
 
 			instance.set({ serial: '12345', active: 'yes' }, 12);

--- a/test/histogramTest.js
+++ b/test/histogramTest.js
@@ -22,7 +22,7 @@ describe('histogram', () => {
 				instance.observe(0.5);
 				const valuePair = getValueByName(
 					'test_histogram_count',
-					instance.get().values
+					instance.get().values,
 				);
 				expect(valuePair.value).toEqual(1);
 			});
@@ -35,7 +35,7 @@ describe('histogram', () => {
 				instance.observe(0.5);
 				const valuePair = getValueByName(
 					'test_histogram_sum',
-					instance.get().values
+					instance.get().values,
 				);
 				expect(valuePair.value).toEqual(0.5);
 			});
@@ -58,7 +58,7 @@ describe('histogram', () => {
 				instance.observe(10);
 				const countValuePair = getValueByName(
 					'test_histogram_count',
-					instance.get().values
+					instance.get().values,
 				);
 				const infValuePair = getValueByLabel('+Inf', instance.get().values);
 				expect(infValuePair.value).toEqual(countValuePair.value);
@@ -68,7 +68,7 @@ describe('histogram', () => {
 				const histogram = new Histogram({
 					name: 'test_histogram_2',
 					help: 'test',
-					buckets: [1, 5]
+					buckets: [1, 5],
 				});
 				histogram.observe(1.5);
 				const values = histogram.get().values;
@@ -80,7 +80,7 @@ describe('histogram', () => {
 				const histogram = new Histogram({
 					name: 'test_histogram_2',
 					help: 'test',
-					labelNames: ['code']
+					labelNames: ['code'],
 				});
 				histogram.observe({ code: '200' }, 1);
 				histogram.observe({ code: '300' }, 1);
@@ -119,7 +119,7 @@ describe('histogram', () => {
 				const i = new Histogram({
 					name: 'histo',
 					help: 'help',
-					labelNames: ['code']
+					labelNames: ['code'],
 				});
 				i.observe({ code: 'test' }, 1);
 				const pair = getValueByLeAndLabel(1, 'code', 'test', i.get().values);
@@ -144,13 +144,13 @@ describe('histogram', () => {
 				instance.observe(0.5);
 				let valuePair = getValueByName(
 					'test_histogram_count',
-					instance.get().values
+					instance.get().values,
 				);
 				expect(valuePair.value).toEqual(1);
 				instance.reset();
 				valuePair = getValueByName(
 					'test_histogram_count',
-					instance.get().values
+					instance.get().values,
 				);
 				expect(valuePair.value).toEqual(undefined);
 			});
@@ -166,7 +166,7 @@ describe('histogram', () => {
 					instance = new Histogram({
 						name: 'histogram_labels',
 						help: 'Histogram with labels fn',
-						labelNames: ['method']
+						labelNames: ['method'],
 					});
 				});
 
@@ -176,7 +176,7 @@ describe('histogram', () => {
 						5,
 						'method',
 						'get',
-						instance.get().values
+						instance.get().values,
 					);
 					expect(res.value).toEqual(1);
 				});
@@ -197,7 +197,7 @@ describe('histogram', () => {
 						0.5,
 						'method',
 						'get',
-						instance.get().values
+						instance.get().values,
 					);
 					expect(res.value).toEqual(1);
 					clock.uninstall();
@@ -212,7 +212,7 @@ describe('histogram', () => {
 						0.5,
 						'method',
 						'get',
-						instance.get().values
+						instance.get().values,
 					);
 					expect(res.value).toEqual(1);
 					clock.uninstall();
@@ -222,7 +222,7 @@ describe('histogram', () => {
 					instance = new Histogram({
 						name: 'histogram_labels_2',
 						help: 'Histogram with labels fn',
-						labelNames: ['method', 'success']
+						labelNames: ['method', 'success'],
 					});
 					const clock = lolex.install();
 					const end = instance.startTimer({ method: 'get' });
@@ -232,13 +232,13 @@ describe('histogram', () => {
 						0.5,
 						'method',
 						'get',
-						instance.get().values
+						instance.get().values,
 					);
 					const res2 = getValueByLeAndLabel(
 						0.5,
 						'success',
 						'SUCCESS',
-						instance.get().values
+						instance.get().values,
 					);
 					expect(res1.value).toEqual(1);
 					expect(res2.value).toEqual(1);
@@ -258,7 +258,7 @@ describe('histogram', () => {
 					instance = new Histogram({
 						name: 'histogram_labels',
 						help: 'Histogram with labels fn',
-						labelNames: ['method']
+						labelNames: ['method'],
 					});
 				});
 
@@ -271,7 +271,7 @@ describe('histogram', () => {
 						5,
 						'method',
 						'GET',
-						instance.get().values
+						instance.get().values,
 					);
 					expect(res.value).toEqual(1);
 				});
@@ -304,7 +304,7 @@ describe('histogram', () => {
 						0.5,
 						'method',
 						'GET',
-						instance.get().values
+						instance.get().values,
 					);
 					expect(res.value).toEqual(1);
 					clock.uninstall();
@@ -324,7 +324,7 @@ describe('histogram', () => {
 					instance = new Histogram({
 						name: 'histogram_labels_2',
 						help: 'Histogram with labels fn',
-						labelNames: ['method', 'success']
+						labelNames: ['method', 'success'],
 					});
 					const clock = lolex.install();
 					const end = instance.startTimer({ method: 'GET' });
@@ -342,14 +342,14 @@ describe('histogram', () => {
 				instance = new Histogram({
 					name: 'test_histogram',
 					help: 'test',
-					registers: []
+					registers: [],
 				});
 			});
 			it('should increase count', () => {
 				instance.observe(0.5);
 				const valuePair = getValueByName(
 					'test_histogram_count',
-					instance.get().values
+					instance.get().values,
 				);
 				expect(valuePair.value).toEqual(1);
 				expect(globalRegistry.getMetricsAsJSON().length).toEqual(0);
@@ -362,14 +362,14 @@ describe('histogram', () => {
 				instance = new Histogram({
 					name: 'test_histogram',
 					help: 'test',
-					registers: [registryInstance]
+					registers: [registryInstance],
 				});
 			});
 			it('should increment counter', () => {
 				instance.observe(0.5);
 				const valuePair = getValueByName(
 					'test_histogram_count',
-					instance.get().values
+					instance.get().values,
 				);
 				expect(valuePair.value).toEqual(1);
 				expect(globalRegistry.getMetricsAsJSON().length).toEqual(0);

--- a/test/metrics/eventLoopLagTest.js
+++ b/test/metrics/eventLoopLagTest.js
@@ -33,31 +33,31 @@ describe('eventLoopLag', () => {
 			expect(metrics[2].name).toEqual('nodejs_eventloop_lag_max_seconds');
 
 			expect(metrics[3].help).toEqual(
-				'The mean of the recorded event loop delays.'
+				'The mean of the recorded event loop delays.',
 			);
 			expect(metrics[3].type).toEqual('gauge');
 			expect(metrics[3].name).toEqual('nodejs_eventloop_lag_mean_seconds');
 
 			expect(metrics[4].help).toEqual(
-				'The standard deviation of the recorded event loop delays.'
+				'The standard deviation of the recorded event loop delays.',
 			);
 			expect(metrics[4].type).toEqual('gauge');
 			expect(metrics[4].name).toEqual('nodejs_eventloop_lag_stddev_seconds');
 
 			expect(metrics[5].help).toEqual(
-				'The 50th percentile of the recorded event loop delays.'
+				'The 50th percentile of the recorded event loop delays.',
 			);
 			expect(metrics[5].type).toEqual('gauge');
 			expect(metrics[5].name).toEqual('nodejs_eventloop_lag_p50_seconds');
 
 			expect(metrics[6].help).toEqual(
-				'The 90th percentile of the recorded event loop delays.'
+				'The 90th percentile of the recorded event loop delays.',
 			);
 			expect(metrics[6].type).toEqual('gauge');
 			expect(metrics[6].name).toEqual('nodejs_eventloop_lag_p90_seconds');
 
 			expect(metrics[7].help).toEqual(
-				'The 99th percentile of the recorded event loop delays.'
+				'The 99th percentile of the recorded event loop delays.',
 			);
 			expect(metrics[7].type).toEqual('gauge');
 			expect(metrics[7].name).toEqual('nodejs_eventloop_lag_p99_seconds');

--- a/test/metrics/gcTest.js
+++ b/test/metrics/gcTest.js
@@ -32,7 +32,7 @@ describe('gc', () => {
 			expect(metrics).toHaveLength(1);
 
 			expect(metrics[0].help).toEqual(
-				'Garbage collection duration by kind, one of major, minor, incremental or weakcb.'
+				'Garbage collection duration by kind, one of major, minor, incremental or weakcb.',
 			);
 			expect(metrics[0].type).toEqual('histogram');
 			expect(metrics[0].name).toEqual('nodejs_gc_duration_seconds');

--- a/test/metrics/heapSpacesSizeAndUsedTest.js
+++ b/test/metrics/heapSpacesSizeAndUsedTest.js
@@ -9,38 +9,38 @@ jest.mock('v8', () => {
 					space_size: 100,
 					space_used_size: 50,
 					space_available_size: 500,
-					physical_space_size: 100
+					physical_space_size: 100,
 				},
 				{
 					space_name: 'old_space',
 					space_size: 100,
 					space_used_size: 50,
 					space_available_size: 500,
-					physical_space_size: 100
+					physical_space_size: 100,
 				},
 				{
 					space_name: 'code_space',
 					space_size: 100,
 					space_used_size: 50,
 					space_available_size: 500,
-					physical_space_size: 100
+					physical_space_size: 100,
 				},
 				{
 					space_name: 'map_space',
 					space_size: 100,
 					space_used_size: 50,
 					space_available_size: 500,
-					physical_space_size: 100
+					physical_space_size: 100,
 				},
 				{
 					space_name: 'large_object_space',
 					space_size: 100,
 					space_used_size: 50,
 					space_available_size: 500,
-					physical_space_size: 100
-				}
+					physical_space_size: 100,
+				},
 			];
-		}
+		},
 	};
 });
 
@@ -60,7 +60,7 @@ describe('heapSpacesSizeAndUsed', () => {
 		const expectedObj = {
 			total: { new: 100, old: 100, code: 100, map: 100, large_object: 100 },
 			used: { new: 50, old: 50, code: 50, map: 50, large_object: 50 },
-			available: { new: 500, old: 500, code: 500, map: 500, large_object: 500 }
+			available: { new: 500, old: 500, code: 500, map: 500, large_object: 500 },
 		};
 
 		expect(heapSpacesSizeAndUsed()()).toEqual(expectedObj);

--- a/test/metrics/maxFileDescriptorsTest.js
+++ b/test/metrics/maxFileDescriptorsTest.js
@@ -32,7 +32,7 @@ describe('processMaxFileDescriptors', () => {
 
 			expect(metrics).toHaveLength(1);
 			expect(metrics[0].help).toEqual(
-				'Maximum number of open file descriptors.'
+				'Maximum number of open file descriptors.',
 			);
 			expect(metrics[0].type).toEqual('gauge');
 			expect(metrics[0].name).toEqual('process_max_fds');

--- a/test/metrics/processHandlesTest.js
+++ b/test/metrics/processHandlesTest.js
@@ -22,7 +22,7 @@ describe('processHandles', () => {
 		expect(metrics).toHaveLength(2);
 
 		expect(metrics[0].help).toEqual(
-			'Number of active libuv handles grouped by handle type. Every handle type is C++ class name.'
+			'Number of active libuv handles grouped by handle type. Every handle type is C++ class name.',
 		);
 		expect(metrics[0].type).toEqual('gauge');
 		expect(metrics[0].name).toEqual('nodejs_active_handles');

--- a/test/metrics/processOpenFileDescriptorsTest.js
+++ b/test/metrics/processOpenFileDescriptorsTest.js
@@ -7,7 +7,7 @@ describe('processOpenFileDescriptors', () => {
 	jest.mock(
 		'process',
 		() =>
-			Object.assign({}, jest.requireActual('process'), { platform: 'linux' }) // This metric only works on Linux
+			Object.assign({}, jest.requireActual('process'), { platform: 'linux' }), // This metric only works on Linux
 	);
 
 	beforeAll(() => {

--- a/test/metrics/processRequestsTest.js
+++ b/test/metrics/processRequestsTest.js
@@ -21,7 +21,7 @@ describe('processRequests', () => {
 
 		expect(metrics).toHaveLength(2);
 		expect(metrics[0].help).toEqual(
-			'Number of active libuv requests grouped by request type. Every request type is C++ class name.'
+			'Number of active libuv requests grouped by request type. Every request type is C++ class name.',
 		);
 		expect(metrics[0].type).toEqual('gauge');
 		expect(metrics[0].name).toEqual('nodejs_active_requests');

--- a/test/metrics/processStartTimeTest.js
+++ b/test/metrics/processStartTimeTest.js
@@ -22,7 +22,7 @@ describe('processStartTime', () => {
 
 		expect(metrics).toHaveLength(1);
 		expect(metrics[0].help).toEqual(
-			'Start time of the process since unix epoch in seconds.'
+			'Start time of the process since unix epoch in seconds.',
 		);
 		expect(metrics[0].type).toEqual('gauge');
 		expect(metrics[0].name).toEqual('process_start_time_seconds');

--- a/test/pushgatewayTest.js
+++ b/test/pushgatewayTest.js
@@ -3,12 +3,12 @@
 const mockHttp = jest.fn().mockReturnValue({
 	on: jest.fn(),
 	end: jest.fn(),
-	write: jest.fn()
+	write: jest.fn(),
 });
 
 jest.mock('http', () => {
 	return {
-		request: mockHttp
+		request: mockHttp,
 	};
 });
 
@@ -89,7 +89,7 @@ describe('pushgateway', () => {
 				instance = new Pushgateway(
 					`http://${auth}@192.168.99.100:9091`,
 					null,
-					registry
+					registry,
 				);
 			});
 
@@ -126,10 +126,10 @@ describe('pushgateway', () => {
 				'http://192.168.99.100:9091',
 				{
 					headers: {
-						'unit-test': '1'
-					}
+						'unit-test': '1',
+					},
 				},
-				registry
+				registry,
 			);
 
 			instance.push({ jobName: 'testJob' });
@@ -164,7 +164,7 @@ describe('pushgateway', () => {
 			const cnt = new promeClient.Counter({
 				name: 'test',
 				help: 'test',
-				registers: [registry]
+				registers: [registry],
 			});
 			cnt.inc(100);
 		});

--- a/test/pushgatewayWithPathTest.js
+++ b/test/pushgatewayWithPathTest.js
@@ -7,12 +7,12 @@ const pushGatewayFullURL = pushGatewayURL + pushGatewayPath;
 const mockHttp = jest.fn().mockReturnValue({
 	on: jest.fn(),
 	end: jest.fn(),
-	write: jest.fn()
+	write: jest.fn(),
 });
 
 jest.mock('http', () => {
 	return {
-		request: mockHttp
+		request: mockHttp,
 	};
 });
 
@@ -50,7 +50,7 @@ describe('pushgateway with path', () => {
 				const invocation = mockHttp.mock.calls[0][0];
 				expect(invocation.method).toEqual('POST');
 				expect(invocation.path).toEqual(
-					'/path/metrics/job/testJob/key/va%26lue'
+					'/path/metrics/job/testJob/key/va%26lue',
 				);
 			});
 		});
@@ -95,7 +95,7 @@ describe('pushgateway with path', () => {
 				instance = new Pushgateway(
 					`http://${auth}@192.168.99.100:9091${pushGatewayPath}`,
 					null,
-					registry
+					registry,
 				);
 			});
 
@@ -132,10 +132,10 @@ describe('pushgateway with path', () => {
 				pushGatewayFullURL,
 				{
 					headers: {
-						'unit-test': '1'
-					}
+						'unit-test': '1',
+					},
 				},
-				registry
+				registry,
 			);
 
 			instance.push({ jobName: 'testJob' });
@@ -170,7 +170,7 @@ describe('pushgateway with path', () => {
 			const cnt = new promClient.Counter({
 				name: 'test',
 				help: 'test',
-				registers: [registry]
+				registers: [registry],
 			});
 			cnt.inc(100);
 		});

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -38,7 +38,7 @@ describe('register', () => {
 		expect(() => {
 			register.registerMetric(getMetric());
 		}).toThrowError(
-			'A metric with the name test_metric has already been registered.'
+			'A metric with the name test_metric has already been registered.',
 		);
 	});
 
@@ -51,11 +51,11 @@ describe('register', () => {
 					help: 'A test metric',
 					values: [
 						{
-							value: NaN
-						}
-					]
+							value: NaN,
+						},
+					],
 				};
-			}
+			},
 		});
 		const lines = register.metrics().split('\n');
 		expect(lines).toHaveLength(4);
@@ -71,11 +71,11 @@ describe('register', () => {
 					help: 'A test metric',
 					values: [
 						{
-							value: Infinity
-						}
-					]
+							value: Infinity,
+						},
+					],
 				};
-			}
+			},
 		});
 		const lines = register.metrics().split('\n');
 		expect(lines).toHaveLength(4);
@@ -91,11 +91,11 @@ describe('register', () => {
 					help: 'A test metric',
 					values: [
 						{
-							value: -Infinity
-						}
-					]
+							value: -Infinity,
+						},
+					],
 				};
-			}
+			},
 		});
 		const lines = register.metrics().split('\n');
 		expect(lines).toHaveLength(4);
@@ -111,11 +111,11 @@ describe('register', () => {
 					help: 'A test metric',
 					values: [
 						{
-							value: 1
-						}
-					]
+							value: 1,
+						},
+					],
 				};
-			}
+			},
 		});
 		expect(register.metrics().split('\n')).toHaveLength(4);
 	});
@@ -128,9 +128,9 @@ describe('register', () => {
 					name: 'test_metric',
 					type: 'counter',
 					help: 'A test metric',
-					values: [{ value: 1 }]
+					values: [{ value: 1 }],
 				};
-			}
+			},
 		});
 
 		const output = register.metrics().split('\n')[2];
@@ -150,16 +150,16 @@ describe('register', () => {
 							value: 1,
 							labels: {
 								testLabel: 'overlapped',
-								anotherLabel: 'value123'
-							}
-						}
-					]
+								anotherLabel: 'value123',
+							},
+						},
+					],
 				};
-			}
+			},
 		});
 
 		expect(register.metrics().split('\n')[2]).toEqual(
-			'test_metric{testLabel="overlapped",anotherLabel="value123"} 1'
+			'test_metric{testLabel="overlapped",anotherLabel="value123"} 1',
 		);
 	});
 
@@ -189,9 +189,9 @@ describe('register', () => {
 					return {
 						name: 'test_"_\\_\n_metric',
 						help: 'help_help',
-						type: 'counter'
+						type: 'counter',
 					};
-				}
+				},
 			});
 			escapedResult = register.metrics();
 		});
@@ -215,12 +215,12 @@ describe('register', () => {
 							value: 12,
 							labels: {
 								label: 'hello',
-								code: '3"03'
-							}
-						}
-					]
+								code: '3"03',
+							},
+						},
+					],
 				};
-			}
+			},
 		});
 		const escapedResult = register.metrics();
 		expect(escapedResult).toMatch(/\\"/);
@@ -241,7 +241,7 @@ describe('register', () => {
 		it('should add default labels to JSON', () => {
 			register.registerMetric(getMetric());
 			register.setDefaultLabels({
-				defaultRegistryLabel: 'testValue'
+				defaultRegistryLabel: 'testValue',
 			});
 			const output = register.getMetricsAsJSON();
 
@@ -253,7 +253,7 @@ describe('register', () => {
 			expect(output[0].values[0].labels).toEqual({
 				code: '303',
 				label: 'hello',
-				defaultRegistryLabel: 'testValue'
+				defaultRegistryLabel: 'testValue',
 			});
 		});
 	});
@@ -287,7 +287,7 @@ describe('register', () => {
 		const metrics = register.metrics();
 
 		expect(metrics.split('\n')[3]).toEqual(
-			'test_metric{label="bye",code="404"} 34'
+			'test_metric{label="bye",code="404"} 34',
 		);
 	});
 
@@ -296,21 +296,21 @@ describe('register', () => {
 			const counter = new Counter({
 				name: 'test_counter',
 				help: 'test metric',
-				labelNames: ['serial', 'active']
+				labelNames: ['serial', 'active'],
 			});
 			const gauge = new Gauge({
 				name: 'test_gauge',
 				help: 'Another test metric',
-				labelNames: ['level']
+				labelNames: ['level'],
 			});
 			const histo = new Histogram({
 				name: 'test_histo',
-				help: 'test'
+				help: 'test',
 			});
 			const summ = new Summary({
 				name: 'test_summ',
 				help: 'test',
-				percentiles: [0.5]
+				percentiles: [0.5],
 			});
 			register.registerMetric(counter);
 			register.registerMetric(gauge);
@@ -346,14 +346,14 @@ describe('register', () => {
 				it('should not throw with default labels (counter)', () => {
 					const r = new Registry();
 					r.setDefaultLabels({
-						env: 'development'
+						env: 'development',
 					});
 
 					const counter = new Counter({
 						name: 'my_counter',
 						help: 'my counter',
 						registers: [r],
-						labelNames: ['type']
+						labelNames: ['type'],
 					});
 
 					const myCounter = counter.labels('myType');
@@ -363,7 +363,7 @@ describe('register', () => {
 					const metrics = r.metrics();
 					const lines = metrics.split('\n');
 					expect(lines).toContain(
-						'my_counter{type="myType",env="development"} 1'
+						'my_counter{type="myType",env="development"} 1',
 					);
 
 					myCounter.inc();
@@ -371,21 +371,21 @@ describe('register', () => {
 					const metrics2 = r.metrics();
 					const lines2 = metrics2.split('\n');
 					expect(lines2).toContain(
-						'my_counter{type="myType",env="development"} 2'
+						'my_counter{type="myType",env="development"} 2',
 					);
 				});
 
 				it('should not throw with default labels (gauge)', () => {
 					const r = new Registry();
 					r.setDefaultLabels({
-						env: 'development'
+						env: 'development',
 					});
 
 					const gauge = new Gauge({
 						name: 'my_gauge',
 						help: 'my gauge',
 						registers: [r],
-						labelNames: ['type']
+						labelNames: ['type'],
 					});
 
 					const myGauge = gauge.labels('myType');
@@ -395,7 +395,7 @@ describe('register', () => {
 					const metrics = r.metrics();
 					const lines = metrics.split('\n');
 					expect(lines).toContain(
-						'my_gauge{type="myType",env="development"} 1'
+						'my_gauge{type="myType",env="development"} 1',
 					);
 
 					myGauge.inc(2);
@@ -403,21 +403,21 @@ describe('register', () => {
 					const metrics2 = r.metrics();
 					const lines2 = metrics2.split('\n');
 					expect(lines2).toContain(
-						'my_gauge{type="myType",env="development"} 3'
+						'my_gauge{type="myType",env="development"} 3',
 					);
 				});
 
 				it('should not throw with default labels (histogram)', () => {
 					const r = new Registry();
 					r.setDefaultLabels({
-						env: 'development'
+						env: 'development',
 					});
 
 					const hist = new Histogram({
 						name: 'my_histogram',
 						help: 'my histogram',
 						registers: [r],
-						labelNames: ['type']
+						labelNames: ['type'],
 					});
 
 					const myHist = hist.labels('myType');
@@ -427,7 +427,7 @@ describe('register', () => {
 					const metrics = r.metrics();
 					const lines = metrics.split('\n');
 					expect(lines).toContain(
-						'my_histogram_bucket{le="1",type="myType",env="development"} 1'
+						'my_histogram_bucket{le="1",type="myType",env="development"} 1',
 					);
 
 					myHist.observe(1);
@@ -435,7 +435,7 @@ describe('register', () => {
 					const metrics2 = r.metrics();
 					const lines2 = metrics2.split('\n');
 					expect(lines2).toContain(
-						'my_histogram_bucket{le="1",type="myType",env="development"} 2'
+						'my_histogram_bucket{le="1",type="myType",env="development"} 2',
 					);
 				});
 			});
@@ -444,14 +444,14 @@ describe('register', () => {
 				it('should not throw with default labels (counter)', () => {
 					const r = new Registry();
 					r.setDefaultLabels({
-						env: 'development'
+						env: 'development',
 					});
 
 					const counter = new Counter({
 						name: 'my_counter',
 						help: 'my counter',
 						registers: [r],
-						labelNames: ['type']
+						labelNames: ['type'],
 					});
 
 					const myCounter = counter.labels('myType');
@@ -467,9 +467,9 @@ describe('register', () => {
 						values: [
 							{
 								labels: { env: 'development', type: 'myType' },
-								value: 1
-							}
-						]
+								value: 1,
+							},
+						],
 					});
 
 					myCounter.inc();
@@ -483,23 +483,23 @@ describe('register', () => {
 						values: [
 							{
 								labels: { env: 'development', type: 'myType' },
-								value: 2
-							}
-						]
+								value: 2,
+							},
+						],
 					});
 				});
 
 				it('should not throw with default labels (gauge)', () => {
 					const r = new Registry();
 					r.setDefaultLabels({
-						env: 'development'
+						env: 'development',
 					});
 
 					const gauge = new Gauge({
 						name: 'my_gauge',
 						help: 'my gauge',
 						registers: [r],
-						labelNames: ['type']
+						labelNames: ['type'],
 					});
 
 					const myGauge = gauge.labels('myType');
@@ -515,9 +515,9 @@ describe('register', () => {
 						values: [
 							{
 								labels: { env: 'development', type: 'myType' },
-								value: 1
-							}
-						]
+								value: 1,
+							},
+						],
 					});
 
 					myGauge.inc(2);
@@ -531,23 +531,23 @@ describe('register', () => {
 						values: [
 							{
 								labels: { env: 'development', type: 'myType' },
-								value: 3
-							}
-						]
+								value: 3,
+							},
+						],
 					});
 				});
 
 				it('should not throw with default labels (histogram)', () => {
 					const r = new Registry();
 					r.setDefaultLabels({
-						env: 'development'
+						env: 'development',
 					});
 
 					const hist = new Histogram({
 						name: 'my_histogram',
 						help: 'my histogram',
 						registers: [r],
-						labelNames: ['type']
+						labelNames: ['type'],
 					});
 
 					const myHist = hist.labels('myType');
@@ -559,7 +559,7 @@ describe('register', () => {
 					expect(metrics[0].values).toContainEqual({
 						labels: { env: 'development', le: 1, type: 'myType' },
 						metricName: 'my_histogram_bucket',
-						value: 1
+						value: 1,
 					});
 
 					myHist.observe(1);
@@ -569,7 +569,7 @@ describe('register', () => {
 					expect(metrics2[0].values).toContainEqual({
 						labels: { env: 'development', le: 1, type: 'myType' },
 						metricName: 'my_histogram_bucket',
-						value: 2
+						value: 2,
 					});
 				});
 			});
@@ -592,7 +592,7 @@ describe('register', () => {
 
 			const merged = Registry.merge([
 				registryOne,
-				registryTwo
+				registryTwo,
 			]).getMetricsAsJSON();
 			expect(merged).toHaveLength(2);
 		});
@@ -623,19 +623,19 @@ describe('register', () => {
 							value: 12,
 							labels: {
 								label: 'hello',
-								code: '303'
-							}
+								code: '303',
+							},
 						},
 						{
 							value: 34,
 							labels: {
 								label: 'bye',
-								code: '404'
-							}
-						}
-					]
+								code: '404',
+							},
+						},
+					],
 				};
-			}
+			},
 		};
 	}
 });

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -24,7 +24,7 @@ describe('summary', () => {
 				expect(instance.get().values[7].metricName).toEqual('summary_test_sum');
 				expect(instance.get().values[7].value).toEqual(100);
 				expect(instance.get().values[8].metricName).toEqual(
-					'summary_test_count'
+					'summary_test_count',
 				);
 				expect(instance.get().values[8].value).toEqual(1);
 			});
@@ -68,7 +68,7 @@ describe('summary', () => {
 				expect(instance.get().values[7].value).toEqual(400);
 
 				expect(instance.get().values[8].metricName).toEqual(
-					'summary_test_count'
+					'summary_test_count',
 				);
 				expect(instance.get().values[8].value).toEqual(5);
 			});
@@ -78,7 +78,7 @@ describe('summary', () => {
 				instance = new Summary({
 					name: 'summary_test',
 					help: 'test',
-					percentiles: [0.5, 0.9]
+					percentiles: [0.5, 0.9],
 				});
 				instance.observe(100);
 				instance.observe(100);
@@ -98,7 +98,7 @@ describe('summary', () => {
 				expect(instance.get().values[2].value).toEqual(400);
 
 				expect(instance.get().values[3].metricName).toEqual(
-					'summary_test_count'
+					'summary_test_count',
 				);
 				expect(instance.get().values[3].value).toEqual(5);
 			});
@@ -108,7 +108,7 @@ describe('summary', () => {
 				instance = new Summary({
 					name: 'summary_test',
 					help: 'test',
-					percentiles: [0.5]
+					percentiles: [0.5],
 				});
 				instance.observe(100);
 				expect(instance.get().values[0].labels.quantile).toEqual(0.5);
@@ -118,7 +118,7 @@ describe('summary', () => {
 				expect(instance.get().values[1].value).toEqual(100);
 
 				expect(instance.get().values[2].metricName).toEqual(
-					'summary_test_count'
+					'summary_test_count',
 				);
 				expect(instance.get().values[2].value).toEqual(1);
 
@@ -131,7 +131,7 @@ describe('summary', () => {
 				expect(instance.get().values[1].value).toEqual(0);
 
 				expect(instance.get().values[2].metricName).toEqual(
-					'summary_test_count'
+					'summary_test_count',
 				);
 				expect(instance.get().values[2].value).toEqual(0);
 			});
@@ -143,7 +143,7 @@ describe('summary', () => {
 						name: 'summary_test',
 						help: 'help',
 						labelNames: ['method', 'endpoint'],
-						percentiles: [0.9]
+						percentiles: [0.9],
 					});
 				});
 
@@ -281,7 +281,7 @@ describe('summary', () => {
 						name: 'summary_test',
 						help: 'help',
 						labelNames: ['method', 'endpoint'],
-						percentiles: [0.9]
+						percentiles: [0.9],
 					});
 
 					instance.labels('GET', '/test').observe(50);
@@ -411,7 +411,7 @@ describe('summary', () => {
 			instance = new Summary({
 				name: 'summary_test',
 				help: 'test',
-				registers: []
+				registers: [],
 			});
 		});
 		it('should increase count', () => {
@@ -432,7 +432,7 @@ describe('summary', () => {
 			instance = new Summary({
 				name: 'summary_test',
 				help: 'test',
-				registers: [registryInstance]
+				registers: [registryInstance],
 			});
 		});
 		it('should increment counter', () => {
@@ -459,7 +459,7 @@ describe('summary', () => {
 				name: 'summary_test',
 				help: 'test',
 				maxAgeSeconds: 5,
-				ageBuckets: 5
+				ageBuckets: 5,
 			});
 
 			localInstance.observe(100);
@@ -468,11 +468,11 @@ describe('summary', () => {
 				expect(localInstance.get().values[0].labels.quantile).toEqual(0.01);
 				expect(localInstance.get().values[0].value).toEqual(100);
 				expect(localInstance.get().values[7].metricName).toEqual(
-					'summary_test_sum'
+					'summary_test_sum',
 				);
 				expect(localInstance.get().values[7].value).toEqual(100);
 				expect(localInstance.get().values[8].metricName).toEqual(
-					'summary_test_count'
+					'summary_test_count',
 				);
 				expect(localInstance.get().values[8].value).toEqual(1);
 				clock.tick(1001);
@@ -485,7 +485,7 @@ describe('summary', () => {
 		it('should not slide when maxAgeSeconds and ageBuckets are not configured', () => {
 			const localInstance = new Summary({
 				name: 'summary_test',
-				help: 'test'
+				help: 'test',
 			});
 			localInstance.observe(100);
 
@@ -493,11 +493,11 @@ describe('summary', () => {
 				expect(localInstance.get().values[0].labels.quantile).toEqual(0.01);
 				expect(localInstance.get().values[0].value).toEqual(100);
 				expect(localInstance.get().values[7].metricName).toEqual(
-					'summary_test_sum'
+					'summary_test_sum',
 				);
 				expect(localInstance.get().values[7].value).toEqual(100);
 				expect(localInstance.get().values[8].metricName).toEqual(
-					'summary_test_count'
+					'summary_test_count',
 				);
 				expect(localInstance.get().values[8].value).toEqual(1);
 				clock.tick(1001);

--- a/test/validationTest.js
+++ b/test/validationTest.js
@@ -14,7 +14,7 @@ describe('validation', () => {
 			expect(() => {
 				validateLabel(['exists'], { somethingElse: null });
 			}).toThrowError(
-				'Added label "somethingElse" is not included in initial labelset: [ \'exists\' ]'
+				'Added label "somethingElse" is not included in initial labelset: [ \'exists\' ]',
 			);
 		});
 	});


### PR DESCRIPTION
Extracted from #322.

This reduces diffs and makes them easier to read.

As an aside, prettier will default to `es5` setting for this in the upcoming v2