### PR TITLE
Allow readonly `labelNames` in metric configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - fix: startTimer returns `number` in typescript instead of `void`
 - fix: incorrect typings of `registry.getSingleMetric' (#388)
 - chore: stop testing node v13 on CI
+- types: improve type checking of labels
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -324,6 +324,28 @@ xhrRequest(function (err, res) {
 });
 ```
 
+#### Strongly typed Labels
+Typescript can also enforce label names using `as const`
+
+```typescript
+import * as client from 'prom-client';
+
+const gauge = new client.Counter({
+  name: 'metric_name',
+  help: 'metric_help',
+  // add `as const` here to enforce label names
+  labelNames: ['method'] as const,
+});
+
+// Ok
+gauge.inc({ method: 1 })
+
+// this is an error since `'methods'` is not a valid `labelName`
+// @ts-expect-error
+gauge.inc({ methods: 1 })
+```
+
+
 #### Default Labels (segmented by registry)
 
 Static labels may be applied to every metric emitted by a registry:

--- a/index.d.ts
+++ b/index.d.ts
@@ -144,7 +144,7 @@ type LabelValues<T extends string> = Partial<Record<T, string | number>>;
 interface MetricConfiguration<T extends string> {
 	name: string;
 	help: string;
-	labelNames?: T[];
+	labelNames?: T[] | readonly T[];
 	registers?: Registry[];
 	aggregator?: Aggregator;
 	collect?: CollectFunction<any>;


### PR DESCRIPTION
This allows using `as const` to infer the type of labels