### PR TITLE
Use Nullish Coalescing Operator in inc()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - feat: added `zero()` to `Histogram` for setting the metrics for a given label combination to zero
+- fix: allow `Gauge.inc/dec(0)` without defaulting to 1
 
 ## [13.1.0] - 2021-01-24
 

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -146,14 +146,16 @@ function startTimer(startLabels) {
 function dec(labels) {
 	return value => {
 		const data = convertLabelsAndValues(labels, value);
-		this.set(data.labels, this._getValue(data.labels) - (data.value || 1));
+		if (data.value === undefined) data.value = 1;
+		this.set(data.labels, this._getValue(data.labels) - data.value);
 	};
 }
 
 function inc(labels) {
 	return value => {
 		const data = convertLabelsAndValues(labels, value);
-		this.set(data.labels, this._getValue(data.labels) + (data.value || 1));
+		if (data.value === undefined) data.value = 1;
+		this.set(data.labels, this._getValue(data.labels) + data.value);
 	};
 }
 

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -41,6 +41,16 @@ describe('gauge', () => {
 				await expectValue(5);
 			});
 
+			it('should set to exactly zero without defaulting to 1', async () => {
+				instance.set(0);
+				await expectValue(0);
+			});
+
+			it('should inc by zero without defaulting to 1', async () => {
+				instance.inc(0);
+				await expectValue(10);
+			});
+
 			it('should start a timer and set a gauge to elapsed in seconds', async () => {
 				jest.useFakeTimers('modern');
 				jest.setSystemTime(0);


### PR DESCRIPTION
Calling `.inc(value)` with a dynamic value that may be 0 or 1 will always cause to increase metrics by 1. This is very problematic and may distort the metrics in a non obvious way.

Closes https://github.com/siimon/prom-client/issues/447