### PR TITLE
Fixes description for setToCurrentTime to seconds instead of milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
   avoid an unnecessarily complex regex.
 - Cleanup code and refactor to be more efficient
 - Correct TS types for working with OpenMetrics
+- Updated Typescript and Readme docs for `setToCurrentTime()` to reflect units as seconds.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ functions will not have the correct value for `this`.
 ##### Utility Functions
 
 ```js
-// Set value to current time:
+// Set value to current time in seconds:
 gauge.setToCurrentTime();
 
 // Record durations:

--- a/index.d.ts
+++ b/index.d.ts
@@ -370,7 +370,7 @@ export class Gauge<T extends string = string> {
 	get(): Promise<MetricObjectWithValues<MetricValue<T>>>;
 
 	/**
-	 * Set gauge value to current epoch time in ms
+	 * Set gauge value to current epoch time in seconds
 	 * @param labels Object with label keys and values
 	 */
 	setToCurrentTime(labels?: LabelValues<T>): void;


### PR DESCRIPTION
Fixes #568 
This was broken since the change in #167 in v11.0.0