### PR TITLE
perf: improve performance of getMetricAsString in next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- In `next` refactor `getMetricAsString` method in the `Registry` class to use `Array.prototype.join`
+  instead of loop of string concatenations.
+- In `next` move local functions used by the `Registry` class to bottom of file
+
 ### Breaking
 
 - drop support for Node.js versions 10, 12 and 17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Changed
-
-- In `next` refactor `getMetricAsString` method in the `Registry` class to use `Array.prototype.join`
-  instead of loop of string concatenations.
-- In `next` move local functions used by the `Registry` class to bottom of file
-
 ### Breaking
 
 - drop support for Node.js versions 10, 12 and 17

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -2,22 +2,6 @@
 
 const { getValueAsString } = require('./util');
 
-function escapeString(str) {
-	return str.replace(/\n/g, '\\n').replace(/\\(?!n)/g, '\\\\');
-}
-function escapeLabelValue(str) {
-	if (typeof str !== 'string') {
-		return str;
-	}
-	return escapeString(str).replace(/"/g, '\\"');
-}
-function standardizeCounterName(name) {
-	if (name.endsWith('_total')) {
-		return name.replace('_total', '');
-	}
-	return name;
-}
-
 class Registry {
 	static get PROMETHEUS_CONTENT_TYPE() {
 		return 'text/plain; version=0.0.4; charset=utf-8';
@@ -44,24 +28,19 @@ class Registry {
 		return Object.values(this._metrics);
 	}
 
-	getLabelSetAsString(metric) {
-		const defaultLabelNames = Object.keys(this._defaultLabels);
-		let values = '';
+	async getMetricsAsString(metrics) {
+		const metric = await metrics.get();
+
+		const name = escapeString(metric.name);
+		const help = `# HELP ${name} ${escapeString(metric.help)}`;
+		const type = `# TYPE ${name} ${metric.type}`;
+		const values = [help, type];
+
+		const defaultLabels =
+			Object.keys(this._defaultLabels).length > 0 ? this._defaultLabels : null;
 
 		for (const val of metric.values || []) {
-			val.labels = val.labels || {};
-
-			if (defaultLabelNames.length > 0) {
-				// Make a copy before mutating
-				val.labels = Object.assign({}, val.labels);
-
-				for (const labelName of defaultLabelNames) {
-					val.labels[labelName] =
-						val.labels[labelName] || this._defaultLabels[labelName];
-				}
-			}
-
-			let metricName = val.metricName || metric.name;
+			let { metricName = name, labels = {} } = val;
 			if (
 				this.contentType === Registry.OPENMETRICS_CONTENT_TYPE &&
 				metric.type === 'counter'
@@ -69,59 +48,31 @@ class Registry {
 				metricName = `${metricName}_total`;
 			}
 
-			const keys = Object.keys(val.labels);
-			const size = keys.length;
-			if (size > 0) {
-				let labels = '';
-				let i = 0;
-				for (; i < size - 1; i++) {
-					labels += `${keys[i]}="${escapeLabelValue(val.labels[keys[i]])}",`;
-				}
-				labels += `${keys[i]}="${escapeLabelValue(val.labels[keys[i]])}"`;
-				metricName += `{${labels}}`;
+			if (defaultLabels) {
+				labels = { ...labels, ...defaultLabels, ...labels };
 			}
-			values += `${metricName} ${getValueAsString(val.value)}`;
-			if (
-				val.exemplar &&
-				this.contentType === Registry.OPENMETRICS_CONTENT_TYPE
-			) {
-				const exemplarKeys = Object.keys(val.exemplar.labelSet);
-				const exemplarSize = exemplarKeys.length;
-				if (exemplarSize > 0) {
-					let labels = '';
-					let i = 0;
-					for (; i < exemplarSize - 1; i++) {
-						labels += `${exemplarKeys[i]}="${escapeLabelValue(
-							val.exemplar.labelSet[exemplarKeys[i]],
-						)}",`;
-					}
-					labels += `${exemplarKeys[i]}="${escapeLabelValue(
-						val.exemplar.labelSet[exemplarKeys[i]],
-					)}"`;
-					values += ` # {${labels}} ${getValueAsString(val.exemplar.value)} ${
-						val.exemplar.timestamp
-					}`;
-				} else {
-					values += ` # {} ${getValueAsString(val.exemplar.value)} ${
-						val.exemplar.timestamp
-					}`;
-				}
+
+			const formattedLabels = formatLabels(labels);
+			const labelsString = formattedLabels.length
+				? `{${formattedLabels.join(',')}}`
+				: '';
+
+			values.push(
+				`${metricName}${labelsString} ${getValueAsString(val.value)}`,
+			);
+
+			const { exemplar } = val;
+			if (exemplar && this.contentType === Registry.OPENMETRICS_CONTENT_TYPE) {
+				const formattedExemplars = formatLabels(exemplar.labelSet);
+				values.push(
+					` # {${formattedExemplars.join(',')}} ${getValueAsString(
+						exemplar.value,
+					)} ${exemplar.timestamp}`,
+				);
 			}
-			values += '\n';
 		}
 
-		return values;
-	}
-
-	async getMetricsAsString(metrics) {
-		const metric = await metrics.get();
-
-		const name = escapeString(metric.name);
-		const help = `# HELP ${name} ${escapeString(metric.help)}`;
-		const type = `# TYPE ${name} ${metric.type}`;
-		const values = this.getLabelSetAsString(metric);
-
-		return `${help}\n${type}\n${values}`.trim();
+		return values.join('\n');
 	}
 
 	async metrics() {
@@ -248,6 +199,25 @@ class Registry {
 		metricsToMerge.forEach(mergedRegistry.registerMetric, mergedRegistry);
 		return mergedRegistry;
 	}
+}
+
+function formatLabels(labels) {
+	return Object.entries(labels).map(
+		([n, v]) => `${n}="${escapeLabelValue(v)}"`,
+	);
+}
+
+function escapeLabelValue(str) {
+	if (typeof str !== 'string') {
+		return str;
+	}
+	return escapeString(str).replace(/"/g, '\\"');
+}
+function escapeString(str) {
+	return str.replace(/\n/g, '\\n').replace(/\\(?!n)/g, '\\\\');
+}
+function standardizeCounterName(name) {
+	return name.replace(/_total$/, '');
 }
 
 module.exports = Registry;


### PR DESCRIPTION
Use `Array.prototype.join` instead string concatenation for constructing Prometheus metric string. This results in improved performance and reduced memory consumption, especially when there's a large amount of dimensions (labels and label values). In addition uses array iteration methods instead of explicit loops.

**note**: there are no tests for exemplar so I could not verify that this functionality works as expected.