### PR TITLE
Fix DEP0152 / deprecated PerformanceEntry.kind usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Don't add event listener to `process` if cluster module is not used.
 - fix: set labels for default memory metrics on linux
+- fix: fix DEP0152 deprecation warning in Node.js v16+
 
 ### Added
 

--- a/lib/metrics/gc.js
+++ b/lib/metrics/gc.js
@@ -41,16 +41,16 @@ module.exports = (registry, config = {}) => {
 
 	const obs = new perf_hooks.PerformanceObserver(list => {
 		const entry = list.getEntries()[0];
+		// Node < 16 uses entry.kind
+		// Node >= 16 uses entry.detail.kind
+		// See: https://nodejs.org/docs/latest-v16.x/api/deprecations.html#deprecations_dep0152_extension_performanceentry_properties
+		const kind = entry.detail ? kinds[entry.detail.kind] : kinds[entry.kind];
 
 		// Convert duration from milliseconds to seconds
-		gcHistogram.observe(
-			Object.assign({ kind: kinds[entry.kind] }, labels),
-			entry.duration / 1000,
-		);
+		gcHistogram.observe(Object.assign({ kind }, labels), entry.duration / 1000);
 	});
 
-	// We do not expect too many gc events per second, so we do not use buffering
-	obs.observe({ entryTypes: ['gc'], buffered: false });
+	obs.observe({ entryTypes: ['gc'] });
 };
 
 module.exports.metricNames = [NODEJS_GC_DURATION_SECONDS];


### PR DESCRIPTION
Fix #435

Node 16 deprecated `PerformanceEntry.kind`, moving it to `PerformanceEntry.detail.kind`.

Use `entry.detail.kind` if available. Fall back to deprecated `entry.kind`.

See https://nodejs.org/docs/latest-v16.x/api/deprecations.html#deprecations_dep0152_extension_performanceentry_properties