### PR TITLE
add labels to osMemoryHeapLinux metrics

### DIFF
--- a/lib/metrics/osMemoryHeapLinux.js
+++ b/lib/metrics/osMemoryHeapLinux.js
@@ -34,11 +34,15 @@ function structureOutput(input) {
 module.exports = (registry, config = {}) => {
 	const registers = registry ? [registry] : undefined;
 	const namePrefix = config.prefix ? config.prefix : '';
+	const labels = config.labels ? config.labels : {};
+	const labelNames = Object.keys(labels);
+
 
 	const residentMemGauge = new Gauge({
 		name: namePrefix + PROCESS_RESIDENT_MEMORY,
 		help: 'Resident memory size in bytes.',
 		registers,
+		labelNames,
 		// Use this one metric's `collect` to set all metrics' values.
 		collect() {
 			try {
@@ -51,9 +55,9 @@ module.exports = (registry, config = {}) => {
 				const stat = fs.readFileSync('/proc/self/status', 'utf8');
 				const structuredOutput = structureOutput(stat);
 
-				residentMemGauge.set(structuredOutput.VmRSS);
-				virtualMemGauge.set(structuredOutput.VmSize);
-				heapSizeMemGauge.set(structuredOutput.VmData);
+				residentMemGauge.set(labels, structuredOutput.VmRSS);
+				virtualMemGauge.set(labels, structuredOutput.VmSize);
+				heapSizeMemGauge.set(labels, structuredOutput.VmData);
 			} catch {
 				// noop
 			}
@@ -63,11 +67,13 @@ module.exports = (registry, config = {}) => {
 		name: namePrefix + PROCESS_VIRTUAL_MEMORY,
 		help: 'Virtual memory size in bytes.',
 		registers,
+		labelNames
 	});
 	const heapSizeMemGauge = new Gauge({
 		name: namePrefix + PROCESS_HEAP,
 		help: 'Process heap size in bytes.',
 		registers,
+		labelNames
 	});
 };
 


### PR DESCRIPTION
The metrics from osMemoryHeapLinux did not pass the global labels config, now they do