### PR TITLE
Fix incompatibility with perf_hooks accross nodejs versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Increase compatibility with external build system such as `rollup` by making perf_hooks optional in gc.js
+
 ### Added
 
 ## [14.1.0] - 2022-08-23

--- a/lib/metrics/gc.js
+++ b/lib/metrics/gc.js
@@ -16,10 +16,10 @@ const DEFAULT_GC_DURATION_BUCKETS = [0.001, 0.01, 0.1, 1, 2, 5];
 const kinds = [];
 
 if (perf_hooks && perf_hooks.constants) {
-    kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_MAJOR] = 'major';
-    kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_MINOR] = 'minor';
-    kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_INCREMENTAL] = 'incremental';
-    kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_WEAKCB] = 'weakcb';
+	kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_MAJOR] = 'major';
+	kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_MINOR] = 'minor';
+	kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_INCREMENTAL] = 'incremental';
+	kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_WEAKCB] = 'weakcb';
 }
 
 module.exports = (registry, config = {}) => {

--- a/lib/metrics/gc.js
+++ b/lib/metrics/gc.js
@@ -14,10 +14,13 @@ const NODEJS_GC_DURATION_SECONDS = 'nodejs_gc_duration_seconds';
 const DEFAULT_GC_DURATION_BUCKETS = [0.001, 0.01, 0.1, 1, 2, 5];
 
 const kinds = [];
-kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_MAJOR] = 'major';
-kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_MINOR] = 'minor';
-kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_INCREMENTAL] = 'incremental';
-kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_WEAKCB] = 'weakcb';
+
+if (perf_hooks) {
+    kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_MAJOR] = 'major';
+    kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_MINOR] = 'minor';
+    kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_INCREMENTAL] = 'incremental';
+    kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_WEAKCB] = 'weakcb';
+}
 
 module.exports = (registry, config = {}) => {
 	if (!perf_hooks) {

--- a/lib/metrics/gc.js
+++ b/lib/metrics/gc.js
@@ -15,7 +15,7 @@ const DEFAULT_GC_DURATION_BUCKETS = [0.001, 0.01, 0.1, 1, 2, 5];
 
 const kinds = [];
 
-if (perf_hooks) {
+if (perf_hooks && perf_hooks.constants) {
     kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_MAJOR] = 'major';
     kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_MINOR] = 'minor';
     kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_INCREMENTAL] = 'incremental';


### PR DESCRIPTION
When using rollup to build an all-in-one esm module, rollup fails to properly handle require in try{}catch{} code.

It causes perf_hooks to not be defined ( that would happens if perf_hooks isn't implemented in current nodejs version) and breaks code accessing perf_hooks constants fields :

```js
perf_hooks.constants.NODE_PERFORMANCE_GC_MAJOR
```

It'd be nice to either require it (and as such require recent nodejs version) or make sure the codebase is compatible when it is not present.

This change is for enabling perf_hooks to not exists. It would also be possible to make it a hard requirement.

Note : `perf_hooks.constants` is defined only on nodejs version starting with the following :

1. >13.9.0
1. >12.17.0

Because of this I'm unsure the rest of the gc.js code will work correctly with nodejs >= 10 & <= 12.17

(Nodejs 10 requirement is from your package.json `engines` field)