### PR TITLE
perf: improve performance of gauge inc() dec()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - changed: typedef for pushgateway to reflect js implementation.
 
+- Improve performance of `gague.inc()` and `gauge.dec()` by calling `hashObject()` once.
+
   Pushgateway's typedef were missing promise return type. That was
   causing vscode to think that push/pushAdd and delete didn't promise
   resulting in incorrect behavior.

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -8,6 +8,7 @@ const type = 'gauge';
 
 const {
 	setValue,
+	setValueDelta,
 	getLabels,
 	hashObject,
 	isObject,
@@ -50,7 +51,7 @@ class Gauge extends Metric {
 		value = getValueArg(labels, value);
 		labels = getLabelArg(labels);
 		if (value === undefined) value = 1;
-		set(this, labels, this._getValue(labels) + value);
+		setDelta(this, labels, value);
 	}
 
 	/**
@@ -63,7 +64,7 @@ class Gauge extends Metric {
 		value = getValueArg(labels, value);
 		labels = getLabelArg(labels);
 		if (value === undefined) value = 1;
-		set(this, labels, this._getValue(labels) - value);
+		setDelta(this, labels, -value);
 	}
 
 	/**
@@ -145,6 +146,16 @@ function set(gauge, labels, value) {
 
 	validateLabel(gauge.labelNames, labels);
 	setValue(gauge.hashMap, value, labels);
+}
+
+function setDelta(gauge, labels, delta) {
+	if (typeof delta !== 'number') {
+		throw new TypeError(`Delta is not a valid number: ${util.format(delta)}`);
+	}
+
+	validateLabel(gauge.labelNames, labels);
+	const hash = hashObject(labels);
+	setValueDelta(gauge.hashMap, delta, labels, hash);
 }
 
 function getLabelArg(labels) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -28,6 +28,21 @@ exports.setValue = function setValue(hashMap, value, labels) {
 	return hashMap;
 };
 
+exports.setValueDelta = function setValueDelta(
+	hashMap,
+	deltaValue,
+	labels,
+	hash = '',
+) {
+	const value = typeof deltaValue === 'number' ? deltaValue : 0;
+	if (hashMap[hash]) {
+		hashMap[hash].value += value;
+	} else {
+		hashMap[hash] = { value, labels };
+	}
+	return hashMap;
+};
+
 exports.getLabels = function (labelNames, args) {
 	if (typeof args[0] === 'object') {
 		return args[0];


### PR DESCRIPTION
**Motivation**
- Right now when using `gauge.inc()` or `gauge.dec()`, we call `hashObject()` 2 times
- It's better to call `hashObject()` once as in `counter.inc()`

**Description**
- New function `setValueDelta()` with a `hash` param
- `gauge.inc()` and `gauge.dec()` to call `setValueDelta()` via `setDelta()` function