### PR TITLE
fix: pushgateway reject with timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Correct TS types for working with OpenMetrics
 - Updated Typescript and Readme docs for `setToCurrentTime()` to reflect units as seconds.
 - Do not ignore error if request to pushgateway fails
+- Make sure to reject the request to pushgateway if it times out
 
 ### Added
 

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -80,7 +80,7 @@ async function useGateway(method, job, groupings) {
 		});
 
 		req.on('timeout', () => {
-			reject(new Error('Pushgateway request timed out'));
+			req.destroy(new Error('Pushgateway request timed out'));
 		});
 
 		if (method !== 'DELETE') {

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -79,6 +79,10 @@ async function useGateway(method, job, groupings) {
 			reject(err);
 		});
 
+		req.on('timeout', () => {
+			reject(new Error('Pushgateway request timed out'));
+		});
+
 		if (method !== 'DELETE') {
 			this.registry
 				.metrics()

--- a/test/pushgatewayTest.js
+++ b/test/pushgatewayTest.js
@@ -66,6 +66,23 @@ describe.each([
 						expect(mockHttp.isDone());
 					});
 			});
+
+			it('should timeout when taking too long', () => {
+				const mockHttp = nock('http://192.168.99.100:9091')
+					.post('/metrics/job/testJob/key/va%26lue', body)
+					.delay(100)
+					.reply(200);
+
+				expect.assertions(1);
+				return instance
+					.pushAdd({
+						jobName: 'testJob',
+						groupings: { key: 'va&lue' },
+					})
+					.catch(err => {
+						expect(err.message).toStrictEqual('Pushgateway request timed out');
+					});
+			});
 		});
 
 		describe('push', () => {
@@ -88,6 +105,18 @@ describe.each([
 					expect(mockHttp.isDone());
 				});
 			});
+
+			it('should timeout when taking too long', () => {
+				const mockHttp = nock('http://192.168.99.100:9091')
+					.put('/metrics/job/test%26Job', body)
+					.delay(100)
+					.reply(200);
+
+				expect.assertions(1);
+				return instance.push({ jobName: 'test&Job' }).catch(err => {
+					expect(err.message).toStrictEqual('Pushgateway request timed out');
+				});
+			});
 		});
 
 		describe('delete', () => {
@@ -98,6 +127,18 @@ describe.each([
 
 				return instance.delete({ jobName: 'testJob' }).then(() => {
 					expect(mockHttp.isDone());
+				});
+			});
+
+			it('should timeout when taking too long', () => {
+				const mockHttp = nock('http://192.168.99.100:9091')
+					.delete('/metrics/job/testJob')
+					.delay(100)
+					.reply(200);
+
+				expect.assertions(1);
+				return instance.delete({ jobName: 'testJob' }).catch(err => {
+					expect(err.message).toStrictEqual('Pushgateway request timed out');
 				});
 			});
 		});
@@ -202,7 +243,7 @@ describe.each([
 
 		beforeEach(() => {
 			registry = undefined;
-			instance = new Pushgateway('http://192.168.99.100:9091');
+			instance = new Pushgateway('http://192.168.99.100:9091', { timeout: 10 });
 			const promClient = require('../index');
 			const cnt = new promClient.Counter({ name: 'test', help: 'test' });
 			cnt.inc(100);
@@ -218,7 +259,11 @@ describe.each([
 
 		beforeEach(() => {
 			registry = new Registry(regType);
-			instance = new Pushgateway('http://192.168.99.100:9091', null, registry);
+			instance = new Pushgateway(
+				'http://192.168.99.100:9091',
+				{ timeout: 10 },
+				registry,
+			);
 			const promeClient = require('../index');
 			const cnt = new promeClient.Counter({
 				name: 'test',


### PR DESCRIPTION
As explained in [README.md](https://github.com/siimon/prom-client/blob/master/README.md?plain=1#L575) the timeout option should timeout the request but it is not doing it.

It was missing listen to the timeout event from `node HTTP` and rejecting the promise (destroying the request).