### PR TITLE
Expose global registry

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -81,7 +81,13 @@ export class Registry {
 	 * @param registers The registers you want to merge together
 	 */
 	static merge(registers: Registry[]): Registry;
+	
+	/**
+	 * Global registry
+	 */
+	globalRegistry: Registry;
 }
+
 export type Collector = () => void;
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -85,7 +85,7 @@ export class Registry {
 	/**
 	 * Global registry
 	 */
-	globalRegistry: Registry;
+	static globalRegistry: Registry;
 }
 
 export type Collector = () => void;


### PR DESCRIPTION
## Problem

Global registry not accessible and having `already registered` errors on test suites.

## Why 

Helps when running test suites. It's a good way to clean the registry on each iteration.

## Current workaround

```ts
((prom.Registry as any).globalRegistry as prom.Registry).clear();
```

Thanks