### PR TITLE
fix: add get method to type definitions of metric classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Add `get` method to type definitions of metric classes
+
 ## [14.1.1] - 2022-12-31
 
 ### Changed

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,12 +29,12 @@ export class Registry {
 	/**
 	 * Get all metrics as objects
 	 */
-	getMetricsAsJSON(): Promise<metric[]>;
+	getMetricsAsJSON(): Promise<MetricObjectWithValues<MetricValue<string>>[]>;
 
 	/**
 	 * Get all metrics as objects
 	 */
-	getMetricsAsArray(): metric[];
+	getMetricsAsArray(): MetricObject[];
 
 	/**
 	 * Remove a single metric
@@ -136,13 +136,27 @@ export enum MetricType {
 
 type CollectFunction<T> = (this: T) => void | Promise<void>;
 
-interface metric {
+interface MetricObject {
 	name: string;
 	help: string;
 	type: MetricType;
 	aggregator: Aggregator;
 	collect: CollectFunction<any>;
 }
+
+interface MetricObjectWithValues<T extends MetricValue<string>>
+	extends MetricObject {
+	values: T[];
+}
+
+type MetricValue<T extends string> = {
+	value: number;
+	labels: LabelValues<T>;
+};
+
+type MetricValueWithName<T extends string> = MetricValue<T> & {
+	metricName?: string;
+};
 
 type LabelValues<T extends string> = Partial<Record<T, string | number>>;
 
@@ -181,6 +195,11 @@ export class Counter<T extends string = string> {
 	 * @param value The value to increment with
 	 */
 	inc(value?: number): void;
+
+	/**
+	 * Get counter metric object
+	 */
+	get(): Promise<MetricObjectWithValues<MetricValue<T>>>;
 
 	/**
 	 * Return the child for given labels
@@ -276,6 +295,11 @@ export class Gauge<T extends string = string> {
 	 * @param value The value to set
 	 */
 	set(value: number): void;
+
+	/**
+	 * Get gauge metric object
+	 */
+	get(): Promise<MetricObjectWithValues<MetricValue<T>>>;
 
 	/**
 	 * Set gauge value to current epoch time in ms
@@ -387,6 +411,11 @@ export class Histogram<T extends string = string> {
 	observe(labels: LabelValues<T>, value: number): void;
 
 	/**
+	 * Get histogram metric object
+	 */
+	get(): Promise<MetricObjectWithValues<MetricValueWithName<T>>>;
+
+	/**
 	 * Start a timer. Calling the returned function will observe the duration in
 	 * seconds in the histogram.
 	 * @param labels Object with label keys and values
@@ -487,6 +516,11 @@ export class Summary<T extends string = string> {
 	 * @param value Value to observe
 	 */
 	observe(labels: LabelValues<T>, value: number): void;
+
+	/**
+	 * Get summary metric object
+	 */
+	get(): Promise<MetricObjectWithValues<MetricValueWithName<T>>>;
 
 	/**
 	 * Start a timer. Calling the returned function will observe the duration in


### PR DESCRIPTION
**Current Limitation**

At the moment there is no clean way to get a single metric value programmatically while using typescript.

The following is not possible as it causes type issues as the getters are implemented in javascript but are missing from type definitions.

```ts
const metric = metrics.register.getSingleMetric("process_cpu_user_seconds_total");

// Property 'get' does not exist on type 'Metric<string>'
const {value} = (await metric.get()).values[0]
```

**Solution**

Add `get` method to type definitions of each metric classes and define `MetricObjectWithValues` type which is returned by getters.

