### PR TITLE
Fix examples of push gateway in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,21 +491,21 @@ const client = require('prom-client');
 let gateway = new client.Pushgateway('http://127.0.0.1:9091');
 
 gateway.pushAdd({ jobName: 'test' })
-	.then({resp, body} => {
+	.then(({resp, body}) => {
 		/* ... */
 	})
 	.catch(err => {
 		/* ... */
 	})); //Add metric and overwrite old ones
 gateway.push({ jobName: 'test' })
-	.then({resp, body} => {
+	.then(({resp, body}) => {
 		/* ... */
 	})
 	.catch(err => {
 		/* ... */
 	})); //Overwrite all metrics (use PUT)
 gateway.delete({ jobName: 'test' })
-	.then({resp, body} => {
+	.then(({resp, body}) => {
 		/* ... */
 	})
 	.catch(err => {
@@ -514,7 +514,7 @@ gateway.delete({ jobName: 'test' })
 
 //All gateway requests can have groupings on it
 gateway.pushAdd({ jobName: 'test', groupings: { key: 'value' } })
-	.then({resp, body} => {
+	.then(({resp, body}) => {
 		/* ... */
 	})
 	.catch(err => {


### PR DESCRIPTION
It's a simple correction in the examples so that newbies don't get frustrated :)

i change `.then({ resp, body } => {` for `.then(({ resp, body }) => {` in all examples

specific error:
```
.then({ resp, body } => {
            ^^^^^^^^^^^^^

SyntaxError: Malformed arrow function parameter list
    at wrapSafe (internal/modules/cjs/loader.js:915:16)
    at Module._compile (internal/modules/cjs/loader.js:963:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
    at internal/main/run_main_module.js:17:47
```