### PR TITLE
fix: set labels for default memory metrics on linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Don't add event listener to `process` if cluster module is not used.
+- fix: set labels for default memory metrics on linux
 
 ### Added
 

--- a/lib/metrics/osMemoryHeapLinux.js
+++ b/lib/metrics/osMemoryHeapLinux.js
@@ -34,11 +34,14 @@ function structureOutput(input) {
 module.exports = (registry, config = {}) => {
 	const registers = registry ? [registry] : undefined;
 	const namePrefix = config.prefix ? config.prefix : '';
+	const labels = config.labels ? config.labels : {};
+	const labelNames = Object.keys(labels);
 
 	const residentMemGauge = new Gauge({
 		name: namePrefix + PROCESS_RESIDENT_MEMORY,
 		help: 'Resident memory size in bytes.',
 		registers,
+		labelNames,
 		// Use this one metric's `collect` to set all metrics' values.
 		collect() {
 			try {
@@ -51,9 +54,9 @@ module.exports = (registry, config = {}) => {
 				const stat = fs.readFileSync('/proc/self/status', 'utf8');
 				const structuredOutput = structureOutput(stat);
 
-				residentMemGauge.set(structuredOutput.VmRSS);
-				virtualMemGauge.set(structuredOutput.VmSize);
-				heapSizeMemGauge.set(structuredOutput.VmData);
+				residentMemGauge.set(labels, structuredOutput.VmRSS);
+				virtualMemGauge.set(labels, structuredOutput.VmSize);
+				heapSizeMemGauge.set(labels, structuredOutput.VmData);
 			} catch {
 				// noop
 			}
@@ -63,11 +66,13 @@ module.exports = (registry, config = {}) => {
 		name: namePrefix + PROCESS_VIRTUAL_MEMORY,
 		help: 'Virtual memory size in bytes.',
 		registers,
+		labelNames,
 	});
 	const heapSizeMemGauge = new Gauge({
 		name: namePrefix + PROCESS_HEAP,
 		help: 'Process heap size in bytes.',
 		registers,
+		labelNames,
 	});
 };
 

--- a/test/defaultMetricsTest.js
+++ b/test/defaultMetricsTest.js
@@ -4,16 +4,10 @@ describe('collectDefaultMetrics', () => {
 	const register = require('../index').register;
 	const Registry = require('../index').Registry;
 	const collectDefaultMetrics = require('../index').collectDefaultMetrics;
-	let platform;
 	let cpuUsage;
 
 	beforeAll(() => {
-		platform = process.platform;
 		cpuUsage = process.cpuUsage;
-
-		Object.defineProperty(process, 'platform', {
-			value: 'my-bogus-platform',
-		});
 
 		if (cpuUsage) {
 			Object.defineProperty(process, 'cpuUsage', {
@@ -31,10 +25,6 @@ describe('collectDefaultMetrics', () => {
 	});
 
 	afterAll(() => {
-		Object.defineProperty(process, 'platform', {
-			value: platform,
-		});
-
 		if (cpuUsage) {
 			Object.defineProperty(process, 'cpuUsage', {
 				value: cpuUsage,


### PR DESCRIPTION
## The Problem

I noticed that the following default metrics were missing labels that were configured in the `collectDefaultMetrics` method
- `process_resident_memory_bytes`
- `process_virtual_memory_bytes`
- `process_heap_bytes`

## The Fix

Looks like `osMemoryHeapLinux.js` missed out in #374 😢 . We just need to pass through the labels from the config to the metrics.

--- 

Thank you so much for this library! It's amazing that in a few simple steps we can all get amazing metrics from our Node.js servers. Cheers 🙇 😊 