### PR TITLE
'pruneAgedBuckets' config option for summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,12 +265,15 @@ new client.Summary({
   help: 'metric_help',
   maxAgeSeconds: 600,
   ageBuckets: 5,
+  pruneAgedBuckets: false,
 });
 ```
 
 The `maxAgeSeconds` will tell how old a bucket can be before it is reset and
 `ageBuckets` configures how many buckets we will have in our sliding window for
-the summary.
+the summary. If `pruneAgedBuckets` is `false` (default), the metric value will
+always be present, even when empty (its percentile values will be `0`). Set
+`pruneAgedBuckets` to `true` if you don't want to export it when it is empty.
 
 ##### Examples
 

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -52,14 +52,22 @@ class Summary extends Metric {
 			const v = this.collect();
 			if (v instanceof Promise) await v;
 		}
-		const data = Object.values(this.hashMap);
+		const hashKeys = Object.keys(this.hashMap);
 		const values = [];
-		data.forEach(s => {
-			extractSummariesForExport(s, this.percentiles).forEach(v => {
-				values.push(v);
-			});
-			values.push(getSumForExport(s, this));
-			values.push(getCountForExport(s, this));
+
+		hashKeys.forEach(hashKey => {
+			const s = this.hashMap[hashKey];
+			if (s) {
+				if (this.pruneAgedBuckets && s.td.size() === 0) {
+					delete this.hashMap[hashKey];
+				} else {
+					extractSummariesForExport(s, this.percentiles).forEach(v => {
+						values.push(v);
+					});
+					values.push(getSumForExport(s, this));
+					values.push(getCountForExport(s, this));
+				}
+			}
 		});
 
 		return {

--- a/lib/timeWindowQuantiles.js
+++ b/lib/timeWindowQuantiles.js
@@ -17,6 +17,11 @@ class TimeWindowQuantiles {
 			(maxAgeSeconds * 1000) / ageBuckets || Infinity;
 	}
 
+	size() {
+		const bucket = rotate.call(this);
+		return bucket.size();
+	}
+
 	percentile(quantile) {
 		const bucket = rotate.call(this);
 		return bucket.percentile(quantile);

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -492,7 +492,7 @@ describe('summary', () => {
 			jest.setSystemTime(0);
 		});
 
-		it('should slide when maxAgeSeconds and ageBuckets are set', async () => {
+		it('should present percentiles as zero when maxAgeSeconds and ageBuckets are set but not pruneAgedBuckets', async () => {
 			const localInstance = new Summary({
 				name: 'summary_test',
 				help: 'test',
@@ -516,6 +516,34 @@ describe('summary', () => {
 			const { values } = await localInstance.get();
 			expect(values[0].labels.quantile).toEqual(0.01);
 			expect(values[0].value).toEqual(0);
+			expect(values[7].value).toEqual(100);
+			expect(values[8].value).toEqual(1);
+		});
+
+		it('should prune expired buckets when pruneAgedBuckets are set with maxAgeSeconds and ageBuckets', async () => {
+			const localInstance = new Summary({
+				name: 'summary_test',
+				help: 'test',
+				maxAgeSeconds: 5,
+				ageBuckets: 5,
+				pruneAgedBuckets: true,
+			});
+
+			localInstance.observe(100);
+
+			for (let i = 0; i < 5; i++) {
+				const { values } = await localInstance.get();
+				expect(values[0].labels.quantile).toEqual(0.01);
+				expect(values[0].value).toEqual(100);
+				expect(values[7].metricName).toEqual('summary_test_sum');
+				expect(values[7].value).toEqual(100);
+				expect(values[8].metricName).toEqual('summary_test_count');
+				expect(values[8].value).toEqual(1);
+				jest.advanceTimersByTime(1001);
+			}
+
+			const { values } = await localInstance.get();
+			expect(values.length).toEqual(0);
 		});
 
 		it('should not slide when maxAgeSeconds and ageBuckets are not configured', async () => {

--- a/test/timeWindowQuantilesTest.js
+++ b/test/timeWindowQuantilesTest.js
@@ -41,7 +41,7 @@ describe('timeWindowQuantiles', () => {
 		});
 	});
 
-	describe('rotatation', () => {
+	describe('rotation', () => {
 		it('rotatation interval should be configured', () => {
 			let localInstance = new TimeWindowQuantiles(undefined, undefined);
 			expect(localInstance.durationBetweenRotatesMillis).toEqual(Infinity);


### PR DESCRIPTION
This will basically remove entries on summary.hashMap when current bucket is empty. Related to #492 