### PR TITLE
add the ability to stop the event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,16 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - The `processResources` metric was added, which keeps a track of all sorts of
   active resources. It consists of the following gauges:
+
   - `nodejs_active_resources` - Number of active resources that are currently
     keeping the event loop alive, grouped by async resource type.
   - `nodejs_active_resources_total` - Total number of active resources.
     It is supposed to provide the combined result of the `processHandles` and
     `processRequests` metrics along with information about any other types of
     async resources that these metrics do not keep a track of (like timers).
+
+- Added a `stop()` function to the return value of `defaultMetrics` which enables
+  a caller to stop the heuristic event loop.
 
 ## [14.0.0] - 2021-09-18
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ const collectDefaultMetrics = client.collectDefaultMetrics;
 collectDefaultMetrics();
 ```
 
+Collection of default metrics can be stopped by calling the
+stop function on the return value.
+
+```js
+const { collectDefaultMetrics } = require('prom-client');
+const { stop } = collectDefaultMetrics();
+stop();
+```
+
 ### Custom Metrics
 
 All metric types have two mandatory parameters: `name` and `help`. Refer to

--- a/lib/defaultMetrics.js
+++ b/lib/defaultMetrics.js
@@ -43,9 +43,17 @@ module.exports = function collectDefaultMetrics(config) {
 
 	config = { eventLoopMonitoringPrecision: 10, ...config };
 
+	const stops = [];
 	for (const metric of Object.values(metrics)) {
-		metric(config.register, config);
+		const { stop = undefined } = metric(config.register, config) || {};
+		if (stop) {
+			stops.push(stop);
+		}
 	}
+
+	return {
+		stop: () => stops.forEach(stop => stop()),
+	};
 };
 
 module.exports.metricsList = metricsList;

--- a/lib/metrics/eventLoopLag.js
+++ b/lib/metrics/eventLoopLag.js
@@ -38,6 +38,7 @@ module.exports = (registry, config = {}) => {
 	const registers = registry ? [registry] : undefined;
 
 	let collect;
+	let stop = () => {};
 	if (!perf_hooks || !perf_hooks.monitorEventLoopDelay) {
 		collect = () => {
 			const start = process.hrtime();
@@ -48,6 +49,7 @@ module.exports = (registry, config = {}) => {
 			resolution: config.eventLoopMonitoringPrecision,
 		});
 		histogram.enable();
+		stop = () => histogram.disable();
 
 		collect = () => {
 			const start = process.hrtime();
@@ -123,6 +125,8 @@ module.exports = (registry, config = {}) => {
 		labelNames,
 		aggregator: 'average',
 	});
+
+	return { stop };
 };
 
 module.exports.metricNames = [


### PR DESCRIPTION
Fixes https://github.com/siimon/prom-client/issues/494

Adds an optional "stop" function which when called will ultimately disable the histogram which will allow the node process to exit.

I also fixed a bug in the tests where a failed assertion in a setTimeout wasn't properly rejecting the test promise.

![Screen Shot 2022-02-25 at 8 52 49 AM](https://user-images.githubusercontent.com/10974/155750031-8b41e2aa-e078-402e-927a-17598273bfbc.png)

