### PR TITLE
fix(pushgateway): use async/await gather metrics in pushgateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - fix: startTimer returns `number` in typescript instead of `void`
 - fix: incorrect typings of `registry.getSingleMetric' (#388)
 - chore: stop testing node v13 on CI
+- fix(pushgateway): use async gather metrics in pushgateway (#390)
 
 ### Added
 

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -39,7 +39,7 @@ class Pushgateway {
 		useGateway.call(this, 'DELETE', params.jobName, params.groupings, callback);
 	}
 }
-async function useGateway(method, job, groupings, callback) {
+function useGateway(method, job, groupings, callback) {
 	// `URL` first added in v6.13.0
 	// eslint-disable-next-line node/no-deprecated-api
 	const gatewayUrlParsed = url.parse(this.gatewayUrl);
@@ -75,8 +75,14 @@ async function useGateway(method, job, groupings, callback) {
 	});
 
 	if (method !== 'DELETE') {
-		const metrics = await this.registry.metrics();
-		req.write(metrics);
+		this.registry
+			.metrics()
+			.then(metrics => {
+				req.write(metrics);
+			})
+			.catch(e => {
+				callback(e);
+			});
 	}
 	req.end();
 }

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -39,7 +39,7 @@ class Pushgateway {
 		useGateway.call(this, 'DELETE', params.jobName, params.groupings, callback);
 	}
 }
-function useGateway(method, job, groupings, callback) {
+async function useGateway(method, job, groupings, callback) {
 	// `URL` first added in v6.13.0
 	// eslint-disable-next-line node/no-deprecated-api
 	const gatewayUrlParsed = url.parse(this.gatewayUrl);
@@ -75,7 +75,8 @@ function useGateway(method, job, groupings, callback) {
 	});
 
 	if (method !== 'DELETE') {
-		req.write(this.registry.metrics());
+		const metrics = await this.registry.metrics();
+		req.write(metrics);
 	}
 	req.end();
 }


### PR DESCRIPTION
#390 
registy `metrics` method is an async function.
So update `useGateway` to an async method and use `async/await` to gather  metrics.