### PR TITLE
feat: improve Registry type by adding the collector functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- feat: exposed `registry.registerCollector()` and `registry.collectors()` methods in TypeScript declaration
+
 ## [12.0.0] - 2020-02-20
 
 ### Breaking

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ export class Registry {
 	registerMetric<T extends string>(metric: Metric<T>): void;
 
 	/**
-	 * Add collector, which is invoked on scrape
+	 * Add metric collector, which is invoked on scrape
 	 */
 	registerCollector(collectorFn: Collector): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,6 +27,16 @@ export class Registry {
 	registerMetric<T extends string>(metric: Metric<T>): void;
 
 	/**
+	 * Add collector, which is invoked on scrape
+	 */
+	registerCollector(collectorFn: Collector): void;
+
+	/**
+	 * Get all registered collector functions
+	 */
+	collectors(): Collector[]
+
+	/**
 	 * Get all metrics as objects
 	 */
 	getMetricsAsJSON(): metric[];
@@ -72,6 +82,7 @@ export class Registry {
 	 */
 	static merge(registers: Registry[]): Registry;
 }
+export type Collector = () => void;
 
 /**
  * The register that contains all metrics


### PR DESCRIPTION
`registerCollector()` and `collectors()` were added to the Registry, expose them in TS type.