### PR TITLE
feat: improve performance of getMetricAsPrometheusString

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -27,40 +27,27 @@ class Registry {
 		const name = escapeString(item.name);
 		const help = `# HELP ${name} ${escapeString(item.help)}`;
 		const type = `# TYPE ${name} ${item.type}`;
-		const defaultLabelNames = Object.keys(this._defaultLabels);
+		const defaultLabels =
+			Object.keys(this._defaultLabels).length > 0 ? this._defaultLabels : null;
 
-		let values = '';
-		for (const val of item.values || []) {
-			val.labels = val.labels || {};
+		const values = [help, type];
+		for (const { metricName = item.name, value, labels = {} } of item.values ||
+			[]) {
+			const labelsWithDefaults = defaultLabels
+				? { ...labels, ...defaultLabels, ...labels }
+				: labels;
 
-			if (defaultLabelNames.length > 0) {
-				// Make a copy before mutating
-				val.labels = Object.assign({}, val.labels);
+			const formattedLabels = Object.entries(labelsWithDefaults).map(
+				([n, v]) => `${n}="${escapeLabelValue(v)}"`,
+			);
+			const labelsString = formattedLabels.length
+				? `{${formattedLabels.join(',')}}`
+				: '';
 
-				for (const labelName of defaultLabelNames) {
-					val.labels[labelName] =
-						val.labels[labelName] || this._defaultLabels[labelName];
-				}
-			}
-
-			let metricName = val.metricName || item.name;
-
-			const keys = Object.keys(val.labels);
-			const size = keys.length;
-			if (size > 0) {
-				let labels = '';
-				let i = 0;
-				for (; i < size - 1; i++) {
-					labels += `${keys[i]}="${escapeLabelValue(val.labels[keys[i]])}",`;
-				}
-				labels += `${keys[i]}="${escapeLabelValue(val.labels[keys[i]])}"`;
-				metricName += `{${labels}}`;
-			}
-
-			values += `${metricName} ${getValueAsString(val.value)}\n`;
+			values.push(`${metricName}${labelsString} ${getValueAsString(value)}`);
 		}
 
-		return `${help}\n${type}\n${values}`.trim();
+		return values.join('\n');
 	}
 
 	async metrics() {


### PR DESCRIPTION
Use Array.prototype.join instead string concatenation for constructing Prometheus metric string. This results in improved performance and reduced memory consumption, especially when there's a large amount of dimensions (labels and label values). In addition uses array iteration methods instead of explicit loops. 