### PR TITLE
docs(README): remove await of getSingleMetric

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ return a string for Prometheus to consume.
 #### Getting a single metric
 
 If you need to get a reference to a previously registered metric, you can use
-`await register.getSingleMetric(*name of metric*)`.
+`register.getSingleMetric(*name of metric*)`.
 
 #### Removing metrics
 


### PR DESCRIPTION
### Summary

`getSingleMetric` is a synchronous function, don't need to `await` it 😅 
ref: https://github.com/siimon/prom-client/blob/master/lib/registry.js#L132