### PR TITLE
Lazily add process event listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Don't add event listener to `process` if cluster module is not used.
+
 ### Added
 
 - feat: added `zero()` to `Histogram` for setting the metrics for a given label combination to zero

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -180,27 +180,29 @@ function addListeners() {
 			}
 		});
 	}
-}
 
-// Respond to master's requests for worker's local metrics.
-process.on('message', message => {
-	if (cluster().isWorker && message.type === GET_METRICS_REQ) {
-		Promise.all(registries.map(r => r.getMetricsAsJSON()))
-			.then(metrics => {
-				process.send({
-					type: GET_METRICS_RES,
-					requestId: message.requestId,
-					metrics,
-				});
-			})
-			.catch(error => {
-				process.send({
-					type: GET_METRICS_RES,
-					requestId: message.requestId,
-					error: error.message,
-				});
-			});
+	if (cluster().isWorker) {
+		// Respond to master's requests for worker's local metrics.
+		process.on('message', message => {
+			if (message.type === GET_METRICS_REQ) {
+				Promise.all(registries.map(r => r.getMetricsAsJSON()))
+					.then(metrics => {
+						process.send({
+							type: GET_METRICS_RES,
+							requestId: message.requestId,
+							metrics,
+						});
+					})
+					.catch(error => {
+						process.send({
+							type: GET_METRICS_RES,
+							requestId: message.requestId,
+							error: error.message,
+						});
+					});
+			}
+		});
 	}
-});
+}
 
 module.exports = AggregatorRegistry;

--- a/test/clusterTest.js
+++ b/test/clusterTest.js
@@ -1,9 +1,10 @@
 'use strict';
 
 const cluster = require('cluster');
+const process = require('process');
 
 describe('AggregatorRegistry', () => {
-	it('requiring the cluster should not add any listeners', () => {
+	it('requiring the cluster should not add any listeners on the cluster module', () => {
 		const originalListenerCount = cluster.listenerCount('message');
 
 		require('../lib/cluster');
@@ -15,6 +16,20 @@ describe('AggregatorRegistry', () => {
 		require('../lib/cluster');
 
 		expect(cluster.listenerCount('message')).toBe(originalListenerCount);
+	});
+
+	it('requiring the cluster should not add any listeners on the process module', () => {
+		const originalListenerCount = process.listenerCount('message');
+
+		require('../lib/cluster');
+
+		expect(process.listenerCount('message')).toBe(originalListenerCount);
+
+		jest.resetModules();
+
+		require('../lib/cluster');
+
+		expect(process.listenerCount('message')).toBe(originalListenerCount);
 	});
 
 	describe('aggregatorRegistry.clusterMetrics()', () => {


### PR DESCRIPTION
Only attach a listener to `process` when the cluster mode is used to prevent a memory leak after multiple requires.

The tests are passing, but I'm not familiar with the way the cluster mode is working. So even if it seems ok to me according to the way it's used in [`example/cluster.js`](https://github.com/siimon/prom-client/blob/c7b9a9ddd048f6a1921fa1b33c56a5296713aa2b/example/cluster.js#L7), you might want to double check that I didn't break anything there :slightly_smiling_face:

Fixes #448.