### PR TITLE
Reset internal histogram of monitorEventLoopDelay after each collect() invocation

### DIFF
--- a/lib/metrics/eventLoopLag.js
+++ b/lib/metrics/eventLoopLag.js
@@ -60,6 +60,8 @@ module.exports = (registry, config = {}) => {
 			lagP50.set(labels, histogram.percentile(50) / 1e9);
 			lagP90.set(labels, histogram.percentile(90) / 1e9);
 			lagP99.set(labels, histogram.percentile(99) / 1e9);
+
+			histogram.reset();
 		};
 	}
 


### PR DESCRIPTION
This PR addresses problem described at #370. 

I've read attentively that issue and propositions about the solution. Anyway after own investigation of the code I've decided that simple calling `histogram.reset()` after each `collect()` invocation will be simply enough.

Event loop lag metrics is important for us because we want to see how our application handles spikes and how internal event loop lag increases, to determine easier, there is hiding the bottleneck. Currently we just cannot see that, because `nodejs_eventloop_lag_seconds` represents just single measurement result (so it is pretty random, as noticed already at #309) and `nodejs_eventloop_lag_mean_seconds` shows mean value for overall process lifetime and I cannot imagine, how to use such information in our case and for what cases it can be useful at all.

If all collected now event loop lag values will represent only scrape interval period that will be simply enough for us and I think that for everyone too. 