### PR TITLE
feat: return the timed duration from gauges and summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- The `done()` functions returned by `gauge.startTimer()` and
+  `summary.startTimer()` now return the timed duration. Histograms already had
+  this behavior.
+
 ### Added
 
 ## [14.0.0] - 2021-09-18

--- a/index.d.ts
+++ b/index.d.ts
@@ -284,11 +284,13 @@ export class Gauge<T extends string> {
 	setToCurrentTime(labels?: LabelValues<T>): void;
 
 	/**
-	 * Start a timer where the gauges value will be the duration in seconds
+	 * Start a timer. Calling the returned function will set the gauge's value
+	 * to the observed duration in seconds.
 	 * @param labels Object with label keys and values
-	 * @return Function to invoke when timer should be stopped
+	 * @return Function to invoke when timer should be stopped. The value it
+	 * returns is the timed duration.
 	 */
-	startTimer(labels?: LabelValues<T>): (labels?: LabelValues<T>) => void;
+	startTimer(labels?: LabelValues<T>): (labels?: LabelValues<T>) => number;
 
 	/**
 	 * Return the child for given labels
@@ -348,10 +350,12 @@ export namespace Gauge {
 		setToCurrentTime(): void;
 
 		/**
-		 * Start a timer where the gauges value will be the duration in seconds
-		 * @return Function to invoke when timer should be stopped
+		 * Start a timer. Calling the returned function will set the gauge's value
+		 * to the observed duration in seconds.
+		 * @return Function to invoke when timer should be stopped. The value it
+		 * returns is the timed duration.
 		 */
-		startTimer(): (labels?: LabelValues<T>) => void;
+		startTimer(): (labels?: LabelValues<T>) => number;
 	}
 }
 
@@ -383,9 +387,11 @@ export class Histogram<T extends string> {
 	observe(labels: LabelValues<T>, value: number): void;
 
 	/**
-	 * Start a timer where the value in seconds will observed
+	 * Start a timer. Calling the returned function will observe the duration in
+	 * seconds in the histogram.
 	 * @param labels Object with label keys and values
-	 * @return Function to invoke when timer should be stopped
+	 * @return Function to invoke when timer should be stopped. The value it
+	 * returns is the timed duration.
 	 */
 	startTimer(labels?: LabelValues<T>): (labels?: LabelValues<T>) => number;
 
@@ -435,9 +441,11 @@ export namespace Histogram {
 		observe(value: number): void;
 
 		/**
-		 * Start a timer where the value in seconds will observed
+		 * Start a timer. Calling the returned function will observe the
+		 * duration in seconds in the histogram.
 		 * @param labels Object with label keys and values
-		 * @return Function to invoke when timer should be stopped
+		 * @return Function to invoke when timer should be stopped. The value it
+		 * returns is the timed duration.
 		 */
 		startTimer(): (labels?: LabelValues<T>) => void;
 	}
@@ -481,11 +489,12 @@ export class Summary<T extends string> {
 	observe(labels: LabelValues<T>, value: number): void;
 
 	/**
-	 * Start a timer where the value in seconds will observed
+	 * Start a timer. Calling the returned function will observe the duration in
+	 * seconds in the summary.
 	 * @param labels Object with label keys and values
 	 * @return Function to invoke when timer should be stopped
 	 */
-	startTimer(labels?: LabelValues<T>): (labels?: LabelValues<T>) => void;
+	startTimer(labels?: LabelValues<T>): (labels?: LabelValues<T>) => number;
 
 	/**
 	 * Reset all values in the summary
@@ -528,11 +537,13 @@ export namespace Summary {
 		observe(value: number): void;
 
 		/**
-		 * Start a timer where the value in seconds will observed
+		 * Start a timer. Calling the returned function will observe the
+		 * duration in seconds in the summary.
 		 * @param labels Object with label keys and values
-		 * @return Function to invoke when timer should be stopped
+		 * @return Function to invoke when timer should be stopped. The value it
+		 * returns is the timed duration.
 		 */
-		startTimer(): (labels?: LabelValues<T>) => void;
+		startTimer(): (labels?: LabelValues<T>) => number;
 	}
 
 	interface Config {

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -94,7 +94,9 @@ class Gauge extends Metric {
 		const start = process.hrtime();
 		return endLabels => {
 			const delta = process.hrtime(start);
-			this.set(Object.assign({}, labels, endLabels), delta[0] + delta[1] / 1e9);
+			const value = delta[0] + delta[1] / 1e9;
+			this.set(Object.assign({}, labels, endLabels), value);
+			return value;
 		};
 	}
 

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -143,10 +143,9 @@ function startTimer(startLabels) {
 		const start = process.hrtime();
 		return endLabels => {
 			const delta = process.hrtime(start);
-			this.observe(
-				Object.assign({}, startLabels, endLabels),
-				delta[0] + delta[1] / 1e9,
-			);
+			const value = delta[0] + delta[1] / 1e9;
+			this.observe(Object.assign({}, startLabels, endLabels), value);
+			return value;
 		};
 	};
 }

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -56,8 +56,9 @@ describe('gauge', () => {
 				jest.setSystemTime(0);
 				const doneFn = instance.startTimer();
 				jest.advanceTimersByTime(500);
-				doneFn();
+				const dur = doneFn();
 				await expectValue(0.5);
+				expect(dur).toEqual(0.5);
 				jest.useRealTimers();
 			});
 

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -207,7 +207,8 @@ describe('summary', () => {
 					jest.setSystemTime(0);
 					const end = instance.labels('GET', '/test').startTimer();
 					jest.advanceTimersByTime(1000);
-					end();
+					const duration = end();
+					expect(duration).toEqual(1);
 					const { values } = await instance.get();
 					expect(values).toHaveLength(3);
 					expect(values[0].labels.method).toEqual('GET');


### PR DESCRIPTION
For consistency with histograms, return the timed duration from the done function returned by `gauge.startTimer()` and `summary.startTimer()`.

Ref #465