### PR TITLE
fix: do not ignore error if request fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
   avoid an unnecessarily complex regex.
 - Cleanup code and refactor to be more efficient
 - Correct TS types for working with OpenMetrics
+- Do not ignore error if request to pushgateway fails
 
 ### Added
 

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -76,9 +76,9 @@ async function useGateway(method, job, groupings) {
 					reject(
 						new Error(`push failed with status ${resp.statusCode}, ${body}`),
 					);
+				} else {
+					resolve({ resp, body });
 				}
-
-				resolve({ resp, body });
 			});
 		});
 		req.on('error', err => {

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -72,8 +72,10 @@ async function useGateway(method, job, groupings) {
 				body += chunk;
 			});
 			resp.on('end', () => {
-				if(resp.statusCode >= 400) {
-					reject(new Error(`push failed with status ${resp.statusCode}, ${body}`))
+				if (resp.statusCode >= 400) {
+					reject(
+						new Error(`push failed with status ${resp.statusCode}, ${body}`),
+					);
 				}
 
 				resolve({ resp, body });

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -72,6 +72,10 @@ async function useGateway(method, job, groupings) {
 				body += chunk;
 			});
 			resp.on('end', () => {
+				if(resp.statusCode >= 400) {
+					reject(new Error(`push failed with status ${resp.statusCode}, ${body}`))
+				}
+
 				resolve({ resp, body });
 			});
 		});

--- a/test/pushgatewayTest.js
+++ b/test/pushgatewayTest.js
@@ -66,6 +66,19 @@ describe.each([
 						expect(mockHttp.isDone());
 					});
 			});
+
+			it('should throw an error if the push failed', () => {
+				nock('http://192.168.99.100:9091')
+					.post('/metrics/job/testJob/key/value', body)
+					.reply(400);
+
+				return expect(
+					instance.pushAdd({
+						jobName: 'testJob',
+						groupings: { key: 'value' },
+					}),
+				).rejects.toThrow('push failed with status 400');
+			});
 		});
 
 		describe('push', () => {
@@ -88,6 +101,19 @@ describe.each([
 					expect(mockHttp.isDone());
 				});
 			});
+
+			it('should throw an error if the push failed', () => {
+				nock('http://192.168.99.100:9091')
+					.put('/metrics/job/testJob/key/value', body)
+					.reply(400);
+
+				return expect(
+					instance.push({
+						jobName: 'testJob',
+						groupings: { key: 'value' },
+					}),
+				).rejects.toThrow('push failed with status 400');
+			});
 		});
 
 		describe('delete', () => {
@@ -99,6 +125,16 @@ describe.each([
 				return instance.delete({ jobName: 'testJob' }).then(() => {
 					expect(mockHttp.isDone());
 				});
+			});
+
+			it('should throw an error if the push failed', () => {
+				nock('http://192.168.99.100:9091')
+					.delete('/metrics/job/testJob')
+					.reply(400);
+
+				return expect(instance.delete({ jobName: 'testJob' })).rejects.toThrow(
+					'push failed with status 400',
+				);
 			});
 		});
 


### PR DESCRIPTION
Throw an error if the gateway rejected the pushed metrics.