### PR TITLE
chore: remove unused catch bindings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,7 @@
 		"es6": true
 	},
 	"parserOptions": {
-		"ecmaVersion": 2015
+		"ecmaVersion": 2019
 	},
 	"rules": {
 		"no-underscore-dangle": "off",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - chore: improve performance of `registry.getMetricAsPrometheusString`
 - chore: refactor metrics to reduce code duplication
 - chore: replace `utils.getPropertiesFromObj` with `Object.values`
+- chore: remove unused `catch` bindings
 
 ### Added
 

--- a/lib/metrics/eventLoopLag.js
+++ b/lib/metrics/eventLoopLag.js
@@ -7,7 +7,7 @@ let perf_hooks;
 try {
 	/* eslint-disable node/no-unsupported-features/node-builtins */
 	perf_hooks = require('perf_hooks');
-} catch (e) {
+} catch {
 	// node version is too old
 }
 

--- a/lib/metrics/gc.js
+++ b/lib/metrics/gc.js
@@ -6,7 +6,7 @@ let perf_hooks;
 try {
 	// eslint-disable-next-line
 	perf_hooks = require('perf_hooks');
-} catch (e) {
+} catch {
 	// node version is too old
 }
 

--- a/lib/metrics/helpers/safeMemoryUsage.js
+++ b/lib/metrics/helpers/safeMemoryUsage.js
@@ -3,7 +3,7 @@
 function safeMemoryUsage() {
 	try {
 		return process.memoryUsage();
-	} catch (ex) {
+	} catch {
 		return;
 	}
 }

--- a/lib/metrics/osMemoryHeapLinux.js
+++ b/lib/metrics/osMemoryHeapLinux.js
@@ -65,8 +65,8 @@ module.exports = (registry, config = {}) => {
 			residentMemGauge.set(structuredOutput.VmRSS);
 			virtualMemGauge.set(structuredOutput.VmSize);
 			heapSizeMemGauge.set(structuredOutput.VmData);
-		} catch (er) {
-			return;
+		} catch {
+			// noop;
 		}
 	};
 };

--- a/lib/metrics/processMaxFileDescriptors.js
+++ b/lib/metrics/processMaxFileDescriptors.js
@@ -20,7 +20,7 @@ module.exports = (registry, config = {}) => {
 					return true;
 				}
 			});
-		} catch (er) {
+		} catch {
 			return () => {};
 		}
 	}

--- a/lib/metrics/processOpenFileDescriptors.js
+++ b/lib/metrics/processOpenFileDescriptors.js
@@ -25,8 +25,8 @@ module.exports = (registry, config = {}) => {
 			// Minus 1 to not count the fd that was used by readdirSync(), its now
 			// closed.
 			fileDescriptorsGauge.set(fds.length - 1);
-		} catch (er) {
-			return;
+		} catch {
+			// noop
 		}
 	};
 };


### PR DESCRIPTION
Updates ESLint parser to 2019.

Removes unused `catch` bindings (supported by Node.js 10+).