### PR TITLE
fix getMetricsAsArray type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking
 
+- types: fixed type for `registry.getMetricsAsArray()`
+
 - changed: `linearBuckets` does not propagate rounding errors anymore.
 
   Fewer bucket bounds will be affected by rounding errors. Histogram bucket

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- types: fixed type for `registry.getMetricsAsArray()`
+
 - changed: typedef for pushgateway to reflect js implementation.
 
   Pushgateway's typedef were missing promise return type. That was
@@ -22,8 +24,6 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ## [14.0.0] - 2021-09-18
 
 ### Breaking
-
-- types: fixed type for `registry.getMetricsAsArray()`
 
 - changed: `linearBuckets` does not propagate rounding errors anymore.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,7 @@ export class Registry {
 	/**
 	 * Get all metrics as objects
 	 */
-	getMetricsAsArray(): Promise<metric[]>;
+	getMetricsAsArray(): metric[];
 
 	/**
 	 * Remove a single metric


### PR DESCRIPTION
This fixes the registry's `getMetricsAsArray()` function type.
It appears to be currently incorrect as it does not return a promise:
https://github.com/siimon/prom-client/blob/4e6aacd4921a3791e8f01ac6ab2fd6bb421b0dc0/lib/registry.js#L21-L23 