### PR TITLE
chore: actually interpolate node version in node_modules cache key

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,9 +32,9 @@ jobs:
         id: cache
         with:
           path: node_modules
-          key: ${{ matrix.os }}-{{ matrix.node-version }}-node_modules-${{ hashFiles('**/package.json') }}
+          key: ${{ matrix.os }}-${{ matrix.node-version }}-node_modules-${{ hashFiles('**/package.json') }}
           restore-keys: |
-            ${{ matrix.os }}-{{ matrix.node-version }}-node_modules-
+            ${{ matrix.os }}-${{ matrix.node-version }}-node_modules-
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm i


### PR DESCRIPTION
Noticed e.g. `Cache restored from key: macOS-latest-{{ matrix.node-version }}-node_modules-bbf6778e247a03b9d5ef0daf8db0e793847c83f8fd1778c2e819b0c1e984d2bd`