### PR TITLE
bug: support array argument to labels() again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
   avoid failures from the server when using `Content-Encoding: gzip` header.
 - Refactor `escapeString` helper in `lib/registry.js` to improve performance and
   avoid an unnecessarily complex regex.
+- Support array argument to `metric.labels()`. This was supported prior to
+  version 13.1 (undocumented). [#553](https://github.com/siimon/prom-client/pull/553)
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ gauge.set({ method: 'GET', statusCode: '200' }, 100);
 gauge.labels({ method: 'GET', statusCode: '200' }).set(100);
 // 3rd version: And again the same effect as above
 gauge.labels('GET', '200').set(100);
+// 4th version: And again the same effect as above
+gauge.labels(['GET', '200']).set(100);
 ```
 
 It is also possible to use timers with labels, both before and after the timer

--- a/index.d.ts
+++ b/index.d.ts
@@ -263,6 +263,13 @@ export class Counter<T extends string = string> {
 	 * @param values Label values
 	 * @return Configured counter with given labels
 	 */
+	labels(values: string[]): Counter.Internal;
+
+	/**
+	 * Return the child for given labels
+	 * @param values Label values
+	 * @return Configured counter with given labels
+	 */
 	labels(...values: string[]): Counter.Internal;
 
 	/**
@@ -276,6 +283,12 @@ export class Counter<T extends string = string> {
 	 * Reset counter values
 	 */
 	reset(): void;
+
+	/**
+	 * Remove metrics for the given label values
+	 * @param values Label values
+	 */
+	remove(values: string[]): void;
 
 	/**
 	 * Remove metrics for the given label values
@@ -378,6 +391,13 @@ export class Gauge<T extends string = string> {
 	 * @param values Label values
 	 * @return Configured gauge with given labels
 	 */
+	labels(values: string[]): Gauge.Internal<T>;
+
+	/**
+	 * Return the child for given labels
+	 * @param values Label values
+	 * @return Configured gauge with given labels
+	 */
 	labels(...values: string[]): Gauge.Internal<T>;
 
 	/**
@@ -391,6 +411,12 @@ export class Gauge<T extends string = string> {
 	 * Reset gauge values
 	 */
 	reset(): void;
+
+	/**
+	 * Remove metrics for the given label values
+	 * @param values Label values
+	 */
+	remove(values: string[]): void;
 
 	/**
 	 * Remove metrics for the given label values
@@ -502,6 +528,13 @@ export class Histogram<T extends string = string> {
 	 * @param values Label values
 	 * @return Configured histogram with given labels
 	 */
+	labels(values: string[]): Histogram.Internal<T>;
+
+	/**
+	 * Return the child for given labels
+	 * @param values Label values
+	 * @return Configured histogram with given labels
+	 */
 	labels(...values: string[]): Histogram.Internal<T>;
 
 	/**
@@ -510,6 +543,12 @@ export class Histogram<T extends string = string> {
 	 * @return Configured counter with given labels
 	 */
 	labels(labels: LabelValues<T>): Histogram.Internal<T>;
+
+	/**
+	 * Remove metrics for the given label values
+	 * @param values Label values
+	 */
+	remove(values: string[]): void;
 
 	/**
 	 * Remove metrics for the given label values
@@ -603,6 +642,13 @@ export class Summary<T extends string = string> {
 	 * @param values Label values
 	 * @return Configured summary with given labels
 	 */
+	labels(values: string[]): Summary.Internal<T>;
+
+	/**
+	 * Return the child for given labels
+	 * @param values Label values
+	 * @return Configured summary with given labels
+	 */
 	labels(...values: string[]): Summary.Internal<T>;
 
 	/**
@@ -611,6 +657,12 @@ export class Summary<T extends string = string> {
 	 * @return Configured counter with given labels
 	 */
 	labels(labels: LabelValues<T>): Summary.Internal<T>;
+
+	/**
+	 * Remove metrics for the given label values
+	 * @param values Label values
+	 */
+	remove(values: string[]): void;
 
 	/**
 	 * Remove metrics for the given label values

--- a/lib/util.js
+++ b/lib/util.js
@@ -44,7 +44,7 @@ exports.setValueDelta = function setValueDelta(
 };
 
 exports.getLabels = function (labelNames, args) {
-	if (typeof args[0] === 'object') {
+	if (typeof args[0] === 'object' && !Array.isArray(args[0])) {
 		return args[0];
 	}
 

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -166,6 +166,13 @@ describe.each([
 					expect(values).toHaveLength(1);
 					expect(values[0].labels).toEqual({ code: '200' });
 				});
+				it('should handle labels provided as an array', async () => {
+					instance.labels([200]).inc();
+
+					const values = (await instance.get()).values;
+					expect(values).toHaveLength(1);
+					expect(values[0].labels).toEqual({ code: '200' });
+				});
 			});
 
 			describe('with remove', () => {


### PR DESCRIPTION
This was undocumented and untested, and broke in 13.1.0.

<sub>I'm not sure why we provide 4 ways to set labels.</sub>

Fixes #499