### PR TITLE
fix: summary.observe should validate labels correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - fix: push client attempting to write Promise
 - types: improve type checking of labels
+- fix: Summary#observe should throw when adding additional labels to labelset (fixes [#262](https://github.com/siimon/prom-client/issues/262))
 
 ### Added
 

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -155,7 +155,7 @@ function observe(labels) {
 	return value => {
 		const labelValuePair = convertLabelsAndValues(labels, value);
 
-		validateLabel(this.labelNames, this.labels);
+		validateLabel(this.labelNames, labels);
 		if (!Number.isFinite(labelValuePair.value)) {
 			throw new TypeError(
 				`Value is not a valid number: ${util.format(labelValuePair.value)}`,

--- a/test/__snapshots__/summaryTest.js.snap
+++ b/test/__snapshots__/summaryTest.js.snap
@@ -3,3 +3,5 @@
 exports[`summary global registry with param as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
 
 exports[`summary global registry with param as object remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+
+exports[`summary global registry with param as object should validate labels when observing 1`] = `"Added label \\"baz\\" is not included in initial labelset: [ 'foo' ]"`;

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -32,6 +32,18 @@ describe('summary', () => {
 				expect((await instance.get()).values[8].value).toEqual(1);
 			});
 
+			it('should validate labels when observing', async () => {
+				const summary = new Summary({
+					name: 'foobar',
+					help: 'Foo Bar',
+					labelNames: ['foo'],
+				});
+
+				expect(() => {
+					summary.observe({ foo: 'bar', baz: 'qaz' }, 10);
+				}).toThrowErrorMatchingSnapshot();
+			});
+
 			it('should correctly calculate percentiles when more values are added to the summary', async () => {
 				instance.observe(100);
 				instance.observe(100);


### PR DESCRIPTION
Fixes #262
Closes #263 (this replaces that PR, adding a test and changelog entry)