### PR TITLE
Fix startTimer return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - chore: refactor metrics to reduce code duplication
 - chore: replace `utils.getPropertiesFromObj` with `Object.values`
 - chore: remove unused `catch` bindings
+- fix: startTimer returns `number` in typescript instead of `void`
 
 ### Added
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -361,7 +361,7 @@ export class Histogram<T extends string> {
 	 * @param labels Object with label keys and values
 	 * @return Function to invoke when timer should be stopped
 	 */
-	startTimer(labels?: LabelValues<T>): (labels?: LabelValues<T>) => void;
+	startTimer(labels?: LabelValues<T>): (labels?: LabelValues<T>) => number;
 
 	/**
 	 * Reset histogram values


### PR DESCRIPTION
# Overview

This PR fixes the TypeScript typings for `startTimer`. 

```ts
// Old 
startTimer(labels?: LabelValues<T>): (labels?: LabelValues<T>) => void;

// New 
startTimer(labels?: LabelValues<T>): (labels?: LabelValues<T>) => number;
```

This corresponds to the actual return value of the `startTimer` function [here.](https://github.com/siimon/prom-client/blob/master/lib/histogram.js#L110)