### PR TITLE
fix(types): `Registry.getSingleMetric` may return `undefined`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - chore: remove unused `catch` bindings
 - chore: upgrade Prettier to 2.x
 - fix: startTimer returns `number` in typescript instead of `void`
+- fix: incorrect typings of `registry.getSingleMetric' (#388)
 
 ### Added
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,7 +46,7 @@ export class Registry {
 	 * Get a single metric
 	 * @param name The name of the metric
 	 */
-	getSingleMetric<T extends string>(name: string): Metric<T>;
+	getSingleMetric<T extends string>(name: string): Metric<T> | undefined;
 
 	/**
 	 * Set static labels to every metric emitted by this registry


### PR DESCRIPTION
This PR fixes a small error in the TypeScript typings.

The implementation does a simple lookup on an object type:

```
	getSingleMetric(name) {
		return this._metrics[name];
	}
```

When supplied with a non-existent name, this will simply return `undefined` -- which is not reflected in the typings.