### PR TITLE
improve performance of registry.metrics()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - chore: refactor metrics to reduce code duplication
 - chore: replace `utils.getPropertiesFromObj` with `Object.values`
 - chore: remove unused `catch` bindings
+- chore: improve performance of `registry.metrics()`
 
 ### Added
 

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -9,11 +9,6 @@ const { validateLabel } = require('./validation');
 const { Metric } = require('./metric');
 
 class Counter extends Metric {
-	constructor(...args) {
-		super(...args);
-		this.type = 'counter';
-	}
-
 	/**
 	 * Increment counter
 	 * @param {object} labels - What label you want to be incremented
@@ -61,6 +56,8 @@ class Counter extends Metric {
 		return removeLabels.call(this, this.hashMap, labels);
 	}
 }
+
+Counter.prototype.type = 'counter';
 
 const reset = function () {
 	this.hashMap = {};

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -4,12 +4,16 @@
 'use strict';
 
 const util = require('util');
-const type = 'counter';
 const { hashObject, isObject, getLabels, removeLabels } = require('./util');
 const { validateLabel } = require('./validation');
 const { Metric } = require('./metric');
 
 class Counter extends Metric {
+	constructor(...args) {
+		super(...args);
+		this.type = 'counter';
+	}
+
 	/**
 	 * Increment counter
 	 * @param {object} labels - What label you want to be incremented
@@ -37,7 +41,7 @@ class Counter extends Metric {
 		return {
 			help: this.help,
 			name: this.name,
-			type,
+			type: this.type,
 			values: Object.values(this.hashMap),
 			aggregator: this.aggregator,
 		};

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const generateFunction = require('generate-function');
+
+function getFormatter(metric, defaultLabels) {
+	const defaultLabelNames = Object.keys(defaultLabels);
+	const name = metric.name;
+	const help = escapeString(metric.help);
+	const type = metric.type;
+	const labelsCode = getLabelsCode(metric, defaultLabelNames, defaultLabels);
+
+	const gen = generateFunction();
+	gen(`
+  function format(item, escapeLabelValue, getValueAsString) {
+    const info = '# HELP ${name} ${help}\\n# TYPE ${name} ${type}\\n';
+    let values = '';
+    for (const val of item.values || []) {
+      val.labels = val.labels || {};
+      let metricName = val.metricName || '${name}';
+      const labels = \`${labelsCode}\`;
+      const hasLabels = labels.length > 0;
+      metricName += \`\${hasLabels ? '{' : ''}\${labels}\${hasLabels ? '}' : ''}\`;
+      let line = \`\${metricName} \${getValueAsString(val.value)}\`;
+      values += \`\${line}\\n\`;
+    }
+    return info + values;
+  }`);
+	return gen.toFunction();
+}
+
+function getLabelsCode(metric, defaultLabelNames, defaultLabels) {
+	let labelString = '';
+	const labelNames = getLabelNames(metric, defaultLabelNames);
+	for (let index = 0; index < labelNames.length; index++) {
+		const labelName = labelNames[index];
+		if (labelName === 'quantile') {
+			labelString += `\${val.labels.quantile != null ? \`quantile="\${escapeLabelValue(val.labels.quantile)}"\` : ''}`;
+		} else if (labelName === 'le') {
+			labelString += `\${val.labels.le != null ? \`le="\${escapeLabelValue(val.labels.le)}"\` : ''}`;
+		} else {
+			labelString += `${labelName}="\${val.labels['${labelName}'] ? escapeLabelValue(val.labels['${labelName}']) : escapeLabelValue('${defaultLabels[labelName]}')}"`;
+		}
+		if (index !== labelNames.length - 1 && labelString.length > 0) {
+			labelString += ',';
+		}
+	}
+	return labelString;
+}
+
+function getLabelNames(metric, defaultLabelNames) {
+	const labelNames = [...metric.labelNames];
+	for (const labelName of defaultLabelNames) {
+		if (!labelNames.includes(labelName)) {
+			labelNames.push(labelName);
+		}
+	}
+	if (metric.type === 'summary') {
+		labelNames.push('quantile');
+	}
+	if (metric.type === 'histogram') {
+		labelNames.push('le');
+	}
+	return labelNames;
+}
+
+function escapeString(str) {
+	return str.replace(/\n/g, '\\\\n').replace(/\\(?!n)/g, '\\\\\\\\');
+}
+
+module.exports = {
+	getFormatter,
+};

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -30,22 +30,33 @@ function getFormatter(metric, defaultLabels) {
 }
 
 function getLabelsCode(metric, defaultLabelNames, defaultLabels) {
-	let labelString = '';
+	const labelString = [];
 	const labelNames = getLabelNames(metric, defaultLabelNames);
 	for (let index = 0; index < labelNames.length; index++) {
+		const comma = index > 0 ? ',' : '';
 		const labelName = labelNames[index];
 		if (labelName === 'quantile') {
-			labelString += `\${val.labels.quantile != null ? \`quantile="\${escapeLabelValue(val.labels.quantile)}"\` : ''}`;
+			labelString.push(
+				`\${val.labels.quantile != null ? \`${comma}quantile="\${escapeLabelValue(val.labels.quantile)}"\` : ''}`,
+			);
 		} else if (labelName === 'le') {
-			labelString += `\${val.labels.le != null ? \`le="\${escapeLabelValue(val.labels.le)}"\` : ''}`;
+			labelString.push(
+				`\${val.labels.le != null ? \`${comma}le="\${escapeLabelValue(val.labels.le)}"\` : ''}`,
+			);
 		} else {
-			labelString += `${labelName}="\${val.labels['${labelName}'] ? escapeLabelValue(val.labels['${labelName}']) : escapeLabelValue('${defaultLabels[labelName]}')}"`;
-		}
-		if (index !== labelNames.length - 1 && labelString.length > 0) {
-			labelString += ',';
+			const defaultLabelValue = defaultLabels[labelName];
+			if (typeof defaultLabelValue === 'undefined') {
+				labelString.push(
+					`\${val.labels['${labelName}'] != null ? \`${comma}${labelName}="\${escapeLabelValue(val.labels['${labelName}'])}"\` : ''}`,
+				);
+			} else {
+				labelString.push(
+					`${comma}${labelName}="\${escapeLabelValue(val.labels['${labelName}']  || '${defaultLabelValue}')}"`,
+				);
+			}
 		}
 	}
-	return labelString;
+	return labelString.join('');
 }
 
 function getLabelNames(metric, defaultLabelNames) {

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const generateFunction = require('generate-function');
-
 function getFormatter(metric, defaultLabels) {
 	const defaultLabelNames = Object.keys(defaultLabels);
 	const name = metric.name;
@@ -9,23 +7,26 @@ function getFormatter(metric, defaultLabels) {
 	const type = metric.type;
 	const labelsCode = getLabelsCode(metric, defaultLabelNames, defaultLabels);
 
-	const gen = generateFunction();
-	gen(`
-  function format(item, escapeLabelValue, getValueAsString) {
-    const info = '# HELP ${name} ${help}\\n# TYPE ${name} ${type}\\n';
-    let values = '';
-    for (const val of item.values || []) {
-      val.labels = val.labels || {};
-      let metricName = val.metricName || '${name}';
-      const labels = \`${labelsCode}\`;
-      const hasLabels = labels.length > 0;
-      metricName += \`\${hasLabels ? '{' : ''}\${labels}\${hasLabels ? '}' : ''}\`;
-      let line = \`\${metricName} \${getValueAsString(val.value)}\`;
-      values += \`\${line}\\n\`;
-    }
-    return info + values;
-  }`);
-	return gen.toFunction();
+	// eslint-disable-next-line no-new-func
+	return new Function(
+		'item',
+		'escapeLabelValue',
+		'getValueAsString',
+		`
+		const info = '# HELP ${name} ${help}\\n# TYPE ${name} ${type}\\n';
+		let values = '';
+		for (const val of item.values || []) {
+		  val.labels = val.labels || {};
+		  let metricName = val.metricName || '${name}';
+		  const labels = \`${labelsCode}\`;
+		  const hasLabels = labels.length > 0;
+		  metricName += \`\${hasLabels ? '{' : ''}\${labels}\${hasLabels ? '}' : ''}\`;
+		  let line = \`\${metricName} \${getValueAsString(val.value)}\`;
+		  values += \`\${line}\\n\`;
+		}
+		return info + values;
+	  	`,
+	);
 }
 
 function getLabelsCode(metric, defaultLabelNames, defaultLabels) {

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -16,11 +16,6 @@ const { validateLabel } = require('./validation');
 const { Metric } = require('./metric');
 
 class Gauge extends Metric {
-	constructor(...args) {
-		super(...args);
-		this.type = 'gauge';
-	}
-
 	/**
 	 * Set a gauge to a value
 	 * @param {object} labels - Object with labels and their values
@@ -116,6 +111,8 @@ class Gauge extends Metric {
 		removeLabels.call(this, this.hashMap, labels);
 	}
 }
+
+Gauge.prototype.type = 'gauge';
 
 function setToCurrentTime(labels) {
 	return () => {

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -4,7 +4,6 @@
 'use strict';
 
 const util = require('util');
-const type = 'gauge';
 
 const {
 	setValue,
@@ -17,6 +16,11 @@ const { validateLabel } = require('./validation');
 const { Metric } = require('./metric');
 
 class Gauge extends Metric {
+	constructor(...args) {
+		super(...args);
+		this.type = 'gauge';
+	}
+
 	/**
 	 * Set a gauge to a value
 	 * @param {object} labels - Object with labels and their values
@@ -85,7 +89,7 @@ class Gauge extends Metric {
 		return {
 			help: this.help,
 			name: this.name,
-			type,
+			type: this.type,
 			values: Object.values(this.hashMap),
 			aggregator: this.aggregator,
 		};

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -37,8 +37,6 @@ class Histogram extends Metric {
 				),
 			};
 		}
-
-		this.type = 'histogram';
 	}
 
 	/**
@@ -100,6 +98,8 @@ class Histogram extends Metric {
 		removeLabels.call(this, this.hashMap, labels);
 	}
 }
+
+Histogram.prototype.type = 'histogram';
 
 function startTimer(startLabels) {
 	return () => {

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -4,7 +4,6 @@
 'use strict';
 
 const util = require('util');
-const type = 'histogram';
 const { getLabels, hashObject, isObject, removeLabels } = require('./util');
 const { validateLabel } = require('./validation');
 const { Metric } = require('./metric');
@@ -38,6 +37,8 @@ class Histogram extends Metric {
 				),
 			};
 		}
+
+		this.type = 'histogram';
 	}
 
 	/**
@@ -59,7 +60,7 @@ class Histogram extends Metric {
 		return {
 			name: this.name,
 			help: this.help,
-			type,
+			type: this.type,
 			values,
 			aggregator: this.aggregator,
 		};

--- a/lib/metric.js
+++ b/lib/metric.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const { globalRegistry } = require('./registry');
-const { isObject } = require('./util');
+const { isObject, getValueAsString, escapeLabelValue } = require('./util');
+const { getFormatter } = require('./formatter');
 const { validateMetricName, validateLabelName } = require('./validation');
 
 /**
@@ -44,6 +45,14 @@ class Metric {
 		for (const register of this.registers) {
 			register.registerMetric(this);
 		}
+	}
+
+	getPrometheusString(defaultLabels) {
+		const item = this.get();
+		if (!this.formatter) {
+			this.formatter = getFormatter(this, defaultLabels);
+		}
+		return this.formatter(item, escapeLabelValue, getValueAsString);
 	}
 
 	reset() {

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,15 +1,4 @@
 'use strict';
-const { getValueAsString } = require('./util');
-
-function escapeString(str) {
-	return str.replace(/\n/g, '\\n').replace(/\\(?!n)/g, '\\\\');
-}
-function escapeLabelValue(str) {
-	if (typeof str !== 'string') {
-		return str;
-	}
-	return escapeString(str).replace(/"/g, '\\"');
-}
 
 class Registry {
 	constructor() {
@@ -23,44 +12,7 @@ class Registry {
 	}
 
 	getMetricAsPrometheusString(metric) {
-		const item = metric.get();
-		const name = escapeString(item.name);
-		const help = `# HELP ${name} ${escapeString(item.help)}`;
-		const type = `# TYPE ${name} ${item.type}`;
-		const defaultLabelNames = Object.keys(this._defaultLabels);
-
-		let values = '';
-		for (const val of item.values || []) {
-			val.labels = val.labels || {};
-
-			if (defaultLabelNames.length > 0) {
-				// Make a copy before mutating
-				val.labels = Object.assign({}, val.labels);
-
-				for (const labelName of defaultLabelNames) {
-					val.labels[labelName] =
-						val.labels[labelName] || this._defaultLabels[labelName];
-				}
-			}
-
-			let metricName = val.metricName || item.name;
-
-			const keys = Object.keys(val.labels);
-			const size = keys.length;
-			if (size > 0) {
-				let labels = '';
-				let i = 0;
-				for (; i < size - 1; i++) {
-					labels += `${keys[i]}="${escapeLabelValue(val.labels[keys[i]])}",`;
-				}
-				labels += `${keys[i]}="${escapeLabelValue(val.labels[keys[i]])}"`;
-				metricName += `{${labels}}`;
-			}
-
-			values += `${metricName} ${getValueAsString(val.value)}\n`;
-		}
-
-		return `${help}\n${type}\n${values}`.trim();
+		return metric.getPrometheusString(this._defaultLabels);
 	}
 
 	metrics() {
@@ -69,7 +21,7 @@ class Registry {
 		this.collect();
 
 		for (const metric of this.getMetricsAsArray()) {
-			metrics += `${this.getMetricAsPrometheusString(metric)}\n\n`;
+			metrics += `${this.getMetricAsPrometheusString(metric)}\n`;
 		}
 
 		return metrics.substring(0, metrics.length - 1);

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -4,7 +4,6 @@
 'use strict';
 
 const util = require('util');
-const type = 'summary';
 const { getLabels, hashObject, removeLabels } = require('./util');
 const { validateLabel } = require('./validation');
 const { Metric } = require('./metric');
@@ -35,6 +34,8 @@ class Summary extends Metric {
 				},
 			};
 		}
+
+		this.type = 'summary';
 	}
 
 	/**
@@ -61,7 +62,7 @@ class Summary extends Metric {
 		return {
 			name: this.name,
 			help: this.help,
-			type,
+			type: this.type,
 			values,
 			aggregator: this.aggregator,
 		};

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -34,8 +34,6 @@ class Summary extends Metric {
 				},
 			};
 		}
-
-		this.type = 'summary';
 	}
 
 	/**
@@ -104,6 +102,8 @@ class Summary extends Metric {
 		removeLabels.call(this, this.hashMap, labels);
 	}
 }
+
+Summary.prototype.type = 'summary';
 
 function extractSummariesForExport(summaryOfLabels, percentiles) {
 	summaryOfLabels.td.compress();

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,14 @@
 'use strict';
 
+const QUOTE_RE = /"/g;
+
+exports.escapeLabelValue = function escapeLabelValue(str) {
+	if (typeof str !== 'string') {
+		return str;
+	}
+	return str.replace(QUOTE_RE, '\\"');
+};
+
 exports.getValueAsString = function getValueString(value) {
 	if (Number.isNaN(value)) {
 		return 'Nan';

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
 		"typescript": "^3.0.3"
 	},
 	"dependencies": {
-		"generate-function": "^2.3.1",
 		"tdigest": "^0.1.1"
 	},
 	"types": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"typescript": "^3.0.3"
 	},
 	"dependencies": {
+		"generate-function": "^2.3.1",
 		"tdigest": "^0.1.1"
 	},
 	"types": "./index.d.ts",

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -103,6 +103,32 @@ describe('register', () => {
 		expect(output).toEqual('test_metric{testLabel="testValue"} 1');
 	});
 
+	it('should handle a metric with default labels with value 0', () => {
+		register.setDefaultLabels({ testLabel: 0 });
+		const counter = new Counter({
+			name: 'test_metric',
+			help: 'A test metric',
+		});
+		counter.inc(1);
+		register.registerMetric(counter);
+
+		const output = register.metrics().split('\n')[2];
+		expect(output).toEqual('test_metric{testLabel="0"} 1');
+	});
+
+	it('should handle a metrics with labels subset', () => {
+		const gauge = new Gauge({
+			name: 'test_metric',
+			help: 'help',
+			labelNames: ['code', 'success'],
+		});
+		gauge.inc({ code: '200' }, 10);
+		register.registerMetric(gauge);
+
+		const output = register.metrics().split('\n')[2];
+		expect(output).toEqual('test_metric{code="200"} 10');
+	});
+
 	it('labeled metrics should take precidence over defaulted', () => {
 		register.setDefaultLabels({ testLabel: 'testValue' });
 		const counter = new Counter({


### PR DESCRIPTION
I've rebased original PR #276 and achieve the same results

```
### Summary:

✓ registry ➭ getMetricsAsJSON#1 with 64 is 1.900% faster.
✓ registry ➭ getMetricsAsJSON#2 with 8 is 2.054% faster.
⚠ registry ➭ getMetricsAsJSON#2 with 4 and 2 with 2 is 7.658% acceptably slower.
✓ registry ➭ getMetricsAsJSON#2 with 2 and 2 with 4 is 8.235% faster.
✓ registry ➭ getMetricsAsJSON#6 with 2 is 4.261% faster.
✓ registry ➭ metrics#1 with 64 is 6.524% faster.
✓ registry ➭ metrics#2 with 8 is 35.91% faster.
✓ registry ➭ metrics#2 with 4 and 2 with 2 is 26.44% faster.
✓ registry ➭ metrics#2 with 2 and 2 with 4 is 31.02% faster.
✓ registry ➭ metrics#6 with 2 is 34.78% faster.
✓ histogram ➭ observe#1 with 64 is 10.78% faster.
✓ histogram ➭ observe#2 with 8 is 9.954% faster.
✓ histogram ➭ observe#2 with 4 and 2 with 2 is 18.51% faster.
✓ histogram ➭ observe#2 with 2 and 2 with 4 is 5.529% faster.
✓ histogram ➭ observe#6 with 2 is 4.469% faster.
⚠ summary ➭ observe#1 with 64 is 0.7088% acceptably slower.
✓ summary ➭ observe#2 with 8 is 0.8064% faster.
⚠ summary ➭ observe#2 with 4 and 2 with 2 is 0.8744% acceptably slower.
⚠ summary ➭ observe#2 with 2 and 2 with 4 is 3.878% acceptably slower.
✓ summary ➭ observe#6 with 2 is 2.453% faster.
```