### PR TITLE
perf: improve perf by caching unchanged histogram strings between gets

### DIFF
--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -96,15 +96,27 @@ class Histogram extends Metric {
 		this.hashMap[hash].bucketExemplars[b].timestamp = nowTimestamp();
 	}
 
-	async get() {
+	async get(getValueAsPrometheusString) {
 		if (this.collect) {
 			const v = this.collect();
 			if (v instanceof Promise) await v;
 		}
+
 		const data = Object.values(this.hashMap);
-		const values = data
-			.map(extractBucketValuesForExport(this))
-			.reduce(addSumAndCountForExport(this), []);
+
+		let values;
+		if (getValueAsPrometheusString) {
+			values = data.map(
+				getPrometheusStringWithCaching(
+					this,
+					getValueAsPrometheusString(this.name, this.type),
+				),
+			);
+		} else {
+			values = data
+				.map(extractBucketValuesForExport(this))
+				.reduce(addSumAndCountForExport(this), []);
+		}
 
 		return {
 			name: this.name,
@@ -220,6 +232,7 @@ function observe(labels) {
 
 		valueFromMap.sum += labelValuePair.value;
 		valueFromMap.count += 1;
+		valueFromMap.promString = '';
 
 		if (Object.prototype.hasOwnProperty.call(valueFromMap.bucketValues, b)) {
 			valueFromMap.bucketValues[b] += 1;
@@ -236,6 +249,7 @@ function createBaseValues(labels, bucketValues, bucketExemplars) {
 		bucketExemplars,
 		sum: 0,
 		count: 0,
+		promString: '',
 	};
 }
 
@@ -249,6 +263,22 @@ function convertLabelsAndValues(labels, value) {
 	return {
 		labels,
 		value,
+	};
+}
+
+function getPrometheusStringWithCaching(histogram, stringify) {
+	const extractBucketValues = extractBucketValuesForExport(histogram);
+	const addSumAndCount = addSumAndCountForExport(histogram);
+	return bucketData => {
+		if (bucketData.promString) {
+			return bucketData.promString;
+		}
+		const bucketValues = extractBucketValues(bucketData);
+		const fullValues = addSumAndCount([], bucketValues);
+		const formattedValues = fullValues.map(stringify);
+		const promString = formattedValues.join('\n');
+		bucketData.promString = promString; // modify in place !!!
+		return promString;
 	};
 }
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -29,72 +29,62 @@ class Registry {
 	}
 
 	async getMetricsAsString(metrics) {
-		const metric = await metrics.get();
+		const defaultLabels =
+			Object.keys(this._defaultLabels).length > 0 ? this._defaultLabels : null;
+
+		const formatValueGenerator = getValueAsPrometheusString(
+			defaultLabels,
+			this.contentType,
+		);
+
+		const metric = await metrics.get(formatValueGenerator);
 
 		const name = escapeString(metric.name);
 		const help = `# HELP ${name} ${escapeString(metric.help)}`;
 		const type = `# TYPE ${name} ${metric.type}`;
-		const values = [help, type];
+		let values = [help, type];
 
-		const defaultLabels =
-			Object.keys(this._defaultLabels).length > 0 ? this._defaultLabels : null;
+		if (metric.values) {
+			const formatValue = formatValueGenerator(metric.name, metric.type);
+			values = metric.values.reduce((acc, value) => {
+				acc.push(typeof value === 'string' ? value : formatValue(value));
 
-		for (const val of metric.values || []) {
-			let { metricName = name, labels = {} } = val;
-			if (
-				this.contentType === Registry.OPENMETRICS_CONTENT_TYPE &&
-				metric.type === 'counter'
-			) {
-				metricName = `${metricName}_total`;
-			}
+				const { exemplar } = value;
+				if (
+					exemplar &&
+					this.contentType === Registry.OPENMETRICS_CONTENT_TYPE
+				) {
+					const formattedExemplars = formatLabels(exemplar.labelSet);
+					acc.push(
+						` # {${formattedExemplars.join(',')}} ${getValueAsString(
+							exemplar.value,
+						)} ${exemplar.timestamp}`,
+					);
+				}
 
-			if (defaultLabels) {
-				labels = { ...labels, ...defaultLabels, ...labels };
-			}
-
-			const formattedLabels = formatLabels(labels);
-			const labelsString = formattedLabels.length
-				? `{${formattedLabels.join(',')}}`
-				: '';
-
-			values.push(
-				`${metricName}${labelsString} ${getValueAsString(val.value)}`,
-			);
-
-			const { exemplar } = val;
-			if (exemplar && this.contentType === Registry.OPENMETRICS_CONTENT_TYPE) {
-				const formattedExemplars = formatLabels(exemplar.labelSet);
-				values.push(
-					` # {${formattedExemplars.join(',')}} ${getValueAsString(
-						exemplar.value,
-					)} ${exemplar.timestamp}`,
-				);
-			}
+				return acc;
+			}, values);
 		}
 
 		return values.join('\n');
 	}
 
 	async metrics() {
-		const promises = [];
-
-		for (const metric of this.getMetricsAsArray()) {
+		const promises = this.getMetricsAsArray().map(metric => {
 			if (
 				this.contentType === Registry.OPENMETRICS_CONTENT_TYPE &&
 				metric.type === 'counter'
 			) {
 				metric.name = standardizeCounterName(metric.name);
 			}
-			promises.push(this.getMetricsAsString(metric));
-		}
+			return this.getMetricsAsString(metric);
+		});
 
 		const resolves = await Promise.all(promises);
 
-		if (this.contentType === Registry.OPENMETRICS_CONTENT_TYPE) {
-			return `${resolves.join('\n')}\n# EOF\n`;
-		} else {
-			return `${resolves.join('\n\n')}\n`;
-		}
+		return this.contentType === Registry.OPENMETRICS_CONTENT_TYPE
+			? `${resolves.join('\n')}\n# EOF\n`
+			: `${resolves.join('\n\n')}\n`;
 	}
 
 	registerMetric(metric) {
@@ -113,34 +103,22 @@ class Registry {
 	}
 
 	async getMetricsAsJSON() {
-		const metrics = [];
-		const defaultLabelNames = Object.keys(this._defaultLabels);
-
-		const promises = [];
-
-		for (const metric of this.getMetricsAsArray()) {
-			promises.push(metric.get());
-		}
-
+		const promises = this.getMetricsAsArray().map(metric => metric.get());
 		const resolves = await Promise.all(promises);
 
-		for (const item of resolves) {
-			if (item.values && defaultLabelNames.length > 0) {
-				for (const val of item.values) {
-					// Make a copy before mutating
-					val.labels = Object.assign({}, val.labels);
-
-					for (const labelName of defaultLabelNames) {
-						val.labels[labelName] =
-							val.labels[labelName] || this._defaultLabels[labelName];
-					}
-				}
-			}
-
-			metrics.push(item);
+		const defaultLabelNames = Object.keys(this._defaultLabels);
+		if (defaultLabelNames.length === 0) {
+			return resolves;
 		}
 
-		return metrics;
+		return resolves.map(item => {
+			if (item.values) {
+				for (const val of item.values) {
+					val.labels = { ...val.labels, ...this._defaultLabels, ...val.labels };
+				}
+			}
+			return item;
+		});
 	}
 
 	removeSingleMetric(name) {
@@ -199,6 +177,31 @@ class Registry {
 		metricsToMerge.forEach(mergedRegistry.registerMetric, mergedRegistry);
 		return mergedRegistry;
 	}
+}
+
+function getValueAsPrometheusString(defaultLabels, contentType) {
+	return (name, type) => {
+		const defaultName = escapeString(name);
+		return ({ metricName = defaultName, value, labels = {} }) => {
+			if (
+				contentType === Registry.OPENMETRICS_CONTENT_TYPE &&
+				type === 'counter'
+			) {
+				metricName = `${metricName}_total`;
+			}
+
+			if (defaultLabels) {
+				labels = { ...labels, ...defaultLabels, ...labels };
+			}
+
+			const formattedLabels = formatLabels(labels);
+			const labelsString = formattedLabels.length
+				? `{${formattedLabels.join(',')}}`
+				: '';
+
+			return `${metricName}${labelsString} ${getValueAsString(value)}`;
+		};
+	};
 }
 
 function formatLabels(labels) {


### PR DESCRIPTION
`Histogram.get()` returns the content of the histogram as JSON that gets converted into a string representation by `Registry.getMetricsAsString()`. This conversion can be expensive, especially when there are many labels / label values / buckets, because each combination needs to be converted. This overhead can be reduced by caching the string representations for each entry in the histogram hash. This is because when there are many combinations, it's likely that most won't change between getting the metrics.

In order to perform the caching, the conversion to string needs to happen inside `Histogram.get()`. To accomplish this `Registry.getMetricsAsString()` will now pass into it an optional value-to-string conversion function. If such a function is provided then the caching will happen, otherwise the same behavior as before.

It's possible to easily extend this behavior to the other metrics types. However they won't get such a significant improvement as the conversion operation for them is less expensive per value.

**note**: registry benchmark has been modified to perform an update of an eighth if a histogram between getting the metrics string. This is so that it's not all cached. This is because full caching is so fast the benchmark explodes.