### PR TITLE
Add type declaration for client.contentType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- fix: add type declaration for `client.contentType`
+
 ## [13.2.0] - 2021-08-08
 
 ### Changed

--- a/index.d.ts
+++ b/index.d.ts
@@ -79,6 +79,11 @@ export type Collector = () => void;
  */
 export const register: Registry;
 
+/**
+ * The Content-Type of the metrics for use in the response headers.
+ */
+export const contentType: string;
+
 export class AggregatorRegistry extends Registry {
 	/**
 	 * Gets aggregated metrics for all workers.

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -609,6 +609,11 @@ describe('register', () => {
 		});
 	});
 
+	it('should have the same contentType as the module', () => {
+		const moduleWideContentType = require('../').contentType;
+		expect(register.contentType).toEqual(moduleWideContentType);
+	});
+
 	function getMetric(name) {
 		name = name || 'test_metric';
 		return {


### PR DESCRIPTION
This property already exists, but the type declaration is missing.

Refs: https://github.com/siimon/prom-client/pull/91