### PR TITLE
fix: remove useless using timestamp param after #333

### DIFF
--- a/lib/metrics/heapSpacesSizeAndUsed.js
+++ b/lib/metrics/heapSpacesSizeAndUsed.js
@@ -31,7 +31,6 @@ module.exports = (registry, config = {}) => {
 			used: {},
 			available: {}
 		};
-		const now = Date.now();
 
 		v8.getHeapSpaceStatistics().forEach(space => {
 			const spaceName = space.space_name.substr(
@@ -43,13 +42,9 @@ module.exports = (registry, config = {}) => {
 			data.used[spaceName] = space.space_used_size;
 			data.available[spaceName] = space.space_available_size;
 
-			gauges.total.set({ space: spaceName }, space.space_size, now);
-			gauges.used.set({ space: spaceName }, space.space_used_size, now);
-			gauges.available.set(
-				{ space: spaceName },
-				space.space_available_size,
-				now
-			);
+			gauges.total.set({ space: spaceName }, space.space_size);
+			gauges.used.set({ space: spaceName }, space.space_used_size);
+			gauges.available.set({ space: spaceName }, space.space_available_size);
 		});
 
 		return data;

--- a/lib/metrics/osMemoryHeap.js
+++ b/lib/metrics/osMemoryHeap.js
@@ -20,7 +20,7 @@ function notLinuxVariant(registry, config = {}) {
 
 		// I don't think the other things returned from `process.memoryUsage()` is relevant to a standard export
 		if (memUsage) {
-			residentMemGauge.set(memUsage.rss, Date.now());
+			residentMemGauge.set(memUsage.rss);
 		}
 	};
 }

--- a/lib/metrics/processCpuTotal.js
+++ b/lib/metrics/processCpuTotal.js
@@ -29,16 +29,15 @@ module.exports = (registry, config = {}) => {
 
 	return () => {
 		const cpuUsage = process.cpuUsage();
-		const now = Date.now();
 
 		const userUsageMicros = cpuUsage.user - lastCpuUsage.user;
 		const systemUsageMicros = cpuUsage.system - lastCpuUsage.system;
 
 		lastCpuUsage = cpuUsage;
 
-		cpuUserUsageCounter.inc(userUsageMicros / 1e6, now);
-		cpuSystemUsageCounter.inc(systemUsageMicros / 1e6, now);
-		cpuUsageCounter.inc((userUsageMicros + systemUsageMicros) / 1e6, now);
+		cpuUserUsageCounter.inc(userUsageMicros / 1e6);
+		cpuSystemUsageCounter.inc(systemUsageMicros / 1e6);
+		cpuUsageCounter.inc((userUsageMicros + systemUsageMicros) / 1e6);
 	};
 };
 

--- a/lib/metrics/processRequests.js
+++ b/lib/metrics/processRequests.js
@@ -31,7 +31,7 @@ module.exports = (registry, config = {}) => {
 	return () => {
 		const requests = process._getActiveRequests();
 		updateMetrics(gauge, aggregateByObjectName(requests));
-		totalGauge.set(requests.length, Date.now());
+		totalGauge.set(requests.length);
 	};
 };
 


### PR DESCRIPTION
I found some useless (after #333) using of third parameter `timestamp` in `Gauge.prototype.set` and `Counter.prototype.inc` functions and removed it.