### PR TITLE
Avoid propagating rounding errors in linearBuckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking
 
+- changed: `linearBuckets` does not propagate rounding errors anymore.
+
+  Fewer bucket bounds will be affected by rounding errors. Histogram bucket
+  labels may change.
+
 ### Changed
 
 ### Added

--- a/lib/bucketGenerators.js
+++ b/lib/bucketGenerators.js
@@ -7,8 +7,7 @@ exports.linearBuckets = (start, width, count) => {
 
 	const buckets = new Array(count);
 	for (let i = 0; i < count; i++) {
-		buckets[i] = start;
-		start += width;
+		buckets[i] = start + i * width;
 	}
 	return buckets;
 };

--- a/test/bucketGeneratorsTest.js
+++ b/test/bucketGeneratorsTest.js
@@ -27,6 +27,11 @@ describe('bucketGenerators', () => {
 			};
 			expect(fn).toThrowError(Error);
 		});
+
+		it('should not propagate rounding errors', () => {
+			result = linearBuckets(0.1, 0.1, 10);
+			expect(result[9]).toEqual(1);
+		});
 	});
 
 	describe('exponential buckets', () => {


### PR DESCRIPTION
Subsequent additions propagate rounding errors in the IEEE 754 model that JavaScript uses for its `number` type. This patch does not remove the possibility of rounding errors, but it removes the propagation of such errors to subsequent bucket bounds. This leads to a smaller error overall.

This might be considered a breaking change because it might change label values in the resulting metrics.