### PR TITLE
add keep alive support to http/https connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,12 +41,12 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - chore: replace `utils.getPropertiesFromObj` with `Object.values`
 - chore: remove unused `catch` bindings
 - chore: upgrade Prettier to 2.x
-- chore: add keep-alive support to client requests in pushgateway
 
 ### Added
 
 - feat: exposed `registry.registerCollector()` and `registry.collectors()` methods in TypeScript declaration
 - Added CHANGELOG reminder
+- chore: add keep-alive support to client requests in pushgateway
 
 ## [12.0.0] - 2020-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - chore: replace `utils.getPropertiesFromObj` with `Object.values`
 - chore: remove unused `catch` bindings
 - chore: upgrade Prettier to 2.x
+- chore: add keep-alive support to client requests in pushgateway
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -449,6 +449,12 @@ gateway.pushAdd({ jobName: 'test', groupings: { key: 'value' } }, function (
 
 //It's possible to extend the Pushgateway with request options from nodes core http/https library
 gateway = new client.Pushgateway('http://127.0.0.1:9091', { timeout: 5000 }); //Set the request timeout to 5000ms
+
+// It is possible to change default nodejs core http agent configuration in options. You can refer https://nodejs.org/api/http.html#http_new_agent_options for more info on this topic
+const http = require('http');
+const httpAgent = new http.Agent({ keepAlive: false });
+
+gateway = new client.Pushgateway('http://127.0.0.1:9091', { agent: httpAgent }); // disable keepAlive support for http requests
 ```
 
 ### Bucket Generators

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -5,6 +5,16 @@ const http = require('http');
 const https = require('https');
 const { globalRegistry } = require('./registry');
 
+const keepAliveConfig = {
+	keepAlive: true,
+	keepAliveMsecs: 10000,
+	maxSockets: 5,
+};
+
+const httpAgent = new https.Agent(keepAliveConfig);
+
+const httpsAgent = new https.Agent(keepAliveConfig);
+
 class Pushgateway {
 	constructor(gatewayUrl, options, registry) {
 		if (!registry) {
@@ -56,7 +66,9 @@ function useGateway(method, job, groupings, callback) {
 	// eslint-disable-next-line node/no-deprecated-api
 	const requestParams = url.parse(target);
 	const httpModule = isHttps(requestParams.href) ? https : http;
-	const options = Object.assign(requestParams, this.requestOptions, {
+	const agent = { agent: isHttps(requestParams.href) ? httpsAgent : httpAgent };
+
+	const options = Object.assign(requestParams, agent, this.requestOptions, {
 		method,
 	});
 

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -11,7 +11,7 @@ const keepAliveConfig = {
 	maxSockets: 5,
 };
 
-const httpAgent = new https.Agent(keepAliveConfig);
+const httpAgent = new http.Agent(keepAliveConfig);
 
 const httpsAgent = new https.Agent(keepAliveConfig);
 

--- a/test/pushgatewayTest.js
+++ b/test/pushgatewayTest.js
@@ -9,6 +9,7 @@ const mockHttp = jest.fn().mockReturnValue({
 jest.mock('http', () => {
 	return {
 		request: mockHttp,
+		Agent: jest.fn(),
 	};
 });
 

--- a/test/pushgatewayWithPathTest.js
+++ b/test/pushgatewayWithPathTest.js
@@ -13,6 +13,7 @@ const mockHttp = jest.fn().mockReturnValue({
 jest.mock('http', () => {
 	return {
 		request: mockHttp,
+		Agent: jest.fn(),
 	};
 });
 


### PR DESCRIPTION
this agent options make http/https connections reusable and not creating new connection on every client request/.