### PR TITLE
Add function for setting a Histogram to zero for given labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- feat: added `zero()` to `Histogram` for setting the metrics for a given label combination to zero
+
 ## [13.1.0] - 2021-01-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -326,6 +326,24 @@ xhrRequest(function (err, res) {
 });
 ```
 
+#### Zeroing metrics with Labels
+
+Metrics with labels can not be exported before they have been observed at least
+once since the possible label values are not known before they're observed.
+
+For histograms, this can be solved by explicitly zeroing all expected label values:
+
+```js
+const histogram = new client.Histogram({
+  name: 'metric_name',
+  help: 'metric_help',
+  buckets: [0.1, 5, 15, 50, 100, 500],
+  labels: ['method'],
+});
+histogram.zero({ method: 'GET' });
+histogram.zero({ method: 'POST' });
+```
+
 #### Strongly typed Labels
 
 Typescript can also enforce label names using `as const`

--- a/index.d.ts
+++ b/index.d.ts
@@ -390,6 +390,11 @@ export class Histogram<T extends string> {
 	reset(): void;
 
 	/**
+	 * Initialize the metrics for the given combination of labels to zero
+	 */
+	zero(labels: LabelValues<T>): void;
+
+	/**
 	 * Return the child for given labels
 	 * @param values Label values
 	 * @return Configured histogram with given labels

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -74,6 +74,19 @@ class Histogram extends Metric {
 	}
 
 	/**
+	 * Initialize the metrics for the given combination of labels to zero
+	 * @param {object} labels - Object with labels where key is the label key and value is label value. Can only be one level deep
+	 * @returns {void}
+	 */
+	zero(labels) {
+		const hash = hashObject(labels);
+		this.hashMap[hash] = createBaseValues(
+			labels,
+			Object.assign({}, this.bucketValues),
+		);
+	}
+
+	/**
 	 * Start a timer that could be used to logging durations
 	 * @param {object} labels - Object with labels where key is the label key and value is label value. Can only be one level deep
 	 * @returns {function} - Function to invoke when you want to stop the timer and observe the duration in seconds


### PR DESCRIPTION
Since PR #139, histograms are initialized to zero if they do not use any labels - however, there currently is no way to do the same for histograms with labels (without directly accessing the internals of the histogram from the outside, which is of course not a great solution).

Therefore, this PR adds a function that lets the user explicitly zero out the metrics for given labels. Since prom-client has no way of knowing what the values of the labels can be, it's up to the user to call this with all expected values.