### PR TITLE
fix: set nodejs_version_info after resetting registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- fix: provide nodejs_version_info metrics after calling `registry.resetMetrics()` (#238)
+
 ### Added
 
 - feat: exposed `registry.registerCollector()` and `registry.collectors()` methods in TypeScript declaration

--- a/lib/metrics/version.js
+++ b/lib/metrics/version.js
@@ -19,11 +19,17 @@ module.exports = (registry, config = {}) => {
 		registers: registry ? [registry] : undefined,
 		aggregator: 'first'
 	});
-	nodeVersionGauge
-		.labels(version, versionSegments[0], versionSegments[1], versionSegments[2])
-		.set(1);
 
-	return () => {};
+	return () => {
+		nodeVersionGauge
+			.labels(
+				version,
+				versionSegments[0],
+				versionSegments[1],
+				versionSegments[2]
+			)
+			.set(1);
+	};
 };
 
 module.exports.metricNames = [NODE_VERSION_INFO];


### PR DESCRIPTION
Fixes #238

Looks like similar changes are needed for `process_max_fds` and `process_start_time_seconds`. I need to go but can work on those later.