### PR TITLE
added histogram example with observe method using labels

### DIFF
--- a/example/histogram-1.js
+++ b/example/histogram-1.js
@@ -15,6 +15,8 @@ const h = new Histogram({
 h.labels('200').observe(0.4);
 h.labels('200').observe(0.6);
 
+h.obsever({ code: '200' }, 0.4);
+
 console.log(register.metrics());
 
 /*
@@ -28,13 +30,13 @@ test_histogram_bucket{le="0.025",code="200"} 0
 test_histogram_bucket{le="0.05",code="200"} 0
 test_histogram_bucket{le="0.1",code="200"} 0
 test_histogram_bucket{le="0.25",code="200"} 0
-test_histogram_bucket{le="0.5",code="200"} 1
-test_histogram_bucket{le="1",code="200"} 2
-test_histogram_bucket{le="2.5",code="200"} 2
-test_histogram_bucket{le="5",code="200"} 2
-test_histogram_bucket{le="10",code="200"} 2
-test_histogram_bucket{le="+Inf",code="200"} 2
-test_histogram_sum{code="200"} 1
-test_histogram_count{code="200"} 2
+test_histogram_bucket{le="0.5",code="200"} 2
+test_histogram_bucket{le="1",code="200"} 3
+test_histogram_bucket{le="2.5",code="200"} 3
+test_histogram_bucket{le="5",code="200"} 3
+test_histogram_bucket{le="10",code="200"} 3
+test_histogram_bucket{le="+Inf",code="200"} 3
+test_histogram_sum{code="200"} 1.4
+test_histogram_count{code="200"} 3
 
 */

--- a/example/histogram-2.js
+++ b/example/histogram-2.js
@@ -15,6 +15,8 @@ const h = new Histogram({
 h.labels('200').observe(0.4);
 h.labels('300').observe(0.6);
 
+h.observe({ code: '200' }, 0.4);
+
 console.log(register.metrics());
 
 /*
@@ -28,14 +30,14 @@ test_histogram_bucket{le="0.025",code="200"} 0
 test_histogram_bucket{le="0.05",code="200"} 0
 test_histogram_bucket{le="0.1",code="200"} 0
 test_histogram_bucket{le="0.25",code="200"} 0
-test_histogram_bucket{le="0.5",code="200"} 1
-test_histogram_bucket{le="1",code="200"} 1
-test_histogram_bucket{le="2.5",code="200"} 1
-test_histogram_bucket{le="5",code="200"} 1
-test_histogram_bucket{le="10",code="200"} 1
-test_histogram_bucket{le="+Inf",code="200"} 1
-test_histogram_sum{code="200"} 0.4
-test_histogram_count{code="200"} 1
+test_histogram_bucket{le="0.5",code="200"} 2
+test_histogram_bucket{le="1",code="200"} 2
+test_histogram_bucket{le="2.5",code="200"} 2
+test_histogram_bucket{le="5",code="200"} 2
+test_histogram_bucket{le="10",code="200"} 2
+test_histogram_bucket{le="+Inf",code="200"} 2
+test_histogram_sum{code="200"} 0.8
+test_histogram_count{code="200"} 2
 test_histogram_bucket{le="0.005",code="300"} 0
 test_histogram_bucket{le="0.01",code="300"} 0
 test_histogram_bucket{le="0.025",code="300"} 0

--- a/example/histogram-3.js
+++ b/example/histogram-3.js
@@ -15,6 +15,8 @@ const h = new Histogram({
 h.labels('200', 'blue').observe(0.4);
 h.labels('200', 'blue').observe(0.6);
 
+h.observe({ code: '200', color: 'blue' }, 0.4);
+
 console.log(register.metrics());
 
 /*
@@ -28,13 +30,13 @@ test_histogram_bucket{le="0.025",code="200",color="blue"} 0
 test_histogram_bucket{le="0.05",code="200",color="blue"} 0
 test_histogram_bucket{le="0.1",code="200",color="blue"} 0
 test_histogram_bucket{le="0.25",code="200",color="blue"} 0
-test_histogram_bucket{le="0.5",code="200",color="blue"} 1
-test_histogram_bucket{le="1",code="200",color="blue"} 2
-test_histogram_bucket{le="2.5",code="200",color="blue"} 2
-test_histogram_bucket{le="5",code="200",color="blue"} 2
-test_histogram_bucket{le="10",code="200",color="blue"} 2
-test_histogram_bucket{le="+Inf",code="200",color="blue"} 2
-test_histogram_sum{code="200",color="blue"} 1
-test_histogram_count{code="200",color="blue"} 2
+test_histogram_bucket{le="0.5",code="200",color="blue"} 2
+test_histogram_bucket{le="1",code="200",color="blue"} 3
+test_histogram_bucket{le="2.5",code="200",color="blue"} 3
+test_histogram_bucket{le="5",code="200",color="blue"} 3
+test_histogram_bucket{le="10",code="200",color="blue"} 3
+test_histogram_bucket{le="+Inf",code="200",color="blue"} 3
+test_histogram_sum{code="200",color="blue"} 1.4
+test_histogram_count{code="200",color="blue"} 3
 
 */


### PR DESCRIPTION
Added examples showing how to use `observe `method on histogram when dealing with labels. Such examples existed for other types of metrics but not for histograms.