### PR TITLE
Support gzipped pushgateway requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
     `processRequests` metrics along with information about any other types of
     async resources that these metrics do not keep a track of (like timers).
 
+- Support gzipped pushgateway requests
+
 ## [14.0.0] - 2021-09-18
 
 ### Breaking

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -3,6 +3,8 @@
 const url = require('url');
 const http = require('http');
 const https = require('https');
+const { Readable } = require('stream');
+const { createGzip } = require('zlib');
 const { globalRegistry } = require('./registry');
 
 class Pushgateway {
@@ -79,8 +81,23 @@ async function useGateway(method, job, groupings) {
 			this.registry
 				.metrics()
 				.then(metrics => {
-					req.write(metrics);
-					req.end();
+					if (
+						options.headers &&
+						options.headers['Content-Encoding'] === 'gzip'
+					) {
+						Readable.from([metrics])
+							.pipe(createGzip())
+							.pipe(req)
+							.on('error', error => {
+								reject(error);
+							})
+							.on('finish', () => {
+								req.end();
+							});
+					} else {
+						req.write(metrics);
+						req.end();
+					}
 				})
 				.catch(err => {
 					reject(err);

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -3,8 +3,7 @@
 const url = require('url');
 const http = require('http');
 const https = require('https');
-const { Readable } = require('stream');
-const { createGzip } = require('zlib');
+const { gzipSync } = require('zlib');
 const { globalRegistry } = require('./registry');
 
 class Pushgateway {
@@ -85,19 +84,10 @@ async function useGateway(method, job, groupings) {
 						options.headers &&
 						options.headers['Content-Encoding'] === 'gzip'
 					) {
-						Readable.from([metrics])
-							.pipe(createGzip())
-							.pipe(req)
-							.on('error', error => {
-								reject(error);
-							})
-							.on('finish', () => {
-								req.end();
-							});
-					} else {
-						req.write(metrics);
-						req.end();
+						metrics = gzipSync(metrics);
 					}
+					req.write(metrics);
+					req.end();
 				})
 				.catch(err => {
 					reject(err);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"index.d.ts"
 	],
 	"engines": {
-		"node": ">=10"
+		"node": ">=12.3.0"
 	},
 	"scripts": {
 		"benchmarks": "node ./benchmarks/index.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"index.d.ts"
 	],
 	"engines": {
-		"node": ">=12.3.0"
+		"node": ">=10"
 	},
 	"scripts": {
 		"benchmarks": "node ./benchmarks/index.js",


### PR DESCRIPTION
This PR allows to use the gzip Content-Encoding introduced with https://github.com/prometheus/pushgateway/pull/477.