### PR TITLE
perf: swap order of escape regexes to avoid lookahead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking
 
 ### Changed
+- Refactor `escapeString` helper in `lib/registry.js` to improve performance and
+  avoid an unnecessarily complex regex.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking
 
 ### Changed
+
 - Refactor `escapeString` helper in `lib/registry.js` to improve performance and
   avoid an unnecessarily complex regex.
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -2,7 +2,7 @@
 const { getValueAsString } = require('./util');
 
 function escapeString(str) {
-	return str.replace(/\n/g, '\\n').replace(/\\(?!n)/g, '\\\\');
+	return str.replace(/\\/g, '\\\\').replace(/\n/g, '\\n');
 }
 function escapeLabelValue(str) {
 	if (typeof str !== 'string') {


### PR DESCRIPTION
When looking at some CPU profiles of metric -> string serialization, I noticed that escaping all of the strings and labels was showing up in the flamegraph more than I would expect. This isn't a massive win by any means, but it's pretty consistently ~20% faster on a microbenchmark: https://jsbench.me/qklez5ombn/1. I'll take 20%.

Some notes:
1) The benchmarks literally don't test this case, as far as I can tell. None of the registry benchmarks have quotes or newlines or anything in the labels? An A/A test (master vs. 14.2.0) was producing inconsistent results, so I'm not quite sure I trust that benchmark anyway.
2) Correctness-wise, this should work. Replacing the `\` before replacing the `\n` fixes the case that made you need the `.replace(/\\(?!n)/g, '\\\\')` regex in the first place, so now we can just do `\\` -> `\\\\` and `\n` -> `\\n` and `"` -> `\\"` in that order without lookaheads.

Relevant to #543.