### PR TITLE
WIP: potential fix for #480

### DIFF
--- a/lib/timeWindowQuantiles.js
+++ b/lib/timeWindowQuantiles.js
@@ -43,18 +43,17 @@ class TimeWindowQuantiles {
 }
 
 function rotate() {
-	let timeSinceLastRotateMillis = Date.now() - this.lastRotateTimestampMillis;
-	while (
-		timeSinceLastRotateMillis > this.durationBetweenRotatesMillis &&
-		this.shouldRotate
-	) {
-		this.ringBuffer[this.currentBuffer] = new TDigest();
+	if (this.shouldRotate) {
+		let timeSinceLastRotateMillis = Date.now() - this.lastRotateTimestampMillis;
+		while (timeSinceLastRotateMillis > this.durationBetweenRotatesMillis) {
+			this.ringBuffer[this.currentBuffer] = new TDigest();
 
-		if (++this.currentBuffer >= this.ringBuffer.length) {
-			this.currentBuffer = 0;
+			if (++this.currentBuffer >= this.ringBuffer.length) {
+				this.currentBuffer = 0;
+			}
+			timeSinceLastRotateMillis -= this.durationBetweenRotatesMillis;
+			this.lastRotateTimestampMillis += this.durationBetweenRotatesMillis;
 		}
-		timeSinceLastRotateMillis -= this.durationBetweenRotatesMillis;
-		this.lastRotateTimestampMillis += this.durationBetweenRotatesMillis;
 	}
 	return this.ringBuffer[this.currentBuffer];
 }


### PR DESCRIPTION
@sky-nunomarcos can you give this branch a try and see if it resolves the performance issue you see?

Am I correct in assuming that you're using Summaries? Are you setting `maxAgeSeconds` and `ageBuckets`?

---

It sounds like `maxAgeSeconds` and `ageBuckets` *should* be set normally. They weren't set when they were added to prom-client to avoid a breaking change. I don't think the rotation interval has to be exact though, so we can batch rotations up at least.