### PR TITLE
fix: Disable content encoding for pushgateway delete requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Disable custom content encoding for pushgateway delete requests in order to
+  avoid failures from the server when using `Content-Encoding: gzip` header.
 - Refactor `escapeString` helper in `lib/registry.js` to improve performance and
   avoid an unnecessarily complex regex.
 

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -62,6 +62,9 @@ async function useGateway(method, job, groupings) {
 	});
 
 	return new Promise((resolve, reject) => {
+		if (method === 'DELETE' && options.headers) {
+			delete options.headers['Content-Encoding'];
+		}
 		const req = httpModule.request(options, resp => {
 			let body = '';
 			resp.setEncoding('utf8');


### PR DESCRIPTION
When using gzip `Content-Encoding` the DELETE requests sent to a pushgateway server fail with error code 400. With this PR we disable `Content-Encoding` option, if found, for DELETE requests.