### PR TITLE
Reset metrics when send to pushgateway

### DIFF
--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -80,6 +80,7 @@ async function useGateway(method, job, groupings) {
 			this.registry
 				.metrics()
 				.then(metrics => {
+					this.registry.resetMetrics();
 					if (
 						options.headers &&
 						options.headers['Content-Encoding'] === 'gzip'


### PR DESCRIPTION
Hi, currently metrics are not automatically reset when sent to pushgateway, instead they are accumulated. 
In this PR, I add resetting the metrics right before the http request (if we do this after the request is made, we lost all the metrics that was changed during the request)