### PR TITLE
Fix typescript definitions for using with Registry<OpenMetricsContentType>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Changed
-
-- Cleanup code and refactor to be more efficient
-
 ### Breaking
 
 - drop support for Node.js versions 10, 12 and 17
@@ -23,6 +19,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
   avoid failures from the server when using `Content-Encoding: gzip` header.
 - Refactor `escapeString` helper in `lib/registry.js` to improve performance and
   avoid an unnecessarily complex regex.
+- Cleanup code and refactor to be more efficient
+- Correct TS types for working with OpenMetrics
 
 ### Added
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,9 +9,9 @@ export type PrometheusMetricsVersion = '0.0.4';
 export type OpenMetricsMIME = 'application/openmetrics-text';
 export type OpenMetricsVersion = '1.0.0';
 
-export type PrometheusContentType =
-	`${OpenMetricsMIME}; version=${OpenMetricsVersion}; charset=${Charset}`;
 export type OpenMetricsContentType =
+	`${OpenMetricsMIME}; version=${OpenMetricsVersion}; charset=${Charset}`;
+export type PrometheusContentType =
 	`${PrometheusMIME}; version=${PrometheusMetricsVersion}; charset=${Charset}`;
 
 export type RegistryContentType =

--- a/index.d.ts
+++ b/index.d.ts
@@ -119,7 +119,7 @@ export const prometheusContentType: PrometheusContentType;
  */
 export const openMetricsContentType: OpenMetricsContentType;
 
-export class AggregatorRegistry extends Registry {
+export class AggregatorRegistry<T extends RegistryContentType> extends Registry<T>  {
 	/**
 	 * Gets aggregated metrics for all workers.
 	 * @return {Promise<string>} Promise that resolves with the aggregated
@@ -136,7 +136,7 @@ export class AggregatorRegistry extends Registry {
 	 *   `registry.getMetricsAsJSON()`.
 	 * @return {Registry} aggregated registry.
 	 */
-	static aggregate(metricsArr: Array<Object>): Registry; // TODO Promise?
+	static aggregate<T extends RegistryContentType>(metricsArr: Array<Object>): Registry<T>; // TODO Promise?
 
 	/**
 	 * Sets the registry or registries to be aggregated. Call from workers to
@@ -145,7 +145,10 @@ export class AggregatorRegistry extends Registry {
 	 *   aggregated.
 	 * @return {void}
 	 */
-	static setRegistries(regs: Array<Registry> | Registry): void;
+	static setRegistries(regs: 
+		| Array<Registry<PrometheusContentType> | Registry<OpenMetricsContentType>> 
+		| Registry<PrometheusContentType>
+		| Registry<OpenMetricsContentType>): void;
 }
 
 /**
@@ -655,13 +658,13 @@ export namespace Summary {
 /**
  * Push metrics to a Pushgateway
  */
-export class Pushgateway {
+export class Pushgateway<T extends RegistryContentType> {
 	/**
 	 * @param url Complete url to the Pushgateway. If port is needed append url with :port
 	 * @param options Options
 	 * @param registry Registry
 	 */
-	constructor(url: string, options?: any, registry?: Registry);
+	constructor(url: string, options?: any, registry?: Registry<T>);
 
 	/**
 	 * Add metric and overwrite old ones
@@ -729,8 +732,8 @@ export function exponentialBuckets(
 	count: number,
 ): number[];
 
-export interface DefaultMetricsCollectorConfiguration {
-	register?: Registry;
+export interface DefaultMetricsCollectorConfiguration<T extends RegistryContentType> {
+	register?: Registry<T>;
 	prefix?: string;
 	gcDurationBuckets?: number[];
 	eventLoopMonitoringPrecision?: number;
@@ -741,8 +744,8 @@ export interface DefaultMetricsCollectorConfiguration {
  * Configure default metrics
  * @param config Configuration object for default metrics collector
  */
-export function collectDefaultMetrics(
-	config?: DefaultMetricsCollectorConfiguration,
+export function collectDefaultMetrics<T extends RegistryContentType>(
+	config?: DefaultMetricsCollectorConfiguration<T>,
 ): void;
 
 export interface defaultMetrics {

--- a/index.d.ts
+++ b/index.d.ts
@@ -119,7 +119,9 @@ export const prometheusContentType: PrometheusContentType;
  */
 export const openMetricsContentType: OpenMetricsContentType;
 
-export class AggregatorRegistry<T extends RegistryContentType> extends Registry<T>  {
+export class AggregatorRegistry<
+	T extends RegistryContentType,
+> extends Registry<T> {
 	/**
 	 * Gets aggregated metrics for all workers.
 	 * @return {Promise<string>} Promise that resolves with the aggregated
@@ -136,7 +138,9 @@ export class AggregatorRegistry<T extends RegistryContentType> extends Registry<
 	 *   `registry.getMetricsAsJSON()`.
 	 * @return {Registry} aggregated registry.
 	 */
-	static aggregate<T extends RegistryContentType>(metricsArr: Array<Object>): Registry<T>; // TODO Promise?
+	static aggregate<T extends RegistryContentType>(
+		metricsArr: Array<Object>,
+	): Registry<T>; // TODO Promise?
 
 	/**
 	 * Sets the registry or registries to be aggregated. Call from workers to
@@ -145,10 +149,14 @@ export class AggregatorRegistry<T extends RegistryContentType> extends Registry<
 	 *   aggregated.
 	 * @return {void}
 	 */
-	static setRegistries(regs: 
-		| Array<Registry<PrometheusContentType> | Registry<OpenMetricsContentType>> 
-		| Registry<PrometheusContentType>
-		| Registry<OpenMetricsContentType>): void;
+	static setRegistries(
+		regs:
+			| Array<
+					Registry<PrometheusContentType> | Registry<OpenMetricsContentType>
+			  >
+			| Registry<PrometheusContentType>
+			| Registry<OpenMetricsContentType>,
+	): void;
 }
 
 /**
@@ -732,7 +740,9 @@ export function exponentialBuckets(
 	count: number,
 ): number[];
 
-export interface DefaultMetricsCollectorConfiguration<T extends RegistryContentType> {
+export interface DefaultMetricsCollectorConfiguration<
+	T extends RegistryContentType,
+> {
 	register?: Registry<T>;
 	prefix?: string;
 	gcDurationBuckets?: number[];


### PR DESCRIPTION
1. Content types was mixed up -  #565 
2. Methods like collectDefaultMetrics without setting generic type does not allows to work with Registry<OpenMetricsContentType>

