### PR TITLE
change: add "collect" fn, make scrape fns async, ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,38 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking
 
+- changed: The following functions are now async (return a promise):
+  `registry.metrics()`
+  `registry.getMetricsAsJSON()`
+  `registry.getMetricsAsArray()`
+  `registry.getSingleMetricAsString()`
+
+  If your metrics server has a line like `res.send(register.metrics())`, you
+  should change it to `res.send(await register.metrics())`.
+
+  Additionally, all metric types now accept an optional `collect` function,
+  which is called when the metric's value should be collected and within which
+  you should set the metric's value. You should provide a `collect` function for
+  point-in-time metrics (e.g. current memory usage, as opposed to HTTP request
+  durations that are continuously logged in a histogram).
+
+- changed: `register.clusterMetrics()` no longer accepts a callback; it only
+  returns a promise.
+
+- removed: v12.0.0 added the undocumented functions `registry.registerCollector`
+  and `registry.collectors()`. These have been removed. If you were using them,
+  you should instead provide a `collect` function as described above.
+
 ### Changed
 
-- fix: provide nodejs_version_info metrics after calling `registry.resetMetrics()` (#238)
+- fix: provide nodejs_version_info metric value after calling `registry.resetMetrics()` (#238)
+- fix: provide process_max_fds metric value after calling `registry.resetMetrics()`
+- fix: provide process_start_time_seconds metric value after calling `registry.resetMetrics()`
 - chore: improve performance of `registry.getMetricAsPrometheusString`
 - chore: refactor metrics to reduce code duplication
 - chore: replace `utils.getPropertiesFromObj` with `Object.values`
 - chore: remove unused `catch` bindings
+- chore: upgrade Prettier to 2.x
 
 ### Added
 

--- a/example/cluster.js
+++ b/example/cluster.js
@@ -11,12 +11,15 @@ if (cluster.isMaster) {
 		cluster.fork();
 	}
 
-	metricsServer.get('/cluster_metrics', (req, res) => {
-		aggregatorRegistry.clusterMetrics((err, metrics) => {
-			if (err) console.log(err);
+	metricsServer.get('/cluster_metrics', async (req, res) => {
+		try {
+			const metrics = await aggregatorRegistry.clusterMetrics();
 			res.set('Content-Type', aggregatorRegistry.contentType);
 			res.send(metrics);
-		});
+		} catch (ex) {
+			res.statusCode = 500;
+			res.send(ex);
+		}
 	});
 
 	metricsServer.listen(3001);

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export class Registry {
 	/**
 	 * Get string representation for all metrics
 	 */
-	metrics(): string;
+	metrics(): Promise<string>;
 
 	/**
 	 * Remove all metrics from the registry
@@ -27,24 +27,14 @@ export class Registry {
 	registerMetric<T extends string>(metric: Metric<T>): void;
 
 	/**
-	 * Add metric collector, which is invoked on scrape
+	 * Get all metrics as objects
 	 */
-	registerCollector(collectorFn: Collector): void;
-
-	/**
-	 * Get all registered collector functions
-	 */
-	collectors(): Collector[];
+	getMetricsAsJSON(): Promise<metric[]>;
 
 	/**
 	 * Get all metrics as objects
 	 */
-	getMetricsAsJSON(): metric[];
-
-	/**
-	 * Get all metrics as objects
-	 */
-	getMetricsAsArray(): metric[];
+	getMetricsAsArray(): Promise<metric[]>;
 
 	/**
 	 * Remove a single metric
@@ -69,7 +59,7 @@ export class Registry {
 	 * Get a string representation of a single metric by name
 	 * @param name The name of the metric
 	 */
-	getSingleMetricAsString(name: string): string;
+	getSingleMetricAsString(name: string): Promise<string>;
 
 	/**
 	 * Gets the Content-Type of the metrics for use in the response headers.
@@ -91,15 +81,11 @@ export const register: Registry;
 
 export class AggregatorRegistry extends Registry {
 	/**
-	 * Gets aggregated metrics for all workers. The optional callback and
-	 * returned Promise resolve with the same value; either may be used.
-	 * @param {Function?} cb (err, metrics) => any
+	 * Gets aggregated metrics for all workers.
 	 * @return {Promise<string>} Promise that resolves with the aggregated
-	 *   metrics.
+	 * metrics.
 	 */
-	clusterMetrics(
-		cb?: (err: Error | null, metrics?: string) => any,
-	): Promise<string>;
+	clusterMetrics(): Promise<string>;
 
 	/**
 	 * Creates a new Registry instance from an array of metrics that were
@@ -110,7 +96,7 @@ export class AggregatorRegistry extends Registry {
 	 *   `registry.getMetricsAsJSON()`.
 	 * @return {Registry} aggregated registry.
 	 */
-	static aggregate(metricsArr: Array<Object>): Registry;
+	static aggregate(metricsArr: Array<Object>): Registry; // TODO Promise?
 
 	/**
 	 * Sets the registry or registries to be aggregated. Call from workers to
@@ -143,11 +129,14 @@ export enum MetricType {
 	Summary,
 }
 
+type CollectFunction<T> = (this: T) => void | Promise<void>;
+
 interface metric {
 	name: string;
 	help: string;
 	type: MetricType;
 	aggregator: Aggregator;
+	collect: CollectFunction<any>;
 }
 
 type LabelValues<T extends string> = Partial<Record<T, string | number>>;
@@ -158,10 +147,13 @@ interface MetricConfiguration<T extends string> {
 	labelNames?: T[];
 	registers?: Registry[];
 	aggregator?: Aggregator;
+	collect?: CollectFunction<any>;
 }
 
 export interface CounterConfiguration<T extends string>
-	extends MetricConfiguration<T> {}
+	extends MetricConfiguration<T> {
+	collect?: CollectFunction<Counter<T>>;
+}
 
 /**
  * A counter is a cumulative metric that represents a single numerical value that only ever goes up
@@ -215,7 +207,9 @@ export namespace Counter {
 }
 
 export interface GaugeConfiguration<T extends string>
-	extends MetricConfiguration<T> {}
+	extends MetricConfiguration<T> {
+	collect?: CollectFunction<Gauge<T>>;
+}
 
 /**
  * A gauge is a metric that represents a single numerical value that can arbitrarily go up and down.
@@ -333,6 +327,7 @@ export namespace Gauge {
 export interface HistogramConfiguration<T extends string>
 	extends MetricConfiguration<T> {
 	buckets?: number[];
+	collect?: CollectFunction<Histogram<T>>;
 }
 
 /**
@@ -412,6 +407,7 @@ export interface SummaryConfiguration<T extends string>
 	maxAgeSeconds?: number;
 	ageBuckets?: number;
 	compressCount?: number;
+	collect?: CollectFunction<Summary<T>>;
 }
 
 /**

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -36,22 +36,16 @@ class AggregatorRegistry extends Registry {
 	/**
 	 * Gets aggregated metrics for all workers. The optional callback and
 	 * returned Promise resolve with the same value; either may be used.
-	 * @param {Function?} callback (err, metrics) => any
 	 * @return {Promise<string>} Promise that resolves with the aggregated
 	 *   metrics.
 	 */
-	clusterMetrics(callback) {
+	clusterMetrics() {
 		const requestId = requestCtr++;
 
 		return new Promise((resolve, reject) => {
 			function done(err, result) {
-				// Don't resolve/reject the promise if a callback is provided
-				if (typeof callback === 'function') {
-					callback(err, result);
-				} else {
-					if (err) reject(err);
-					else resolve(result);
-				}
+				if (err) reject(err);
+				else resolve(result);
 			}
 
 			const request = {

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -33,7 +33,11 @@ class Counter extends Metric {
 		return reset.call(this);
 	}
 
-	get() {
+	async get() {
+		if (this.collect) {
+			const v = this.collect();
+			if (v instanceof Promise) await v;
+		}
 		return {
 			help: this.help,
 			name: this.name,

--- a/lib/defaultMetrics.js
+++ b/lib/defaultMetrics.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { isObject } = require('./util');
-const { globalRegistry } = require('./registry');
 
 // Default metrics.
 const processCpuTotal = require('./metrics/processCpuTotal');
@@ -38,41 +37,11 @@ module.exports = function collectDefaultMetrics(config) {
 		throw new TypeError('config must be null, undefined, or an object');
 	}
 
-	config = Object.assign({ eventLoopMonitoringPrecision: 10 }, config);
+	config = { eventLoopMonitoringPrecision: 10, ...config };
 
-	const registry = config.register || globalRegistry;
-	const last = registry
-		.collectors()
-		.find(collector => collector._source === metrics);
-
-	if (last) {
-		throw new Error(
-			'Cannot add the default metrics twice to the same registry',
-		);
+	for (const metric of Object.values(metrics)) {
+		metric(config.register, config);
 	}
-
-	const scrapers = metricsList.map(key => {
-		const metric = metrics[key];
-		return metric(config.register, config);
-	});
-
-	// Ideally the library would be based around a concept of collectors and
-	// async callbacks, but in the short-term, trigger scraping of the
-	// current metric value synchronously.
-	// - // https://prometheus.io/docs/instrumenting/writing_clientlibs/#overall-structure
-	function defaultMetricCollector() {
-		scrapers.forEach(scraper => scraper());
-	}
-
-	// defaultMetricCollector has to be dynamic, because the scrapers are in
-	// its closure, but we still want to identify a default collector, so
-	// tag it with a value known only to this module (the const metric array
-	// value) so we can find it later.
-	defaultMetricCollector._source = metrics;
-	registry.registerCollector(defaultMetricCollector);
-
-	// Because the tests expect an immediate collection.
-	defaultMetricCollector();
 };
 
 module.exports.metricsList = metricsList;

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -81,7 +81,11 @@ class Gauge extends Metric {
 		return startTimer.call(this, labels)();
 	}
 
-	get() {
+	async get() {
+		if (this.collect) {
+			const v = this.collect();
+			if (v instanceof Promise) await v;
+		}
 		return {
 			help: this.help,
 			name: this.name,

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -50,7 +50,11 @@ class Histogram extends Metric {
 		observe.call(this, labels === 0 ? 0 : labels || {})(value);
 	}
 
-	get() {
+	async get() {
+		if (this.collect) {
+			const v = this.collect();
+			if (v instanceof Promise) await v;
+		}
 		const data = Object.values(this.hashMap);
 		const values = data
 			.map(extractBucketValuesForExport(this))

--- a/lib/metric.js
+++ b/lib/metric.js
@@ -38,6 +38,9 @@ class Metric {
 		if (!validateLabelName(this.labelNames)) {
 			throw new Error('Invalid label name');
 		}
+		if (this.collect && typeof this.collect !== 'function') {
+			throw new Error('Optional "collect" parameter must be a function');
+		}
 
 		this.reset();
 

--- a/lib/metrics/eventLoopLag.js
+++ b/lib/metrics/eventLoopLag.js
@@ -11,8 +11,7 @@ try {
 	// node version is too old
 }
 
-// Reported always, but because legacy lag_seconds is collected async, the value
-// will always be stale by one scrape interval.
+// Reported always.
 const NODEJS_EVENTLOOP_LAG = 'nodejs_eventloop_lag_seconds';
 
 // Reported only when perf_hooks is available.
@@ -34,73 +33,77 @@ function reportEventloopLag(start, gauge) {
 
 module.exports = (registry, config = {}) => {
 	const namePrefix = config.prefix ? config.prefix : '';
+	const registers = registry ? [registry] : undefined;
+
+	let collect;
+	if (!perf_hooks || !perf_hooks.monitorEventLoopDelay) {
+		collect = () => {
+			const start = process.hrtime();
+			setImmediate(reportEventloopLag, start, lag);
+		};
+	} else {
+		const histogram = perf_hooks.monitorEventLoopDelay({
+			resolution: config.eventLoopMonitoringPrecision,
+		});
+		histogram.enable();
+
+		collect = () => {
+			const start = process.hrtime();
+			setImmediate(reportEventloopLag, start, lag);
+
+			lagMin.set(histogram.min / 1e9);
+			lagMax.set(histogram.max / 1e9);
+			lagMean.set(histogram.mean / 1e9);
+			lagStddev.set(histogram.stddev / 1e9);
+			lagP50.set(histogram.percentile(50) / 1e9);
+			lagP90.set(histogram.percentile(90) / 1e9);
+			lagP99.set(histogram.percentile(99) / 1e9);
+		};
+	}
 
 	const lag = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG,
 		help: 'Lag of event loop in seconds.',
-		registers: registry ? [registry] : undefined,
+		registers,
 		aggregator: 'average',
+		// Use this one metric's `collect` to set all metrics' values.
+		collect,
 	});
 	const lagMin = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_MIN,
 		help: 'The minimum recorded event loop delay.',
-		registers: registry ? [registry] : undefined,
+		registers,
 	});
 	const lagMax = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_MAX,
 		help: 'The maximum recorded event loop delay.',
-		registers: registry ? [registry] : undefined,
+		registers,
 	});
 	const lagMean = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_MEAN,
 		help: 'The mean of the recorded event loop delays.',
-		registers: registry ? [registry] : undefined,
+		registers,
 	});
 	const lagStddev = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_STDDEV,
 		help: 'The standard deviation of the recorded event loop delays.',
-		registers: registry ? [registry] : undefined,
+		registers,
 	});
 	const lagP50 = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_P50,
 		help: 'The 50th percentile of the recorded event loop delays.',
-		registers: registry ? [registry] : undefined,
+		registers,
 	});
 	const lagP90 = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_P90,
 		help: 'The 90th percentile of the recorded event loop delays.',
-		registers: registry ? [registry] : undefined,
+		registers,
 	});
 	const lagP99 = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_P99,
 		help: 'The 99th percentile of the recorded event loop delays.',
-		registers: registry ? [registry] : undefined,
+		registers,
 	});
-
-	if (!perf_hooks || !perf_hooks.monitorEventLoopDelay) {
-		return () => {
-			const start = process.hrtime();
-			setImmediate(reportEventloopLag, start, lag);
-		};
-	}
-
-	const histogram = perf_hooks.monitorEventLoopDelay({
-		resolution: config.eventLoopMonitoringPrecision,
-	});
-	histogram.enable();
-
-	return () => {
-		const start = process.hrtime();
-		setImmediate(reportEventloopLag, start, lag);
-
-		lagMin.set(histogram.min / 1e9);
-		lagMax.set(histogram.max / 1e9);
-		lagMean.set(histogram.mean / 1e9);
-		lagStddev.set(histogram.stddev / 1e9);
-		lagP50.set(histogram.percentile(50) / 1e9);
-		lagP90.set(histogram.percentile(90) / 1e9);
-		lagP99.set(histogram.percentile(99) / 1e9);
-	};
 };
 
 module.exports.metricNames = [

--- a/lib/metrics/gc.js
+++ b/lib/metrics/gc.js
@@ -21,7 +21,7 @@ kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_WEAKCB] = 'weakcb';
 
 module.exports = (registry, config = {}) => {
 	if (!perf_hooks) {
-		return () => {};
+		return;
 	}
 
 	const namePrefix = config.prefix ? config.prefix : '';
@@ -47,8 +47,6 @@ module.exports = (registry, config = {}) => {
 
 	// We do not expect too many gc events per second, so we do not use buffering
 	obs.observe({ entryTypes: ['gc'], buffered: false });
-
-	return () => {};
 };
 
 module.exports.metricNames = [NODEJS_GC_DURATION_SECONDS];

--- a/lib/metrics/heapSizeAndUsed.js
+++ b/lib/metrics/heapSizeAndUsed.js
@@ -9,16 +9,28 @@ const NODEJS_EXTERNAL_MEMORY = 'nodejs_external_memory_bytes';
 
 module.exports = (registry, config = {}) => {
 	if (typeof process.memoryUsage !== 'function') {
-		return () => {};
+		return;
 	}
 
 	const registers = registry ? [registry] : undefined;
 	const namePrefix = config.prefix ? config.prefix : '';
+	const collect = () => {
+		const memUsage = safeMemoryUsage();
+		if (memUsage) {
+			heapSizeTotal.set(memUsage.heapTotal);
+			heapSizeUsed.set(memUsage.heapUsed);
+			if (memUsage.external !== undefined) {
+				externalMemUsed.set(memUsage.external);
+			}
+		}
+	};
 
 	const heapSizeTotal = new Gauge({
 		name: namePrefix + NODEJS_HEAP_SIZE_TOTAL,
 		help: 'Process heap size from Node.js in bytes.',
 		registers,
+		// Use this one metric's `collect` to set all metrics' values.
+		collect,
 	});
 	const heapSizeUsed = new Gauge({
 		name: namePrefix + NODEJS_HEAP_SIZE_USED,
@@ -30,24 +42,6 @@ module.exports = (registry, config = {}) => {
 		help: 'Node.js external memory size in bytes.',
 		registers,
 	});
-
-	return () => {
-		// process.memoryUsage() can throw on some platforms, see #67
-		const memUsage = safeMemoryUsage();
-		if (memUsage) {
-			heapSizeTotal.set(memUsage.heapTotal);
-			heapSizeUsed.set(memUsage.heapUsed);
-			if (memUsage.external && externalMemUsed) {
-				externalMemUsed.set(memUsage.external);
-			}
-		}
-
-		return {
-			total: heapSizeTotal,
-			used: heapSizeUsed,
-			external: externalMemUsed,
-		};
-	};
 };
 
 module.exports.metricNames = [

--- a/lib/metrics/heapSpacesSizeAndUsed.js
+++ b/lib/metrics/heapSpacesSizeAndUsed.js
@@ -25,29 +25,18 @@ module.exports = (registry, config = {}) => {
 		});
 	});
 
-	return () => {
-		const data = {
-			total: {},
-			used: {},
-			available: {},
-		};
-
-		v8.getHeapSpaceStatistics().forEach(space => {
+	// Use this one metric's `collect` to set all metrics' values.
+	gauges.total.collect = () => {
+		for (const space of v8.getHeapSpaceStatistics()) {
 			const spaceName = space.space_name.substr(
 				0,
 				space.space_name.indexOf('_space'),
 			);
 
-			data.total[spaceName] = space.space_size;
-			data.used[spaceName] = space.space_used_size;
-			data.available[spaceName] = space.space_available_size;
-
 			gauges.total.set({ space: spaceName }, space.space_size);
 			gauges.used.set({ space: spaceName }, space.space_used_size);
 			gauges.available.set({ space: spaceName }, space.space_available_size);
-		});
-
-		return data;
+		}
 	};
 };
 

--- a/lib/metrics/helpers/safeMemoryUsage.js
+++ b/lib/metrics/helpers/safeMemoryUsage.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// process.memoryUsage() can throw on some platforms, see #67
 function safeMemoryUsage() {
 	try {
 		return process.memoryUsage();

--- a/lib/metrics/osMemoryHeap.js
+++ b/lib/metrics/osMemoryHeap.js
@@ -9,20 +9,19 @@ const PROCESS_RESIDENT_MEMORY = 'process_resident_memory_bytes';
 function notLinuxVariant(registry, config = {}) {
 	const namePrefix = config.prefix ? config.prefix : '';
 
-	const residentMemGauge = new Gauge({
+	new Gauge({
 		name: namePrefix + PROCESS_RESIDENT_MEMORY,
 		help: 'Resident memory size in bytes.',
 		registers: registry ? [registry] : undefined,
+		collect() {
+			const memUsage = safeMemoryUsage();
+
+			// I don't think the other things returned from `process.memoryUsage()` is relevant to a standard export
+			if (memUsage) {
+				this.set(memUsage.rss);
+			}
+		},
 	});
-
-	return () => {
-		const memUsage = safeMemoryUsage();
-
-		// I don't think the other things returned from `process.memoryUsage()` is relevant to a standard export
-		if (memUsage) {
-			residentMemGauge.set(memUsage.rss);
-		}
-	};
 }
 
 module.exports = (registry, config) =>

--- a/lib/metrics/osMemoryHeapLinux.js
+++ b/lib/metrics/osMemoryHeapLinux.js
@@ -39,6 +39,25 @@ module.exports = (registry, config = {}) => {
 		name: namePrefix + PROCESS_RESIDENT_MEMORY,
 		help: 'Resident memory size in bytes.',
 		registers,
+		// Use this one metric's `collect` to set all metrics' values.
+		collect() {
+			try {
+				// Sync I/O is often problematic, but /proc isn't really I/O, it
+				// a virtual filesystem that maps directly to in-kernel data
+				// structures and never blocks.
+				//
+				// Node.js/libuv do this already for process.memoryUsage(), see:
+				// - https://github.com/libuv/libuv/blob/a629688008694ed8022269e66826d4d6ec688b83/src/unix/linux-core.c#L506-L523
+				const stat = fs.readFileSync('/proc/self/status', 'utf8');
+				const structuredOutput = structureOutput(stat);
+
+				residentMemGauge.set(structuredOutput.VmRSS);
+				virtualMemGauge.set(structuredOutput.VmSize);
+				heapSizeMemGauge.set(structuredOutput.VmData);
+			} catch {
+				// noop
+			}
+		},
 	});
 	const virtualMemGauge = new Gauge({
 		name: namePrefix + PROCESS_VIRTUAL_MEMORY,
@@ -50,25 +69,6 @@ module.exports = (registry, config = {}) => {
 		help: 'Process heap size in bytes.',
 		registers,
 	});
-
-	// Sync I/O is often problematic, but /proc isn't really I/O, it a
-	// virtual filesystem that maps directly to in-kernel data structures
-	// and never blocks.
-	//
-	// Node.js/libuv do this already for process.memoryUsage(), see:
-	// - https://github.com/libuv/libuv/blob/a629688008694ed8022269e66826d4d6ec688b83/src/unix/linux-core.c#L506-L523
-	return () => {
-		try {
-			const stat = fs.readFileSync('/proc/self/status', 'utf8');
-			const structuredOutput = structureOutput(stat);
-
-			residentMemGauge.set(structuredOutput.VmRSS);
-			virtualMemGauge.set(structuredOutput.VmSize);
-			heapSizeMemGauge.set(structuredOutput.VmData);
-		} catch {
-			// noop;
-		}
-	};
 };
 
 module.exports.metricNames = [

--- a/lib/metrics/processCpuTotal.js
+++ b/lib/metrics/processCpuTotal.js
@@ -9,10 +9,25 @@ module.exports = (registry, config = {}) => {
 	const registers = registry ? [registry] : undefined;
 	const namePrefix = config.prefix ? config.prefix : '';
 
+	let lastCpuUsage = process.cpuUsage();
+
 	const cpuUserUsageCounter = new Counter({
 		name: namePrefix + PROCESS_CPU_USER_SECONDS,
 		help: 'Total user CPU time spent in seconds.',
 		registers,
+		// Use this one metric's `collect` to set all metrics' values.
+		collect() {
+			const cpuUsage = process.cpuUsage();
+
+			const userUsageMicros = cpuUsage.user - lastCpuUsage.user;
+			const systemUsageMicros = cpuUsage.system - lastCpuUsage.system;
+
+			lastCpuUsage = cpuUsage;
+
+			cpuUserUsageCounter.inc(userUsageMicros / 1e6);
+			cpuSystemUsageCounter.inc(systemUsageMicros / 1e6);
+			cpuUsageCounter.inc((userUsageMicros + systemUsageMicros) / 1e6);
+		},
 	});
 	const cpuSystemUsageCounter = new Counter({
 		name: namePrefix + PROCESS_CPU_SYSTEM_SECONDS,
@@ -24,21 +39,6 @@ module.exports = (registry, config = {}) => {
 		help: 'Total user and system CPU time spent in seconds.',
 		registers,
 	});
-
-	let lastCpuUsage = process.cpuUsage();
-
-	return () => {
-		const cpuUsage = process.cpuUsage();
-
-		const userUsageMicros = cpuUsage.user - lastCpuUsage.user;
-		const systemUsageMicros = cpuUsage.system - lastCpuUsage.system;
-
-		lastCpuUsage = cpuUsage;
-
-		cpuUserUsageCounter.inc(userUsageMicros / 1e6);
-		cpuSystemUsageCounter.inc(systemUsageMicros / 1e6);
-		cpuUsageCounter.inc((userUsageMicros + systemUsageMicros) / 1e6);
-	};
 };
 
 module.exports.metricNames = [

--- a/lib/metrics/processHandles.js
+++ b/lib/metrics/processHandles.js
@@ -8,31 +8,34 @@ const NODEJS_ACTIVE_HANDLES = 'nodejs_active_handles';
 const NODEJS_ACTIVE_HANDLES_TOTAL = 'nodejs_active_handles_total';
 
 module.exports = (registry, config = {}) => {
-	// Don't do anything if the function is removed in later nodes (exists in node@6)
+	// Don't do anything if the function is removed in later nodes (exists in node@6-12...)
 	if (typeof process._getActiveHandles !== 'function') {
-		return () => {};
+		return;
 	}
 
+	const registers = registry ? [registry] : undefined;
 	const namePrefix = config.prefix ? config.prefix : '';
 
-	const gauge = new Gauge({
+	new Gauge({
 		name: namePrefix + NODEJS_ACTIVE_HANDLES,
 		help:
 			'Number of active libuv handles grouped by handle type. Every handle type is C++ class name.',
 		labelNames: ['type'],
-		registers: registry ? [registry] : undefined,
+		registers,
+		collect() {
+			const handles = process._getActiveHandles();
+			updateMetrics(this, aggregateByObjectName(handles));
+		},
 	});
-	const totalGauge = new Gauge({
+	new Gauge({
 		name: namePrefix + NODEJS_ACTIVE_HANDLES_TOTAL,
 		help: 'Total number of active handles.',
-		registers: registry ? [registry] : undefined,
+		registers,
+		collect() {
+			const handles = process._getActiveHandles();
+			this.set(handles.length);
+		},
 	});
-
-	return () => {
-		const handles = process._getActiveHandles();
-		updateMetrics(gauge, aggregateByObjectName(handles));
-		totalGauge.set(handles.length);
-	};
 };
 
 module.exports.metricNames = [

--- a/lib/metrics/processMaxFileDescriptors.js
+++ b/lib/metrics/processMaxFileDescriptors.js
@@ -13,30 +13,30 @@ module.exports = (registry, config = {}) => {
 		try {
 			const limits = fs.readFileSync('/proc/self/limits', 'utf8');
 			const lines = limits.split('\n');
-			lines.find(line => {
+			for (const line of lines) {
 				if (line.startsWith('Max open files')) {
 					const parts = line.split(/  +/);
 					maxFds = Number(parts[1]);
-					return true;
+					break;
 				}
-			});
+			}
 		} catch {
-			return () => {};
+			return;
 		}
 	}
 
-	if (maxFds === undefined) return () => {};
+	if (maxFds === undefined) return;
 
 	const namePrefix = config.prefix ? config.prefix : '';
-	const fileDescriptorsGauge = new Gauge({
+
+	new Gauge({
 		name: namePrefix + PROCESS_MAX_FDS,
 		help: 'Maximum number of open file descriptors.',
 		registers: registry ? [registry] : undefined,
+		collect() {
+			if (maxFds !== undefined) this.set(maxFds);
+		},
 	});
-
-	fileDescriptorsGauge.set(Number(maxFds));
-
-	return () => {};
 };
 
 module.exports.metricNames = [PROCESS_MAX_FDS];

--- a/lib/metrics/processOpenFileDescriptors.js
+++ b/lib/metrics/processOpenFileDescriptors.js
@@ -8,27 +8,26 @@ const PROCESS_OPEN_FDS = 'process_open_fds';
 
 module.exports = (registry, config = {}) => {
 	if (process.platform !== 'linux') {
-		return () => {};
+		return;
 	}
 
 	const namePrefix = config.prefix ? config.prefix : '';
 
-	const fileDescriptorsGauge = new Gauge({
+	new Gauge({
 		name: namePrefix + PROCESS_OPEN_FDS,
 		help: 'Number of open file descriptors.',
 		registers: registry ? [registry] : undefined,
+		collect() {
+			try {
+				const fds = fs.readdirSync('/proc/self/fd');
+				// Minus 1 to not count the fd that was used by readdirSync(),
+				// it's now closed.
+				this.set(fds.length - 1);
+			} catch {
+				// noop
+			}
+		},
 	});
-
-	return () => {
-		try {
-			const fds = fs.readdirSync('/proc/self/fd');
-			// Minus 1 to not count the fd that was used by readdirSync(), its now
-			// closed.
-			fileDescriptorsGauge.set(fds.length - 1);
-		} catch {
-			// noop
-		}
-	};
 };
 
 module.exports.metricNames = [PROCESS_OPEN_FDS];

--- a/lib/metrics/processRequests.js
+++ b/lib/metrics/processRequests.js
@@ -9,30 +9,32 @@ const NODEJS_ACTIVE_REQUESTS_TOTAL = 'nodejs_active_requests_total';
 module.exports = (registry, config = {}) => {
 	// Don't do anything if the function is removed in later nodes (exists in node@6)
 	if (typeof process._getActiveRequests !== 'function') {
-		return () => {};
+		return;
 	}
 
 	const namePrefix = config.prefix ? config.prefix : '';
 
-	const gauge = new Gauge({
+	new Gauge({
 		name: namePrefix + NODEJS_ACTIVE_REQUESTS,
 		help:
 			'Number of active libuv requests grouped by request type. Every request type is C++ class name.',
 		labelNames: ['type'],
 		registers: registry ? [registry] : undefined,
+		collect() {
+			const requests = process._getActiveRequests();
+			updateMetrics(this, aggregateByObjectName(requests));
+		},
 	});
 
-	const totalGauge = new Gauge({
+	new Gauge({
 		name: namePrefix + NODEJS_ACTIVE_REQUESTS_TOTAL,
 		help: 'Total number of active requests.',
 		registers: registry ? [registry] : undefined,
+		collect() {
+			const requests = process._getActiveRequests();
+			this.set(requests.length);
+		},
 	});
-
-	return () => {
-		const requests = process._getActiveRequests();
-		updateMetrics(gauge, aggregateByObjectName(requests));
-		totalGauge.set(requests.length);
-	};
 };
 
 module.exports.metricNames = [

--- a/lib/metrics/processStartTime.js
+++ b/lib/metrics/processStartTime.js
@@ -8,15 +8,15 @@ const PROCESS_START_TIME = 'process_start_time_seconds';
 module.exports = (registry, config = {}) => {
 	const namePrefix = config.prefix ? config.prefix : '';
 
-	const cpuUserGauge = new Gauge({
+	new Gauge({
 		name: namePrefix + PROCESS_START_TIME,
 		help: 'Start time of the process since unix epoch in seconds.',
 		registers: registry ? [registry] : undefined,
 		aggregator: 'omit',
+		collect() {
+			this.set(startInSeconds);
+		},
 	});
-	cpuUserGauge.set(startInSeconds);
-
-	return () => {};
 };
 
 module.exports.metricNames = [PROCESS_START_TIME];

--- a/lib/metrics/version.js
+++ b/lib/metrics/version.js
@@ -9,24 +9,22 @@ const NODE_VERSION_INFO = 'nodejs_version_info';
 module.exports = (registry, config = {}) => {
 	const namePrefix = config.prefix ? config.prefix : '';
 
-	const nodeVersionGauge = new Gauge({
+	new Gauge({
 		name: namePrefix + NODE_VERSION_INFO,
 		help: 'Node.js version info.',
 		labelNames: ['version', 'major', 'minor', 'patch'],
 		registers: registry ? [registry] : undefined,
 		aggregator: 'first',
-	});
-
-	return () => {
-		nodeVersionGauge
-			.labels(
+		collect() {
+			// Needs to be in collect() so value is present even if reg is reset
+			this.labels(
 				version,
 				versionSegments[0],
 				versionSegments[1],
 				versionSegments[2],
-			)
-			.set(1);
-	};
+			).set(1);
+		},
+	});
 };
 
 module.exports.metricNames = [NODE_VERSION_INFO];

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -22,8 +22,8 @@ class Registry {
 		return Object.values(this._metrics);
 	}
 
-	getMetricAsPrometheusString(metric) {
-		const item = metric.get();
+	async getMetricAsPrometheusString(metric) {
+		const item = await metric.get();
 		const name = escapeString(item.name);
 		const help = `# HELP ${name} ${escapeString(item.help)}`;
 		const type = `# TYPE ${name} ${item.type}`;
@@ -63,16 +63,16 @@ class Registry {
 		return `${help}\n${type}\n${values}`.trim();
 	}
 
-	metrics() {
-		let metrics = '';
-
-		this.collect();
+	async metrics() {
+		const promises = [];
 
 		for (const metric of this.getMetricsAsArray()) {
-			metrics += `${this.getMetricAsPrometheusString(metric)}\n\n`;
+			promises.push(this.getMetricAsPrometheusString(metric));
 		}
 
-		return metrics.substring(0, metrics.length - 1);
+		const resolves = await Promise.all(promises);
+
+		return `${resolves.join('\n\n')}\n`;
 	}
 
 	registerMetric(metric) {
@@ -85,36 +85,24 @@ class Registry {
 		this._metrics[metric.name] = metric;
 	}
 
-	registerCollector(collectorFn) {
-		if (this._collectors.includes(collectorFn)) {
-			return; // Silently ignore repeated registration.
-		}
-		this._collectors.push(collectorFn);
-	}
-
-	collectors() {
-		return this._collectors;
-	}
-
-	collect() {
-		this._collectors.forEach(collector => collector());
-	}
-
 	clear() {
 		this._metrics = {};
-		this._collectors = [];
 		this._defaultLabels = {};
 	}
 
-	getMetricsAsJSON() {
+	async getMetricsAsJSON() {
 		const metrics = [];
 		const defaultLabelNames = Object.keys(this._defaultLabels);
 
-		this.collect();
+		const promises = [];
 
 		for (const metric of this.getMetricsAsArray()) {
-			const item = metric.get();
+			promises.push(metric.get());
+		}
 
+		const resolves = await Promise.all(promises);
+
+		for (const item of resolves) {
 			if (item.values && defaultLabelNames.length > 0) {
 				for (const val of item.values) {
 					// Make a copy before mutating

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -47,7 +47,11 @@ class Summary extends Metric {
 		observe.call(this, labels === 0 ? 0 : labels || {})(value);
 	}
 
-	get() {
+	async get() {
+		if (this.collect) {
+			const v = this.collect();
+			if (v instanceof Promise) await v;
+		}
 		const data = Object.values(this.hashMap);
 		const values = [];
 		data.forEach(s => {

--- a/test/clusterTest.js
+++ b/test/clusterTest.js
@@ -18,19 +18,11 @@ describe('AggregatorRegistry', () => {
 	});
 
 	describe('aggregatorRegistry.clusterMetrics()', () => {
-		it('works properly if there are no cluster workers', done => {
+		it('works properly if there are no cluster workers', async () => {
 			const AggregatorRegistry = require('../lib/cluster');
 			const ar = new AggregatorRegistry();
-			let tickElapsed = false;
-			process.nextTick(() => {
-				tickElapsed = true;
-			});
-			ar.clusterMetrics((err, metrics) => {
-				expect(tickElapsed).toBe(true);
-				expect(err).toBeNull();
-				expect(metrics).toEqual('');
-				done();
-			});
+			const metrics = await ar.clusterMetrics();
+			expect(metrics).toEqual('');
 		});
 	});
 
@@ -154,7 +146,7 @@ describe('AggregatorRegistry', () => {
 
 		const aggregated = Registry.aggregate([metricsArr1, metricsArr2]);
 
-		it('defaults to summation, preserves histogram bins', () => {
+		it('defaults to summation, preserves histogram bins', async () => {
 			const histogram = aggregated.getSingleMetric('test_histogram').get();
 			expect(histogram).toEqual({
 				name: 'test_histogram',

--- a/test/counterTest.js
+++ b/test/counterTest.js
@@ -14,17 +14,17 @@ describe('counter', () => {
 			globalRegistry.clear();
 		});
 
-		it('should increment counter', () => {
+		it('should increment counter', async () => {
 			instance.inc();
-			expect(instance.get().values[0].value).toEqual(1);
+			expect((await instance.get()).values[0].value).toEqual(1);
 			instance.inc();
-			expect(instance.get().values[0].value).toEqual(2);
+			expect((await instance.get()).values[0].value).toEqual(2);
 			instance.inc(0);
-			expect(instance.get().values[0].value).toEqual(2);
+			expect((await instance.get()).values[0].value).toEqual(2);
 		});
-		it('should increment with a provided value', () => {
+		it('should increment with a provided value', async () => {
 			instance.inc(100);
-			expect(instance.get().values[0].value).toEqual(100);
+			expect((await instance.get()).values[0].value).toEqual(100);
 		});
 		it('should not be possible to decrease a counter', () => {
 			const fn = function () {
@@ -38,12 +38,12 @@ describe('counter', () => {
 			};
 			expect(fn).toThrowErrorMatchingSnapshot();
 		});
-		it('should handle incrementing with 0', () => {
+		it('should handle incrementing with 0', async () => {
 			instance.inc(0);
-			expect(instance.get().values[0].value).toEqual(0);
+			expect((await instance.get()).values[0].value).toEqual(0);
 		});
-		it('should init counter to 0', () => {
-			const values = instance.get().values;
+		it('should init counter to 0', async () => {
+			const values = (await instance.get()).values;
 			expect(values).toHaveLength(1);
 			expect(values[0].value).toEqual(0);
 		});
@@ -57,19 +57,19 @@ describe('counter', () => {
 				});
 			});
 
-			it('should handle 1 value per label', () => {
+			it('should handle 1 value per label', async () => {
 				instance.labels('GET', '/test').inc();
 				instance.labels('POST', '/test').inc();
 
-				const values = instance.get().values;
+				const values = (await instance.get()).values;
 				expect(values).toHaveLength(2);
 			});
 
-			it('should handle labels which are provided as arguments to inc()', () => {
+			it('should handle labels which are provided as arguments to inc()', async () => {
 				instance.inc({ method: 'GET', endpoint: '/test' });
 				instance.inc({ method: 'POST', endpoint: '/test' });
 
-				const values = instance.get().values;
+				const values = (await instance.get()).values;
 				expect(values).toHaveLength(2);
 			});
 
@@ -87,9 +87,9 @@ describe('counter', () => {
 				expect(fn).toThrowErrorMatchingSnapshot();
 			});
 
-			it('should increment label value with provided value', () => {
+			it('should increment label value with provided value', async () => {
 				instance.labels('GET', '/test').inc(100);
-				const values = instance.get().values;
+				const values = (await instance.get()).values;
 				expect(values[0].value).toEqual(100);
 			});
 		});
@@ -110,10 +110,10 @@ describe('counter', () => {
 			globalRegistry.clear();
 		});
 
-		it('should remove matching label', () => {
+		it('should remove matching label', async () => {
 			instance.remove('POST', '/test');
 
-			const values = instance.get().values;
+			const values = (await instance.get()).values;
 			expect(values).toHaveLength(1);
 			expect(values[0].value).toEqual(1);
 			expect(values[0].labels.method).toEqual('GET');
@@ -121,11 +121,11 @@ describe('counter', () => {
 			expect(values[0].timestamp).toEqual(undefined);
 		});
 
-		it('should remove all labels', () => {
+		it('should remove all labels', async () => {
 			instance.remove('GET', '/test');
 			instance.remove('POST', '/test');
 
-			expect(instance.get().values).toHaveLength(0);
+			expect((await instance.get()).values).toHaveLength(0);
 		});
 
 		it('should throw error if label lengths does not match', () => {
@@ -144,11 +144,11 @@ describe('counter', () => {
 				registers: [],
 			});
 		});
-		it('should increment counter', () => {
+		it('should increment counter', async () => {
 			instance.inc();
-			expect(globalRegistry.getMetricsAsJSON().length).toEqual(0);
-			expect(instance.get().values[0].value).toEqual(1);
-			expect(instance.get().values[0].timestamp).toEqual(undefined);
+			expect((await globalRegistry.getMetricsAsJSON()).length).toEqual(0);
+			expect((await instance.get()).values[0].value).toEqual(1);
+			expect((await instance.get()).values[0].timestamp).toEqual(undefined);
 		});
 	});
 	describe('registry instance', () => {
@@ -161,34 +161,34 @@ describe('counter', () => {
 				registers: [registryInstance],
 			});
 		});
-		it('should increment counter', () => {
+		it('should increment counter', async () => {
 			instance.inc();
-			expect(globalRegistry.getMetricsAsJSON().length).toEqual(0);
-			expect(registryInstance.getMetricsAsJSON().length).toEqual(1);
-			expect(instance.get().values[0].value).toEqual(1);
-			expect(instance.get().values[0].timestamp).toEqual(undefined);
+			expect((await globalRegistry.getMetricsAsJSON()).length).toEqual(0);
+			expect((await registryInstance.getMetricsAsJSON()).length).toEqual(1);
+			expect((await instance.get()).values[0].value).toEqual(1);
+			expect((await instance.get()).values[0].timestamp).toEqual(undefined);
 		});
 	});
 	describe('counter reset', () => {
 		afterEach(() => {
 			globalRegistry.clear();
 		});
-		it('should reset labelless counter', () => {
+		it('should reset labelless counter', async () => {
 			const instance = new Counter({
 				name: 'test_metric',
 				help: 'Another test metric',
 			});
 
 			instance.inc(12);
-			expect(instance.get().values[0].value).toEqual(12);
+			expect((await instance.get()).values[0].value).toEqual(12);
 
 			instance.reset();
-			expect(instance.get().values[0].value).toEqual(0);
+			expect((await instance.get()).values[0].value).toEqual(0);
 
 			instance.inc(10);
-			expect(instance.get().values[0].value).toEqual(10);
+			expect((await instance.get()).values[0].value).toEqual(10);
 		});
-		it('should reset the counter, incl labels', () => {
+		it('should reset the counter, incl labels', async () => {
 			const instance = new Counter({
 				name: 'test_metric',
 				help: 'Another test metric',
@@ -196,18 +196,18 @@ describe('counter', () => {
 			});
 
 			instance.inc({ serial: '12345', active: 'yes' }, 12);
-			expect(instance.get().values[0].value).toEqual(12);
-			expect(instance.get().values[0].labels.serial).toEqual('12345');
-			expect(instance.get().values[0].labels.active).toEqual('yes');
+			expect((await instance.get()).values[0].value).toEqual(12);
+			expect((await instance.get()).values[0].labels.serial).toEqual('12345');
+			expect((await instance.get()).values[0].labels.active).toEqual('yes');
 
 			instance.reset();
 
-			expect(instance.get().values).toEqual([]);
+			expect((await instance.get()).values).toEqual([]);
 
 			instance.inc({ serial: '12345', active: 'no' }, 10);
-			expect(instance.get().values[0].value).toEqual(10);
-			expect(instance.get().values[0].labels.serial).toEqual('12345');
-			expect(instance.get().values[0].labels.active).toEqual('no');
+			expect((await instance.get()).values[0].value).toEqual(10);
+			expect((await instance.get()).values[0].labels.serial).toEqual('12345');
+			expect((await instance.get()).values[0].labels.active).toEqual('no');
 		});
 	});
 });

--- a/test/defaultMetricsTest.js
+++ b/test/defaultMetricsTest.js
@@ -6,7 +6,6 @@ describe('collectDefaultMetrics', () => {
 	const collectDefaultMetrics = require('../index').collectDefaultMetrics;
 	let platform;
 	let cpuUsage;
-	let interval;
 
 	beforeAll(() => {
 		platform = process.platform;
@@ -47,28 +46,27 @@ describe('collectDefaultMetrics', () => {
 
 	afterEach(() => {
 		register.clear();
-		clearInterval(interval);
 	});
 
-	it('should add metrics to the registry', () => {
-		expect(register.getMetricsAsJSON()).toHaveLength(0);
-		interval = collectDefaultMetrics();
-		expect(register.getMetricsAsJSON()).not.toHaveLength(0);
+	it('should add metrics to the registry', async () => {
+		expect(await register.getMetricsAsJSON()).toHaveLength(0);
+		collectDefaultMetrics();
+		expect(await register.getMetricsAsJSON()).not.toHaveLength(0);
 	});
 
-	it('should allow blacklisting all metrics', () => {
-		expect(register.getMetricsAsJSON()).toHaveLength(0);
+	it('should allow blacklisting all metrics', async () => {
+		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 		clearInterval(collectDefaultMetrics());
 		register.clear();
-		expect(register.getMetricsAsJSON()).toHaveLength(0);
+		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 	});
 
-	it('should prefix metric names when configured', () => {
-		interval = collectDefaultMetrics({ prefix: 'some_prefix_' });
-		expect(register.getMetricsAsJSON()).not.toHaveLength(0);
-		register.getMetricsAsJSON().forEach(metric => {
+	it('should prefix metric names when configured', async () => {
+		collectDefaultMetrics({ prefix: 'some_prefix_' });
+		expect(await register.getMetricsAsJSON()).not.toHaveLength(0);
+		for (const metric of await register.getMetricsAsJSON()) {
 			expect(metric.name.substring(0, 12)).toEqual('some_prefix_');
-		});
+		}
 	});
 
 	describe('disabling', () => {
@@ -82,21 +80,21 @@ describe('collectDefaultMetrics', () => {
 	});
 
 	describe('custom registry', () => {
-		it('should allow to register metrics to custom registry', () => {
+		it('should allow to register metrics to custom registry', async () => {
 			const registry = new Registry();
 
-			expect(register.getMetricsAsJSON()).toHaveLength(0);
-			expect(registry.getMetricsAsJSON()).toHaveLength(0);
+			expect(await register.getMetricsAsJSON()).toHaveLength(0);
+			expect(await registry.getMetricsAsJSON()).toHaveLength(0);
 
 			collectDefaultMetrics();
 
-			expect(register.getMetricsAsJSON()).not.toHaveLength(0);
-			expect(registry.getMetricsAsJSON()).toHaveLength(0);
+			expect(await register.getMetricsAsJSON()).not.toHaveLength(0);
+			expect(await registry.getMetricsAsJSON()).toHaveLength(0);
 
 			collectDefaultMetrics({ register: registry });
 
-			expect(register.getMetricsAsJSON()).not.toHaveLength(0);
-			expect(registry.getMetricsAsJSON()).not.toHaveLength(0);
+			expect(await register.getMetricsAsJSON()).not.toHaveLength(0);
+			expect(await registry.getMetricsAsJSON()).not.toHaveLength(0);
 		});
 	});
 });

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -17,45 +17,45 @@ describe('gauge', () => {
 				instance.set(10);
 			});
 
-			it('should set a gauge to provided value', () => {
-				expectValue(10);
+			it('should set a gauge to provided value', async () => {
+				await expectValue(10);
 			});
 
-			it('should increase with 1 if no param provided', () => {
+			it('should increase with 1 if no param provided', async () => {
 				instance.inc();
-				expectValue(11);
+				await expectValue(11);
 			});
 
-			it('should increase with param value if provided', () => {
+			it('should increase with param value if provided', async () => {
 				instance.inc(5);
-				expectValue(15);
+				await expectValue(15);
 			});
 
-			it('should decrease with 1 if no param provided', () => {
+			it('should decrease with 1 if no param provided', async () => {
 				instance.dec();
-				expectValue(9);
+				await expectValue(9);
 			});
 
-			it('should decrease with param if provided', () => {
+			it('should decrease with param if provided', async () => {
 				instance.dec(5);
-				expectValue(5);
+				await expectValue(5);
 			});
 
-			it('should start a timer and set a gauge to elapsed in seconds', () => {
+			it('should start a timer and set a gauge to elapsed in seconds', async () => {
 				jest.useFakeTimers('modern');
 				jest.setSystemTime(0);
 				const doneFn = instance.startTimer();
 				jest.advanceTimersByTime(500);
 				doneFn();
-				expectValue(0.5);
+				await expectValue(0.5);
 				jest.useRealTimers();
 			});
 
-			it('should set to current time', () => {
+			it('should set to current time', async () => {
 				jest.useFakeTimers('modern');
 				jest.setSystemTime(0);
 				instance.setToCurrentTime();
-				expectValue(Date.now());
+				await expectValue(Date.now());
 				jest.useRealTimers();
 			});
 
@@ -66,12 +66,12 @@ describe('gauge', () => {
 				expect(fn).toThrowErrorMatchingSnapshot();
 			});
 
-			it('should init to 0', () => {
+			it('should init to 0', async () => {
 				instance = new Gauge({
 					name: 'init_gauge',
 					help: 'somehelp',
 				});
-				expectValue(0);
+				await expectValue(0);
 			});
 
 			describe('with labels', () => {
@@ -83,44 +83,44 @@ describe('gauge', () => {
 					});
 					instance.set({ code: '200' }, 20);
 				});
-				it('should be able to increment', () => {
+				it('should be able to increment', async () => {
 					instance.labels('200').inc();
-					expectValue(21);
+					await expectValue(21);
 				});
-				it('should be able to decrement', () => {
+				it('should be able to decrement', async () => {
 					instance.labels('200').dec();
-					expectValue(19);
+					await expectValue(19);
 				});
-				it('should be able to set value', () => {
+				it('should be able to set value', async () => {
 					instance.labels('200').set(500);
-					expectValue(500);
+					await expectValue(500);
 				});
-				it('should be able to set value to current time', () => {
+				it('should be able to set value to current time', async () => {
 					jest.useFakeTimers('modern');
 					jest.setSystemTime(0);
 					instance.labels('200').setToCurrentTime();
-					expectValue(Date.now());
+					await expectValue(Date.now());
 					jest.useRealTimers();
 				});
-				it('should be able to start a timer', () => {
+				it('should be able to start a timer', async () => {
 					jest.useFakeTimers('modern');
 					jest.setSystemTime(0);
 					const end = instance.labels('200').startTimer();
 					jest.advanceTimersByTime(1000);
 					end();
-					expectValue(1);
+					await expectValue(1);
 					jest.useRealTimers();
 				});
-				it('should be able to start a timer and set labels afterwards', () => {
+				it('should be able to start a timer and set labels afterwards', async () => {
 					jest.useFakeTimers('modern');
 					jest.setSystemTime(0);
 					const end = instance.startTimer();
 					jest.advanceTimersByTime(1000);
 					end({ code: 200 });
-					expectValue(1);
+					await expectValue(1);
 					jest.useRealTimers();
 				});
-				it('should allow labels before and after timers', () => {
+				it('should allow labels before and after timers', async () => {
 					instance = new Gauge({
 						name: 'name_2',
 						help: 'help',
@@ -131,7 +131,7 @@ describe('gauge', () => {
 					const end = instance.startTimer({ code: 200 });
 					jest.advanceTimersByTime(1000);
 					end({ success: 'SUCCESS' });
-					expectValue(1);
+					await expectValue(1);
 					jest.useRealTimers();
 				});
 				it('should not mutate passed startLabels', () => {
@@ -152,17 +152,17 @@ describe('gauge', () => {
 					instance.set({ code: '200' }, 20);
 					instance.set({ code: '400' }, 0);
 				});
-				it('should be able to remove matching label', () => {
+				it('should be able to remove matching label', async () => {
 					instance.remove('200');
-					const values = instance.get().values;
+					const values = (await instance.get()).values;
 					expect(values.length).toEqual(1);
 					expect(values[0].labels.code).toEqual('400');
 					expect(values[0].value).toEqual(0);
 				});
-				it('should be able to remove all labels', () => {
+				it('should be able to remove all labels', async () => {
 					instance.remove('200');
 					instance.remove('400');
-					expect(instance.get().values.length).toEqual(0);
+					expect((await instance.get()).values.length).toEqual(0);
 				});
 			});
 		});
@@ -175,9 +175,9 @@ describe('gauge', () => {
 			instance = new Gauge({ name: 'gauge_test', help: 'help', registers: [] });
 			instance.set(10);
 		});
-		it('should set a gauge to provided value', () => {
-			expectValue(10);
-			expect(globalRegistry.getMetricsAsJSON().length).toEqual(0);
+		it('should set a gauge to provided value', async () => {
+			await expectValue(10);
+			expect((await globalRegistry.getMetricsAsJSON()).length).toEqual(0);
 		});
 	});
 	describe('registry instance', () => {
@@ -191,32 +191,32 @@ describe('gauge', () => {
 			});
 			instance.set(10);
 		});
-		it('should set a gauge to provided value', () => {
-			expect(globalRegistry.getMetricsAsJSON().length).toEqual(0);
-			expect(registryInstance.getMetricsAsJSON().length).toEqual(1);
-			expectValue(10);
+		it('should set a gauge to provided value', async () => {
+			expect((await globalRegistry.getMetricsAsJSON()).length).toEqual(0);
+			expect((await registryInstance.getMetricsAsJSON()).length).toEqual(1);
+			await expectValue(10);
 		});
 	});
 	describe('gauge reset', () => {
 		afterEach(() => {
 			globalRegistry.clear();
 		});
-		it('should reset labelless gauge', () => {
+		it('should reset labelless gauge', async () => {
 			const instance = new Gauge({
 				name: 'test_metric',
 				help: 'Another test metric',
 			});
 
 			instance.set(12);
-			expect(instance.get().values[0].value).toEqual(12);
+			expect((await instance.get()).values[0].value).toEqual(12);
 
 			instance.reset();
-			expect(instance.get().values[0].value).toEqual(0);
+			expect((await instance.get()).values[0].value).toEqual(0);
 
 			instance.set(10);
-			expect(instance.get().values[0].value).toEqual(10);
+			expect((await instance.get()).values[0].value).toEqual(10);
 		});
-		it('should reset the gauge, incl labels', () => {
+		it('should reset the gauge, incl labels', async () => {
 			const instance = new Gauge({
 				name: 'test_metric',
 				help: 'Another test metric',
@@ -224,22 +224,22 @@ describe('gauge', () => {
 			});
 
 			instance.set({ serial: '12345', active: 'yes' }, 12);
-			expect(instance.get().values[0].value).toEqual(12);
-			expect(instance.get().values[0].labels.serial).toEqual('12345');
-			expect(instance.get().values[0].labels.active).toEqual('yes');
+			expect((await instance.get()).values[0].value).toEqual(12);
+			expect((await instance.get()).values[0].labels.serial).toEqual('12345');
+			expect((await instance.get()).values[0].labels.active).toEqual('yes');
 
 			instance.reset();
 
-			expect(instance.get().values).toEqual([]);
+			expect((await instance.get()).values).toEqual([]);
 
 			instance.set({ serial: '12345', active: 'no' }, 10);
-			expect(instance.get().values[0].value).toEqual(10);
-			expect(instance.get().values[0].labels.serial).toEqual('12345');
-			expect(instance.get().values[0].labels.active).toEqual('no');
+			expect((await instance.get()).values[0].value).toEqual(10);
+			expect((await instance.get()).values[0].labels.serial).toEqual('12345');
+			expect((await instance.get()).values[0].labels.active).toEqual('no');
 		});
 	});
 
-	function expectValue(val) {
-		expect(instance.get().values[0].value).toEqual(val);
+	async function expectValue(val) {
+		expect((await instance.get()).values[0].value).toEqual(val);
 	}
 });

--- a/test/metrics/eventLoopLagTest.js
+++ b/test/metrics/eventLoopLagTest.js
@@ -12,12 +12,12 @@ describe('eventLoopLag', () => {
 		register.clear();
 	});
 
-	it('should add metric to the registry', done => {
-		expect(register.getMetricsAsJSON()).toHaveLength(0);
-		eventLoopLag()();
+	it('should add metric to the registry', async done => {
+		expect(await register.getMetricsAsJSON()).toHaveLength(0);
+		eventLoopLag();
 
-		setTimeout(() => {
-			const metrics = register.getMetricsAsJSON();
+		setTimeout(async () => {
+			const metrics = await register.getMetricsAsJSON();
 			expect(metrics).toHaveLength(8);
 
 			expect(metrics[0].help).toEqual('Lag of event loop in seconds.');

--- a/test/metrics/gcTest.js
+++ b/test/metrics/gcTest.js
@@ -12,19 +12,19 @@ describe('gc', () => {
 		register.clear();
 	});
 
-	it('should add metric to the registry', () => {
-		expect(register.getMetricsAsJSON()).toHaveLength(0);
+	it('should add metric to the registry', async () => {
+		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
-		processHandles()();
+		processHandles();
 
-		const metrics = register.getMetricsAsJSON();
+		const metrics = await register.getMetricsAsJSON();
 
 		// Check if perf_hooks module is available
 		let perf_hooks;
 		try {
 			// eslint-disable-next-line
 			perf_hooks = require('perf_hooks');
-		} catch (e) {
+		} catch {
 			// node version is too old
 		}
 

--- a/test/metrics/heapSizeAndUsedTest.js
+++ b/test/metrics/heapSizeAndUsedTest.js
@@ -10,32 +10,28 @@ describe('heapSizeAndUsed', () => {
 		globalRegistry.clear();
 	});
 
-	it('should return an empty function if memoryUsed does not exist', () => {
-		process.memoryUsage = null;
-		expect(heapSizeAndUsed()()).toBeUndefined();
-	});
-
-	it('should set total heap size gauge with total from memoryUsage', () => {
+	it('should set gauge values from memoryUsage', async () => {
 		process.memoryUsage = function () {
 			return { heapTotal: 1000, heapUsed: 500, external: 100 };
 		};
-		const totalGauge = heapSizeAndUsed()().total.get();
-		expect(totalGauge.values[0].value).toEqual(1000);
-	});
 
-	it('should set used gauge with used from memoryUsage', () => {
-		process.memoryUsage = function () {
-			return { heapTotal: 1000, heapUsed: 500, external: 100 };
-		};
-		const gauge = heapSizeAndUsed()().used.get();
-		expect(gauge.values[0].value).toEqual(500);
-	});
+		heapSizeAndUsed();
+		// Note: these three gauges' values are set by the _total gauge's
+		// "collect" function.
 
-	it('should set external gauge with external from memoryUsage', () => {
-		process.memoryUsage = function () {
-			return { heapTotal: 1000, heapUsed: 500, external: 100 };
-		};
-		const gauge = heapSizeAndUsed()().external.get();
-		expect(gauge.values[0].value).toEqual(100);
+		const totalGauge = globalRegistry.getSingleMetric(
+			'nodejs_heap_size_total_bytes',
+		);
+		expect((await totalGauge.get()).values[0].value).toEqual(1000);
+
+		const usedGauge = globalRegistry.getSingleMetric(
+			'nodejs_heap_size_used_bytes',
+		);
+		expect((await usedGauge.get()).values[0].value).toEqual(500);
+
+		const externalGauge = globalRegistry.getSingleMetric(
+			'nodejs_external_memory_bytes',
+		);
+		expect((await externalGauge.get()).values[0].value).toEqual(100);
 	});
 });

--- a/test/metrics/heapSpacesSizeAndUsedTest.js
+++ b/test/metrics/heapSpacesSizeAndUsedTest.js
@@ -56,13 +56,38 @@ describe('heapSpacesSizeAndUsed', () => {
 		globalRegistry.clear();
 	});
 
-	it('should set total heap spaces size gauges with from v8', () => {
-		const expectedObj = {
-			total: { new: 100, old: 100, code: 100, map: 100, large_object: 100 },
-			used: { new: 50, old: 50, code: 50, map: 50, large_object: 50 },
-			available: { new: 500, old: 500, code: 500, map: 500, large_object: 500 },
-		};
+	it('should set total heap spaces size gauges with values from v8', async () => {
+		expect(await globalRegistry.getMetricsAsJSON()).toHaveLength(0);
 
-		expect(heapSpacesSizeAndUsed()()).toEqual(expectedObj);
+		heapSpacesSizeAndUsed();
+
+		const metrics = await globalRegistry.getMetricsAsJSON();
+
+		expect(metrics[0].name).toEqual('nodejs_heap_space_size_total_bytes');
+		expect(metrics[0].values).toEqual([
+			{ labels: { space: 'new' }, value: 100 },
+			{ labels: { space: 'old' }, value: 100 },
+			{ labels: { space: 'code' }, value: 100 },
+			{ labels: { space: 'map' }, value: 100 },
+			{ labels: { space: 'large_object' }, value: 100 },
+		]);
+
+		expect(metrics[1].name).toEqual('nodejs_heap_space_size_used_bytes');
+		expect(metrics[1].values).toEqual([
+			{ labels: { space: 'new' }, value: 50 },
+			{ labels: { space: 'old' }, value: 50 },
+			{ labels: { space: 'code' }, value: 50 },
+			{ labels: { space: 'map' }, value: 50 },
+			{ labels: { space: 'large_object' }, value: 50 },
+		]);
+
+		expect(metrics[2].name).toEqual('nodejs_heap_space_size_available_bytes');
+		expect(metrics[2].values).toEqual([
+			{ labels: { space: 'new' }, value: 500 },
+			{ labels: { space: 'old' }, value: 500 },
+			{ labels: { space: 'code' }, value: 500 },
+			{ labels: { space: 'map' }, value: 500 },
+			{ labels: { space: 'large_object' }, value: 500 },
+		]);
 	});
 });

--- a/test/metrics/maxFileDescriptorsTest.js
+++ b/test/metrics/maxFileDescriptorsTest.js
@@ -15,20 +15,20 @@ describe('processMaxFileDescriptors', () => {
 	});
 
 	if (process.platform !== 'linux') {
-		it('should not add metric to the registry', () => {
-			expect(register.getMetricsAsJSON()).toHaveLength(0);
+		it('should not add metric to the registry', async () => {
+			expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
-			processMaxFileDescriptors()();
+			processMaxFileDescriptors();
 
-			expect(register.getMetricsAsJSON()).toHaveLength(0);
+			expect(await register.getMetricsAsJSON()).toHaveLength(0);
 		});
 	} else {
-		it('should add metric to the registry', () => {
-			expect(register.getMetricsAsJSON()).toHaveLength(0);
+		it('should add metric to the registry', async () => {
+			expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
-			processMaxFileDescriptors()();
+			processMaxFileDescriptors();
 
-			const metrics = register.getMetricsAsJSON();
+			const metrics = await register.getMetricsAsJSON();
 
 			expect(metrics).toHaveLength(1);
 			expect(metrics[0].help).toEqual(
@@ -39,13 +39,13 @@ describe('processMaxFileDescriptors', () => {
 			expect(metrics[0].values).toHaveLength(1);
 		});
 
-		it('should have a reasonable metric value', () => {
+		it('should have a reasonable metric value', async () => {
 			const maxFiles = Number(exec('ulimit -Hn', { encoding: 'utf8' }));
 
-			expect(register.getMetricsAsJSON()).toHaveLength(0);
-			processMaxFileDescriptors(register, {})();
+			expect(await register.getMetricsAsJSON()).toHaveLength(0);
+			processMaxFileDescriptors(register, {});
 
-			const metrics = register.getMetricsAsJSON();
+			const metrics = await register.getMetricsAsJSON();
 
 			expect(metrics).toHaveLength(1);
 			expect(metrics[0].values).toHaveLength(1);

--- a/test/metrics/processHandlesTest.js
+++ b/test/metrics/processHandlesTest.js
@@ -12,12 +12,12 @@ describe('processHandles', () => {
 		register.clear();
 	});
 
-	it('should add metric to the registry', () => {
-		expect(register.getMetricsAsJSON()).toHaveLength(0);
+	it('should add metric to the registry', async () => {
+		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
-		processHandles()();
+		processHandles();
 
-		const metrics = register.getMetricsAsJSON();
+		const metrics = await register.getMetricsAsJSON();
 
 		expect(metrics).toHaveLength(2);
 

--- a/test/metrics/processOpenFileDescriptorsTest.js
+++ b/test/metrics/processOpenFileDescriptorsTest.js
@@ -18,12 +18,12 @@ describe('processOpenFileDescriptors', () => {
 		register.clear();
 	});
 
-	it('should add metric to the registry', () => {
-		expect(register.getMetricsAsJSON()).toHaveLength(0);
+	it('should add metric to the registry', async () => {
+		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
-		processOpenFileDescriptors()();
+		processOpenFileDescriptors();
 
-		const metrics = register.getMetricsAsJSON();
+		const metrics = await register.getMetricsAsJSON();
 
 		expect(metrics).toHaveLength(1);
 		expect(metrics[0].help).toEqual('Number of open file descriptors.');

--- a/test/metrics/processRequestsTest.js
+++ b/test/metrics/processRequestsTest.js
@@ -12,12 +12,12 @@ describe('processRequests', () => {
 		register.clear();
 	});
 
-	it('should add metric to the registry', () => {
-		expect(register.getMetricsAsJSON()).toHaveLength(0);
+	it('should add metric to the registry', async () => {
+		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
-		processRequests()();
+		processRequests();
 
-		const metrics = register.getMetricsAsJSON();
+		const metrics = await register.getMetricsAsJSON();
 
 		expect(metrics).toHaveLength(2);
 		expect(metrics[0].help).toEqual(

--- a/test/metrics/processStartTimeTest.js
+++ b/test/metrics/processStartTimeTest.js
@@ -12,12 +12,12 @@ describe('processStartTime', () => {
 		register.clear();
 	});
 
-	it('should add metric to the registry', () => {
-		expect(register.getMetricsAsJSON()).toHaveLength(0);
+	it('should add metric to the registry', async () => {
+		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
-		op()();
+		op();
 
-		const metrics = register.getMetricsAsJSON();
+		const metrics = await register.getMetricsAsJSON();
 		const startTime = Math.ceil(Date.now() / 1000 - process.uptime());
 
 		expect(metrics).toHaveLength(1);

--- a/test/metrics/versionTest.js
+++ b/test/metrics/versionTest.js
@@ -27,23 +27,22 @@ describe('version', () => {
 		register.clear();
 	});
 
-	it('should add metric to the registry', () => {
-		expect(register.getMetricsAsJSON()).toHaveLength(0);
+	it('should add metric to the registry', async () => {
+		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 		expect(typeof versionSegments[0]).toEqual('number');
 		expect(typeof versionSegments[1]).toEqual('number');
 		expect(typeof versionSegments[2]).toEqual('number');
 
-		version()();
+		version();
 
-		const metrics = register.getMetricsAsJSON();
+		const metrics = await register.getMetricsAsJSON();
 		expectVersionMetrics(metrics);
 	});
 
-	it('should still be present after resetting the registry #238', () => {
+	it('should still be present after resetting the registry #238', async () => {
 		const collector = version();
-		register.registerCollector(collector);
-		expectVersionMetrics(register.getMetricsAsJSON());
+		expectVersionMetrics(await register.getMetricsAsJSON());
 		register.resetMetrics();
-		expectVersionMetrics(register.getMetricsAsJSON());
+		expectVersionMetrics(await register.getMetricsAsJSON());
 	});
 });

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -16,63 +16,62 @@ describe('summary', () => {
 				instance = new Summary({ name: 'summary_test', help: 'test' });
 			});
 
-			it('should add a value to the summary', () => {
+			it('should add a value to the summary', async () => {
 				instance.observe(100);
-				expect(instance.get().values[0].labels.quantile).toEqual(0.01);
-				expect(instance.get().values[0].value).toEqual(100);
-				expect(instance.get().values[7].metricName).toEqual('summary_test_sum');
-				expect(instance.get().values[7].value).toEqual(100);
-				expect(instance.get().values[8].metricName).toEqual(
-					'summary_test_count',
-				);
-				expect(instance.get().values[8].value).toEqual(1);
+				const { values } = await instance.get();
+				expect(values[0].labels.quantile).toEqual(0.01);
+				expect(values[0].value).toEqual(100);
+				expect(values[7].metricName).toEqual('summary_test_sum');
+				expect(values[7].value).toEqual(100);
+				expect(values[8].metricName).toEqual('summary_test_count');
+				expect(values[8].value).toEqual(1);
 			});
 
-			it('should be able to observe 0s', () => {
+			it('should be able to observe 0s', async () => {
 				instance.observe(0);
-				expect(instance.get().values[8].value).toEqual(1);
+				expect((await instance.get()).values[8].value).toEqual(1);
 			});
 
-			it('should correctly calculate percentiles when more values are added to the summary', () => {
+			it('should correctly calculate percentiles when more values are added to the summary', async () => {
 				instance.observe(100);
 				instance.observe(100);
 				instance.observe(100);
 				instance.observe(50);
 				instance.observe(50);
 
-				expect(instance.get().values.length).toEqual(9);
+				const { values } = await instance.get();
 
-				expect(instance.get().values[0].labels.quantile).toEqual(0.01);
-				expect(instance.get().values[0].value).toEqual(50);
+				expect(values.length).toEqual(9);
 
-				expect(instance.get().values[1].labels.quantile).toEqual(0.05);
-				expect(instance.get().values[1].value).toEqual(50);
+				expect(values[0].labels.quantile).toEqual(0.01);
+				expect(values[0].value).toEqual(50);
 
-				expect(instance.get().values[2].labels.quantile).toEqual(0.5);
-				expect(instance.get().values[2].value).toEqual(80);
+				expect(values[1].labels.quantile).toEqual(0.05);
+				expect(values[1].value).toEqual(50);
 
-				expect(instance.get().values[3].labels.quantile).toEqual(0.9);
-				expect(instance.get().values[3].value).toEqual(100);
+				expect(values[2].labels.quantile).toEqual(0.5);
+				expect(values[2].value).toEqual(80);
 
-				expect(instance.get().values[4].labels.quantile).toEqual(0.95);
-				expect(instance.get().values[4].value).toEqual(100);
+				expect(values[3].labels.quantile).toEqual(0.9);
+				expect(values[3].value).toEqual(100);
 
-				expect(instance.get().values[5].labels.quantile).toEqual(0.99);
-				expect(instance.get().values[5].value).toEqual(100);
+				expect(values[4].labels.quantile).toEqual(0.95);
+				expect(values[4].value).toEqual(100);
 
-				expect(instance.get().values[6].labels.quantile).toEqual(0.999);
-				expect(instance.get().values[6].value).toEqual(100);
+				expect(values[5].labels.quantile).toEqual(0.99);
+				expect(values[5].value).toEqual(100);
 
-				expect(instance.get().values[7].metricName).toEqual('summary_test_sum');
-				expect(instance.get().values[7].value).toEqual(400);
+				expect(values[6].labels.quantile).toEqual(0.999);
+				expect(values[6].value).toEqual(100);
 
-				expect(instance.get().values[8].metricName).toEqual(
-					'summary_test_count',
-				);
-				expect(instance.get().values[8].value).toEqual(5);
+				expect(values[7].metricName).toEqual('summary_test_sum');
+				expect(values[7].value).toEqual(400);
+
+				expect(values[8].metricName).toEqual('summary_test_count');
+				expect(values[8].value).toEqual(5);
 			});
 
-			it('should correctly use calculate other percentiles when configured', () => {
+			it('should correctly use calculate other percentiles when configured', async () => {
 				globalRegistry.clear();
 				instance = new Summary({
 					name: 'summary_test',
@@ -85,24 +84,24 @@ describe('summary', () => {
 				instance.observe(50);
 				instance.observe(50);
 
-				expect(instance.get().values.length).toEqual(4);
+				const { values } = await instance.get();
 
-				expect(instance.get().values[0].labels.quantile).toEqual(0.5);
-				expect(instance.get().values[0].value).toEqual(80);
+				expect(values.length).toEqual(4);
 
-				expect(instance.get().values[1].labels.quantile).toEqual(0.9);
-				expect(instance.get().values[1].value).toEqual(100);
+				expect(values[0].labels.quantile).toEqual(0.5);
+				expect(values[0].value).toEqual(80);
 
-				expect(instance.get().values[2].metricName).toEqual('summary_test_sum');
-				expect(instance.get().values[2].value).toEqual(400);
+				expect(values[1].labels.quantile).toEqual(0.9);
+				expect(values[1].value).toEqual(100);
 
-				expect(instance.get().values[3].metricName).toEqual(
-					'summary_test_count',
-				);
-				expect(instance.get().values[3].value).toEqual(5);
+				expect(values[2].metricName).toEqual('summary_test_sum');
+				expect(values[2].value).toEqual(400);
+
+				expect(values[3].metricName).toEqual('summary_test_count');
+				expect(values[3].value).toEqual(5);
 			});
 
-			it('should allow to reset itself', () => {
+			it('should allow to reset itself', async () => {
 				globalRegistry.clear();
 				instance = new Summary({
 					name: 'summary_test',
@@ -110,29 +109,30 @@ describe('summary', () => {
 					percentiles: [0.5],
 				});
 				instance.observe(100);
-				expect(instance.get().values[0].labels.quantile).toEqual(0.5);
-				expect(instance.get().values[0].value).toEqual(100);
 
-				expect(instance.get().values[1].metricName).toEqual('summary_test_sum');
-				expect(instance.get().values[1].value).toEqual(100);
+				const { values } = await instance.get();
 
-				expect(instance.get().values[2].metricName).toEqual(
-					'summary_test_count',
-				);
-				expect(instance.get().values[2].value).toEqual(1);
+				expect(values[0].labels.quantile).toEqual(0.5);
+				expect(values[0].value).toEqual(100);
+
+				expect(values[1].metricName).toEqual('summary_test_sum');
+				expect(values[1].value).toEqual(100);
+
+				expect(values[2].metricName).toEqual('summary_test_count');
+				expect(values[2].value).toEqual(1);
 
 				instance.reset();
 
-				expect(instance.get().values[0].labels.quantile).toEqual(0.5);
-				expect(instance.get().values[0].value).toEqual(0);
+				const { values: valuesPost } = await instance.get();
 
-				expect(instance.get().values[1].metricName).toEqual('summary_test_sum');
-				expect(instance.get().values[1].value).toEqual(0);
+				expect(valuesPost[0].labels.quantile).toEqual(0.5);
+				expect(valuesPost[0].value).toEqual(0);
 
-				expect(instance.get().values[2].metricName).toEqual(
-					'summary_test_count',
-				);
-				expect(instance.get().values[2].value).toEqual(0);
+				expect(valuesPost[1].metricName).toEqual('summary_test_sum');
+				expect(valuesPost[1].value).toEqual(0);
+
+				expect(valuesPost[2].metricName).toEqual('summary_test_count');
+				expect(valuesPost[2].value).toEqual(0);
 			});
 
 			describe('labels', () => {
@@ -146,11 +146,11 @@ describe('summary', () => {
 					});
 				});
 
-				it('should record and calculate the correct values per label', () => {
+				it('should record and calculate the correct values per label', async () => {
 					instance.labels('GET', '/test').observe(50);
 					instance.labels('POST', '/test').observe(100);
 
-					const values = instance.get().values;
+					const { values } = await instance.get();
 					expect(values).toHaveLength(6);
 					expect(values[0].labels.method).toEqual('GET');
 					expect(values[0].labels.endpoint).toEqual('/test');
@@ -190,13 +190,13 @@ describe('summary', () => {
 					expect(fn).toThrowErrorMatchingSnapshot();
 				});
 
-				it('should start a timer', () => {
+				it('should start a timer', async () => {
 					jest.useFakeTimers('modern');
 					jest.setSystemTime(0);
 					const end = instance.labels('GET', '/test').startTimer();
 					jest.advanceTimersByTime(1000);
 					end();
-					const values = instance.get().values;
+					const { values } = await instance.get();
 					expect(values).toHaveLength(3);
 					expect(values[0].labels.method).toEqual('GET');
 					expect(values[0].labels.endpoint).toEqual('/test');
@@ -216,13 +216,13 @@ describe('summary', () => {
 					jest.useRealTimers();
 				});
 
-				it('should start a timer and set labels afterwards', () => {
+				it('should start a timer and set labels afterwards', async () => {
 					jest.useFakeTimers('modern');
 					jest.setSystemTime(0);
 					const end = instance.startTimer();
 					jest.advanceTimersByTime(1000);
 					end({ method: 'GET', endpoint: '/test' });
-					const values = instance.get().values;
+					const { values } = await instance.get();
 					expect(values).toHaveLength(3);
 					expect(values[0].labels.method).toEqual('GET');
 					expect(values[0].labels.endpoint).toEqual('/test');
@@ -242,13 +242,13 @@ describe('summary', () => {
 					jest.useRealTimers();
 				});
 
-				it('should allow labels before and after timers', () => {
+				it('should allow labels before and after timers', async () => {
 					jest.useFakeTimers('modern');
 					jest.setSystemTime(0);
 					const end = instance.startTimer({ method: 'GET' });
 					jest.advanceTimersByTime(1000);
 					end({ endpoint: '/test' });
-					const values = instance.get().values;
+					const { values } = await instance.get();
 					expect(values).toHaveLength(3);
 					expect(values[0].labels.method).toEqual('GET');
 					expect(values[0].labels.endpoint).toEqual('/test');
@@ -290,10 +290,10 @@ describe('summary', () => {
 					instance.labels('POST', '/test').observe(100);
 				});
 
-				it('should remove matching label', () => {
+				it('should remove matching label', async () => {
 					instance.remove('GET', '/test');
 
-					const values = instance.get().values;
+					const { values } = await instance.get();
 					expect(values).toHaveLength(3);
 					expect(values[0].labels.quantile).toEqual(0.9);
 					expect(values[0].labels.method).toEqual('POST');
@@ -311,11 +311,11 @@ describe('summary', () => {
 					expect(values[2].value).toEqual(1);
 				});
 
-				it('should remove all labels', () => {
+				it('should remove all labels', async () => {
 					instance.remove('GET', '/test');
 					instance.remove('POST', '/test');
 
-					expect(instance.get().values).toHaveLength(0);
+					expect((await instance.get()).values).toHaveLength(0);
 				});
 
 				it('should throw error if label lengths does not match', () => {
@@ -325,7 +325,7 @@ describe('summary', () => {
 					expect(fn).toThrowErrorMatchingSnapshot();
 				});
 
-				it('should remove timer values', () => {
+				it('should remove timer values', async () => {
 					jest.useFakeTimers('modern');
 					jest.setSystemTime(0);
 					const end = instance.labels('GET', '/test').startTimer();
@@ -333,7 +333,7 @@ describe('summary', () => {
 					end();
 					instance.remove('GET', '/test');
 
-					const values = instance.get().values;
+					const { values } = await instance.get();
 					expect(values).toHaveLength(3);
 					expect(values[0].labels.quantile).toEqual(0.9);
 					expect(values[0].labels.method).toEqual('POST');
@@ -353,7 +353,7 @@ describe('summary', () => {
 					jest.useRealTimers();
 				});
 
-				it('should remove timer values when labels are set afterwards', () => {
+				it('should remove timer values when labels are set afterwards', async () => {
 					jest.useFakeTimers('modern');
 					jest.setSystemTime(0);
 					const end = instance.startTimer();
@@ -361,7 +361,7 @@ describe('summary', () => {
 					end({ method: 'GET', endpoint: '/test' });
 					instance.remove('GET', '/test');
 
-					const values = instance.get().values;
+					const { values } = await instance.get();
 					expect(values).toHaveLength(3);
 					expect(values[0].labels.quantile).toEqual(0.9);
 					expect(values[0].labels.method).toEqual('POST');
@@ -381,7 +381,7 @@ describe('summary', () => {
 					jest.useRealTimers();
 				});
 
-				it('should remove timer values with before and after labels', () => {
+				it('should remove timer values with before and after labels', async () => {
 					jest.useFakeTimers('modern');
 					jest.setSystemTime(0);
 					const end = instance.startTimer({ method: 'GET' });
@@ -389,7 +389,7 @@ describe('summary', () => {
 					end({ endpoint: '/test' });
 					instance.remove('GET', '/test');
 
-					const values = instance.get().values;
+					const { values } = await instance.get();
 					expect(values).toHaveLength(3);
 					expect(values[0].labels.quantile).toEqual(0.9);
 					expect(values[0].labels.method).toEqual('POST');
@@ -419,15 +419,16 @@ describe('summary', () => {
 				registers: [],
 			});
 		});
-		it('should increase count', () => {
+		it('should increase count', async () => {
 			instance.observe(100);
-			expect(instance.get().values[0].labels.quantile).toEqual(0.01);
-			expect(instance.get().values[0].value).toEqual(100);
-			expect(instance.get().values[7].metricName).toEqual('summary_test_sum');
-			expect(instance.get().values[7].value).toEqual(100);
-			expect(instance.get().values[8].metricName).toEqual('summary_test_count');
-			expect(instance.get().values[8].value).toEqual(1);
-			expect(globalRegistry.getMetricsAsJSON().length).toEqual(0);
+			const { values } = await instance.get();
+			expect(values[0].labels.quantile).toEqual(0.01);
+			expect(values[0].value).toEqual(100);
+			expect(values[7].metricName).toEqual('summary_test_sum');
+			expect(values[7].value).toEqual(100);
+			expect(values[8].metricName).toEqual('summary_test_count');
+			expect(values[8].value).toEqual(1);
+			expect((await globalRegistry.getMetricsAsJSON()).length).toEqual(0);
 		});
 	});
 	describe('registry instance', () => {
@@ -440,16 +441,17 @@ describe('summary', () => {
 				registers: [registryInstance],
 			});
 		});
-		it('should increment counter', () => {
+		it('should increment counter', async () => {
 			instance.observe(100);
-			expect(instance.get().values[0].labels.quantile).toEqual(0.01);
-			expect(instance.get().values[0].value).toEqual(100);
-			expect(instance.get().values[7].metricName).toEqual('summary_test_sum');
-			expect(instance.get().values[7].value).toEqual(100);
-			expect(instance.get().values[8].metricName).toEqual('summary_test_count');
-			expect(instance.get().values[8].value).toEqual(1);
-			expect(globalRegistry.getMetricsAsJSON().length).toEqual(0);
-			expect(registryInstance.getMetricsAsJSON().length).toEqual(1);
+			const { values } = await instance.get();
+			expect(values[0].labels.quantile).toEqual(0.01);
+			expect(values[0].value).toEqual(100);
+			expect(values[7].metricName).toEqual('summary_test_sum');
+			expect(values[7].value).toEqual(100);
+			expect(values[8].metricName).toEqual('summary_test_count');
+			expect(values[8].value).toEqual(1);
+			expect((await globalRegistry.getMetricsAsJSON()).length).toEqual(0);
+			expect((await registryInstance.getMetricsAsJSON()).length).toEqual(1);
 		});
 	});
 	describe('sliding window', () => {
@@ -460,7 +462,7 @@ describe('summary', () => {
 			jest.setSystemTime(0);
 		});
 
-		it('should slide when maxAgeSeconds and ageBuckets are set', () => {
+		it('should slide when maxAgeSeconds and ageBuckets are set', async () => {
 			const localInstance = new Summary({
 				name: 'summary_test',
 				help: 'test',
@@ -471,24 +473,22 @@ describe('summary', () => {
 			localInstance.observe(100);
 
 			for (let i = 0; i < 5; i++) {
-				expect(localInstance.get().values[0].labels.quantile).toEqual(0.01);
-				expect(localInstance.get().values[0].value).toEqual(100);
-				expect(localInstance.get().values[7].metricName).toEqual(
-					'summary_test_sum',
-				);
-				expect(localInstance.get().values[7].value).toEqual(100);
-				expect(localInstance.get().values[8].metricName).toEqual(
-					'summary_test_count',
-				);
-				expect(localInstance.get().values[8].value).toEqual(1);
+				const { values } = await localInstance.get();
+				expect(values[0].labels.quantile).toEqual(0.01);
+				expect(values[0].value).toEqual(100);
+				expect(values[7].metricName).toEqual('summary_test_sum');
+				expect(values[7].value).toEqual(100);
+				expect(values[8].metricName).toEqual('summary_test_count');
+				expect(values[8].value).toEqual(1);
 				jest.advanceTimersByTime(1001);
 			}
 
-			expect(localInstance.get().values[0].labels.quantile).toEqual(0.01);
-			expect(localInstance.get().values[0].value).toEqual(0);
+			const { values } = await localInstance.get();
+			expect(values[0].labels.quantile).toEqual(0.01);
+			expect(values[0].value).toEqual(0);
 		});
 
-		it('should not slide when maxAgeSeconds and ageBuckets are not configured', () => {
+		it('should not slide when maxAgeSeconds and ageBuckets are not configured', async () => {
 			const localInstance = new Summary({
 				name: 'summary_test',
 				help: 'test',
@@ -496,21 +496,19 @@ describe('summary', () => {
 			localInstance.observe(100);
 
 			for (let i = 0; i < 5; i++) {
-				expect(localInstance.get().values[0].labels.quantile).toEqual(0.01);
-				expect(localInstance.get().values[0].value).toEqual(100);
-				expect(localInstance.get().values[7].metricName).toEqual(
-					'summary_test_sum',
-				);
-				expect(localInstance.get().values[7].value).toEqual(100);
-				expect(localInstance.get().values[8].metricName).toEqual(
-					'summary_test_count',
-				);
-				expect(localInstance.get().values[8].value).toEqual(1);
+				const { values } = await localInstance.get();
+				expect(values[0].labels.quantile).toEqual(0.01);
+				expect(values[0].value).toEqual(100);
+				expect(values[7].metricName).toEqual('summary_test_sum');
+				expect(values[7].value).toEqual(100);
+				expect(values[8].metricName).toEqual('summary_test_count');
+				expect(values[8].value).toEqual(1);
 				jest.advanceTimersByTime(1001);
 			}
 
-			expect(localInstance.get().values[0].labels.quantile).toEqual(0.01);
-			expect(localInstance.get().values[0].value).toEqual(100);
+			const { values } = await localInstance.get();
+			expect(values[0].labels.quantile).toEqual(0.01);
+			expect(values[0].value).toEqual(100);
 		});
 	});
 });


### PR DESCRIPTION
Finally, this is the semver-major change to the interface I'm proposing per discussion in #337. What do you guys think? @sam-github I can't seem to request a review from you, but would love your thoughts.

(This is also the first non-"mechanical" entry in the changelog, FWIW.)

---

* Adds a `collect` fn, which may be async, to each metric type. This provides a cleaner interface than registering collectors, and allows the collector to do asynchronous work. (Previously it would be one scrape behind if it had to do async work.)

* In turn, makes `registry.metrics()` and `registry.get...` async, and removes the `collectors`/`registerCollector` functions.

* Fixes `process_max_fds` and `process_start_time_seconds` so that they have values after the registry is reset (same vein as #238)

* Cleans up the readme a bit (removes some out-of-date info)

---

I don't suspect this will be a problem, but this does increase the number of Promises created on each scrape. I could decrease that by one per metric fairly easily.

I also forgot to update the benchmark code. Will do if y'all are +1s on this.