### PR TITLE
chore: upgrade to Jest 26

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 13.x]
+        node-version: [10.x, 12.x, 13.x, 14.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     runs-on: ${{ matrix.os }}

--- a/package.json
+++ b/package.json
@@ -32,16 +32,16 @@
 	"homepage": "https://github.com/siimon/prom-client",
 	"devDependencies": {
 		"@clevernature/benchmark-regression": "^1.0.0",
+		"@sinonjs/fake-timers": "^6.0.1",
 		"eslint": "^6.8.0",
 		"eslint-config-prettier": "^6.10.0",
 		"eslint-plugin-node": "^11.0.0",
 		"eslint-plugin-prettier": "^3.0.1",
 		"express": "^4.13.3",
 		"husky": "^4.2.1",
-		"jest": "^25.1.0",
+		"jest": "^26.0.1",
 		"lint-staged": "^10.0.4",
-		"lolex": "^5.1.2",
-		"prettier": "2.0.2",
+		"prettier": "2.0.5",
 		"typescript": "^3.0.3"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
 	"homepage": "https://github.com/siimon/prom-client",
 	"devDependencies": {
 		"@clevernature/benchmark-regression": "^1.0.0",
-		"@sinonjs/fake-timers": "^6.0.1",
 		"eslint": "^6.8.0",
 		"eslint-config-prettier": "^6.10.0",
 		"eslint-plugin-node": "^11.0.0",

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -4,7 +4,6 @@ describe('gauge', () => {
 	const Gauge = require('../index').Gauge;
 	const Registry = require('../index').Registry;
 	const globalRegistry = require('../index').register;
-	const lolex = require('@sinonjs/fake-timers');
 	let instance;
 
 	describe('global registry', () => {
@@ -43,19 +42,21 @@ describe('gauge', () => {
 			});
 
 			it('should start a timer and set a gauge to elapsed in seconds', () => {
-				const clock = lolex.install();
+				jest.useFakeTimers('modern');
+				jest.setSystemTime(0);
 				const doneFn = instance.startTimer();
-				clock.tick(500);
+				jest.advanceTimersByTime(500);
 				doneFn();
 				expectValue(0.5);
-				clock.uninstall();
+				jest.useRealTimers();
 			});
 
 			it('should set to current time', () => {
-				const clock = lolex.install();
+				jest.useFakeTimers('modern');
+				jest.setSystemTime(0);
 				instance.setToCurrentTime();
 				expectValue(Date.now());
-				clock.uninstall();
+				jest.useRealTimers();
 			});
 
 			it('should not allow non numbers', () => {
@@ -95,26 +96,29 @@ describe('gauge', () => {
 					expectValue(500);
 				});
 				it('should be able to set value to current time', () => {
-					const clock = lolex.install();
+					jest.useFakeTimers('modern');
+					jest.setSystemTime(0);
 					instance.labels('200').setToCurrentTime();
 					expectValue(Date.now());
-					clock.uninstall();
+					jest.useRealTimers();
 				});
 				it('should be able to start a timer', () => {
-					const clock = lolex.install();
+					jest.useFakeTimers('modern');
+					jest.setSystemTime(0);
 					const end = instance.labels('200').startTimer();
-					clock.tick(1000);
+					jest.advanceTimersByTime(1000);
 					end();
 					expectValue(1);
-					clock.uninstall();
+					jest.useRealTimers();
 				});
 				it('should be able to start a timer and set labels afterwards', () => {
-					const clock = lolex.install();
+					jest.useFakeTimers('modern');
+					jest.setSystemTime(0);
 					const end = instance.startTimer();
-					clock.tick(1000);
+					jest.advanceTimersByTime(1000);
 					end({ code: 200 });
 					expectValue(1);
-					clock.uninstall();
+					jest.useRealTimers();
 				});
 				it('should allow labels before and after timers', () => {
 					instance = new Gauge({
@@ -122,12 +126,13 @@ describe('gauge', () => {
 						help: 'help',
 						labelNames: ['code', 'success'],
 					});
-					const clock = lolex.install();
+					jest.useFakeTimers('modern');
+					jest.setSystemTime(0);
 					const end = instance.startTimer({ code: 200 });
-					clock.tick(1000);
+					jest.advanceTimersByTime(1000);
 					end({ success: 'SUCCESS' });
 					expectValue(1);
-					clock.uninstall();
+					jest.useRealTimers();
 				});
 				it('should not mutate passed startLabels', () => {
 					const startLabels = { code: '200' };

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -4,7 +4,7 @@ describe('gauge', () => {
 	const Gauge = require('../index').Gauge;
 	const Registry = require('../index').Registry;
 	const globalRegistry = require('../index').register;
-	const lolex = require('lolex');
+	const lolex = require('@sinonjs/fake-timers');
 	let instance;
 
 	describe('global registry', () => {

--- a/test/histogramTest.js
+++ b/test/histogramTest.js
@@ -4,7 +4,6 @@ describe('histogram', () => {
 	const Histogram = require('../index').Histogram;
 	const Registry = require('../index').Registry;
 	const globalRegistry = require('../index').register;
-	const lolex = require('@sinonjs/fake-timers');
 	let instance;
 
 	afterEach(() => {
@@ -90,22 +89,24 @@ describe('histogram', () => {
 			});
 
 			it('should time requests', () => {
-				const clock = lolex.install();
+				jest.useFakeTimers('modern');
+				jest.setSystemTime(0);
 				const doneFn = instance.startTimer();
-				clock.tick(500);
+				jest.advanceTimersByTime(500);
 				doneFn();
 				const valuePair = getValueByLabel(0.5, instance.get().values);
 				expect(valuePair.value).toEqual(1);
-				clock.uninstall();
+				jest.useRealTimers();
 			});
 
 			it('should time requests, end function should return time spent value', () => {
-				const clock = lolex.install();
+				jest.useFakeTimers('modern');
+				jest.setSystemTime(0);
 				const doneFn = instance.startTimer();
-				clock.tick(500);
+				jest.advanceTimersByTime(500);
 				const value = doneFn();
 				expect(value).toEqual(0.5);
-				clock.uninstall();
+				jest.useRealTimers();
 			});
 
 			it('should not allow non numbers', () => {
@@ -189,9 +190,10 @@ describe('histogram', () => {
 				});
 
 				it('should start a timer', () => {
-					const clock = lolex.install();
+					jest.useFakeTimers('modern');
+					jest.setSystemTime(0);
 					const end = instance.labels('get').startTimer();
-					clock.tick(500);
+					jest.advanceTimersByTime(500);
 					end();
 					const res = getValueByLeAndLabel(
 						0.5,
@@ -200,13 +202,14 @@ describe('histogram', () => {
 						instance.get().values,
 					);
 					expect(res.value).toEqual(1);
-					clock.uninstall();
+					jest.useRealTimers();
 				});
 
 				it('should start a timer and set labels afterwards', () => {
-					const clock = lolex.install();
+					jest.useFakeTimers('modern');
+					jest.setSystemTime(0);
 					const end = instance.startTimer();
-					clock.tick(500);
+					jest.advanceTimersByTime(500);
 					end({ method: 'get' });
 					const res = getValueByLeAndLabel(
 						0.5,
@@ -215,7 +218,7 @@ describe('histogram', () => {
 						instance.get().values,
 					);
 					expect(res.value).toEqual(1);
-					clock.uninstall();
+					jest.useRealTimers();
 				});
 
 				it('should allow labels before and after timers', () => {
@@ -224,9 +227,10 @@ describe('histogram', () => {
 						help: 'Histogram with labels fn',
 						labelNames: ['method', 'success'],
 					});
-					const clock = lolex.install();
+					jest.useFakeTimers('modern');
+					jest.setSystemTime(0);
 					const end = instance.startTimer({ method: 'get' });
-					clock.tick(500);
+					jest.advanceTimersByTime(500);
 					end({ success: 'SUCCESS' });
 					const res1 = getValueByLeAndLabel(
 						0.5,
@@ -242,7 +246,7 @@ describe('histogram', () => {
 					);
 					expect(res1.value).toEqual(1);
 					expect(res2.value).toEqual(1);
-					clock.uninstall();
+					jest.useRealTimers();
 				});
 
 				it('should not mutate passed startLabels', () => {
@@ -293,10 +297,11 @@ describe('histogram', () => {
 				});
 
 				it('should remove timer labels', () => {
-					const clock = lolex.install();
+					jest.useFakeTimers('modern');
+					jest.setSystemTime(0);
 					const getEnd = instance.labels('GET').startTimer();
 					const postEnd = instance.labels('POST').startTimer();
-					clock.tick(500);
+					jest.advanceTimersByTime(500);
 					postEnd();
 					getEnd();
 					instance.remove('POST');
@@ -307,17 +312,18 @@ describe('histogram', () => {
 						instance.get().values,
 					);
 					expect(res.value).toEqual(1);
-					clock.uninstall();
+					jest.useRealTimers();
 				});
 
 				it('should remove timer labels when labels are set afterwards', () => {
-					const clock = lolex.install();
+					jest.useFakeTimers('modern');
+					jest.setSystemTime(0);
 					const end = instance.startTimer();
-					clock.tick(500);
+					jest.advanceTimersByTime(500);
 					end({ method: 'GET' });
 					instance.remove('GET');
 					expect(instance.get().values).toHaveLength(0);
-					clock.uninstall();
+					jest.useRealTimers();
 				});
 
 				it('should remove labels before and after timers', () => {
@@ -326,13 +332,14 @@ describe('histogram', () => {
 						help: 'Histogram with labels fn',
 						labelNames: ['method', 'success'],
 					});
-					const clock = lolex.install();
+					jest.useFakeTimers('modern');
+					jest.setSystemTime(0);
 					const end = instance.startTimer({ method: 'GET' });
-					clock.tick(500);
+					jest.advanceTimersByTime(500);
 					end({ success: 'SUCCESS' });
 					instance.remove('GET', 'SUCCESS');
 					expect(instance.get().values).toHaveLength(0);
-					clock.uninstall();
+					jest.useRealTimers();
 				});
 			});
 		});

--- a/test/histogramTest.js
+++ b/test/histogramTest.js
@@ -4,7 +4,7 @@ describe('histogram', () => {
 	const Histogram = require('../index').Histogram;
 	const Registry = require('../index').Registry;
 	const globalRegistry = require('../index').register;
-	const lolex = require('lolex');
+	const lolex = require('@sinonjs/fake-timers');
 	let instance;
 
 	afterEach(() => {

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -4,7 +4,7 @@ describe('summary', () => {
 	const Summary = require('../index').Summary;
 	const Registry = require('../index').Registry;
 	const globalRegistry = require('../index').register;
-	const lolex = require('lolex');
+	const lolex = require('@sinonjs/fake-timers');
 	let instance;
 
 	describe('global registry', () => {

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -4,7 +4,6 @@ describe('summary', () => {
 	const Summary = require('../index').Summary;
 	const Registry = require('../index').Registry;
 	const globalRegistry = require('../index').register;
-	const lolex = require('@sinonjs/fake-timers');
 	let instance;
 
 	describe('global registry', () => {
@@ -192,9 +191,10 @@ describe('summary', () => {
 				});
 
 				it('should start a timer', () => {
-					const clock = lolex.install();
+					jest.useFakeTimers('modern');
+					jest.setSystemTime(0);
 					const end = instance.labels('GET', '/test').startTimer();
-					clock.tick(1000);
+					jest.advanceTimersByTime(1000);
 					end();
 					const values = instance.get().values;
 					expect(values).toHaveLength(3);
@@ -213,13 +213,14 @@ describe('summary', () => {
 					expect(values[2].labels.endpoint).toEqual('/test');
 					expect(values[2].value).toEqual(1);
 
-					clock.uninstall();
+					jest.useRealTimers();
 				});
 
 				it('should start a timer and set labels afterwards', () => {
-					const clock = lolex.install();
+					jest.useFakeTimers('modern');
+					jest.setSystemTime(0);
 					const end = instance.startTimer();
-					clock.tick(1000);
+					jest.advanceTimersByTime(1000);
 					end({ method: 'GET', endpoint: '/test' });
 					const values = instance.get().values;
 					expect(values).toHaveLength(3);
@@ -238,13 +239,14 @@ describe('summary', () => {
 					expect(values[2].labels.endpoint).toEqual('/test');
 					expect(values[2].value).toEqual(1);
 
-					clock.uninstall();
+					jest.useRealTimers();
 				});
 
 				it('should allow labels before and after timers', () => {
-					const clock = lolex.install();
+					jest.useFakeTimers('modern');
+					jest.setSystemTime(0);
 					const end = instance.startTimer({ method: 'GET' });
-					clock.tick(1000);
+					jest.advanceTimersByTime(1000);
 					end({ endpoint: '/test' });
 					const values = instance.get().values;
 					expect(values).toHaveLength(3);
@@ -263,7 +265,7 @@ describe('summary', () => {
 					expect(values[2].labels.endpoint).toEqual('/test');
 					expect(values[2].value).toEqual(1);
 
-					clock.uninstall();
+					jest.useRealTimers();
 				});
 
 				it('should not mutate passed startLabels', () => {
@@ -324,9 +326,10 @@ describe('summary', () => {
 				});
 
 				it('should remove timer values', () => {
-					const clock = lolex.install();
+					jest.useFakeTimers('modern');
+					jest.setSystemTime(0);
 					const end = instance.labels('GET', '/test').startTimer();
-					clock.tick(1000);
+					jest.advanceTimersByTime(1000);
 					end();
 					instance.remove('GET', '/test');
 
@@ -347,13 +350,14 @@ describe('summary', () => {
 					expect(values[2].labels.endpoint).toEqual('/test');
 					expect(values[2].value).toEqual(1);
 
-					clock.uninstall();
+					jest.useRealTimers();
 				});
 
 				it('should remove timer values when labels are set afterwards', () => {
-					const clock = lolex.install();
+					jest.useFakeTimers('modern');
+					jest.setSystemTime(0);
 					const end = instance.startTimer();
-					clock.tick(1000);
+					jest.advanceTimersByTime(1000);
 					end({ method: 'GET', endpoint: '/test' });
 					instance.remove('GET', '/test');
 
@@ -374,13 +378,14 @@ describe('summary', () => {
 					expect(values[2].labels.endpoint).toEqual('/test');
 					expect(values[2].value).toEqual(1);
 
-					clock.uninstall();
+					jest.useRealTimers();
 				});
 
 				it('should remove timer values with before and after labels', () => {
-					const clock = lolex.install();
+					jest.useFakeTimers('modern');
+					jest.setSystemTime(0);
 					const end = instance.startTimer({ method: 'GET' });
-					clock.tick(1000);
+					jest.advanceTimersByTime(1000);
 					end({ endpoint: '/test' });
 					instance.remove('GET', '/test');
 
@@ -401,7 +406,7 @@ describe('summary', () => {
 					expect(values[2].labels.endpoint).toEqual('/test');
 					expect(values[2].value).toEqual(1);
 
-					clock.uninstall();
+					jest.useRealTimers();
 				});
 			});
 		});
@@ -451,7 +456,8 @@ describe('summary', () => {
 		let clock;
 		beforeEach(() => {
 			globalRegistry.clear();
-			clock = lolex.install();
+			jest.useFakeTimers('modern');
+			jest.setSystemTime(0);
 		});
 
 		it('should slide when maxAgeSeconds and ageBuckets are set', () => {
@@ -475,7 +481,7 @@ describe('summary', () => {
 					'summary_test_count',
 				);
 				expect(localInstance.get().values[8].value).toEqual(1);
-				clock.tick(1001);
+				jest.advanceTimersByTime(1001);
 			}
 
 			expect(localInstance.get().values[0].labels.quantile).toEqual(0.01);
@@ -500,7 +506,7 @@ describe('summary', () => {
 					'summary_test_count',
 				);
 				expect(localInstance.get().values[8].value).toEqual(1);
-				clock.tick(1001);
+				jest.advanceTimersByTime(1001);
 			}
 
 			expect(localInstance.get().values[0].labels.quantile).toEqual(0.01);

--- a/test/timeWindowQuantilesTest.js
+++ b/test/timeWindowQuantilesTest.js
@@ -2,7 +2,7 @@
 
 describe('timeWindowQuantiles', () => {
 	const TimeWindowQuantiles = require('../lib/timeWindowQuantiles');
-	const lolex = require('lolex');
+	const lolex = require('@sinonjs/fake-timers');
 	let instance;
 	let clock;
 

--- a/test/timeWindowQuantilesTest.js
+++ b/test/timeWindowQuantilesTest.js
@@ -2,12 +2,12 @@
 
 describe('timeWindowQuantiles', () => {
 	const TimeWindowQuantiles = require('../lib/timeWindowQuantiles');
-	const lolex = require('@sinonjs/fake-timers');
 	let instance;
 	let clock;
 
 	beforeEach(() => {
-		clock = lolex.install();
+		jest.useFakeTimers('modern');
+		jest.setSystemTime(0);
 		instance = new TimeWindowQuantiles(5, 5);
 	});
 
@@ -54,19 +54,19 @@ describe('timeWindowQuantiles', () => {
 		it('should rotate', () => {
 			instance.push(1);
 			expect(instance.currentBuffer).toEqual(0);
-			clock.tick(1001);
+			jest.advanceTimersByTime(1001);
 			instance.percentile(0.5);
 			expect(instance.currentBuffer).toEqual(1);
-			clock.tick(1001);
+			jest.advanceTimersByTime(1001);
 			instance.percentile(0.5);
 			expect(instance.currentBuffer).toEqual(2);
-			clock.tick(1001);
+			jest.advanceTimersByTime(1001);
 			instance.percentile(0.5);
 			expect(instance.currentBuffer).toEqual(3);
-			clock.tick(1001);
+			jest.advanceTimersByTime(1001);
 			instance.percentile(0.5);
 			expect(instance.currentBuffer).toEqual(4);
-			clock.tick(1001);
+			jest.advanceTimersByTime(1001);
 			instance.percentile(0.5);
 			expect(instance.currentBuffer).toEqual(0);
 


### PR DESCRIPTION
Also add Node 14 to CI.

~Lolex has been renamed to `@sinonjs/fake-timers`. Jest bundles it now, but this keeps the diff down~ meh, second commit uses it. Note that I fake system time to be `0` (epoch). This is the default when using `lolex`/`@sinonjs/fake-timers`, while Jest default to the current system real time. _Not_ setting this gives a bunch of failing tests (e.g. we expect seconds to match ms from `Date.now()` etc). That's a bug in our tests, but I don't think it should be fixed in this PR