### PR TITLE
Set aggregation method for newer event loop metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Don't add event listener to `process` if cluster module is not used.
 - fix: set labels for default memory metrics on linux
 - fix: fix DEP0152 deprecation warning in Node.js v16+
+- fix: Set aggregation mode for newer event loop metrics. (Fixes [#418](https://github.com/siimon/prom-client/issues/418))
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ will only reveal that individual worker's metrics, which is generally
 undesirable. To solve this, you can aggregate all of the workers' metrics in the
 master process. See `example/cluster.js` for an example.
 
-Default metrics use sensible aggregation methods. Custom metrics are summed
-across workers by default. To use a different aggregation method, set the
-`aggregator` property in the metric config to one of 'sum', 'first', 'min',
-'max', 'average' or 'omit'. (See `lib/metrics/version.js` for an example.)
+Default metrics use sensible aggregation methods. (Note, however, that the event
+loop lag mean and percentiles are averaged, which is not perfectly accurate.)
+Custom metrics are summed across workers by default. To use a different
+aggregation method, set the `aggregator` property in the metric config to one of
+'sum', 'first', 'min', 'max', 'average' or 'omit'. (See `lib/metrics/version.js`
+for an example.)
 
 If you need to expose metrics about an individual worker, you can include a
 value that is unique to the worker (such as the worker ID or process ID) in a

--- a/lib/metrics/eventLoopLag.js
+++ b/lib/metrics/eventLoopLag.js
@@ -77,42 +77,49 @@ module.exports = (registry, config = {}) => {
 		help: 'The minimum recorded event loop delay.',
 		registers,
 		labelNames,
+		aggregator: 'min',
 	});
 	const lagMax = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_MAX,
 		help: 'The maximum recorded event loop delay.',
 		registers,
 		labelNames,
+		aggregator: 'max',
 	});
 	const lagMean = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_MEAN,
 		help: 'The mean of the recorded event loop delays.',
 		registers,
 		labelNames,
+		aggregator: 'average',
 	});
 	const lagStddev = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_STDDEV,
 		help: 'The standard deviation of the recorded event loop delays.',
 		registers,
 		labelNames,
+		aggregator: 'average',
 	});
 	const lagP50 = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_P50,
 		help: 'The 50th percentile of the recorded event loop delays.',
 		registers,
 		labelNames,
+		aggregator: 'average',
 	});
 	const lagP90 = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_P90,
 		help: 'The 90th percentile of the recorded event loop delays.',
 		registers,
 		labelNames,
+		aggregator: 'average',
 	});
 	const lagP99 = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_P99,
 		help: 'The 99th percentile of the recorded event loop delays.',
 		registers,
 		labelNames,
+		aggregator: 'average',
 	});
 };
 


### PR DESCRIPTION
These are not entirely accurate: they're the "mean of the mean" and "mean of percentiles," but that's as good as we can get.

No tests added - doesn't seem worth asserting that these properties are set.

Fixes #418