### PR TITLE
perf: improve getMetricAsString for long strings + less allocations

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -2,6 +2,18 @@
 
 const { getValueAsString } = require('./util');
 
+const ESCAPE_STRING_REPLACE_MAP = {
+	'\\': '\\\\',
+	'\n': '\\n',
+};
+
+const ESCAPE_LABEL_VALUE_REPLACE_MAP = {
+	...ESCAPE_STRING_REPLACE_MAP,
+	'"': '\\\\"',
+};
+
+const ESCAPE_REPLACE_REGEXP = /\\|\n|"/g;
+
 function REPLACE_FUNC(dict) {
 	return char => dict[char] || '';
 }
@@ -13,23 +25,6 @@ class Registry {
 
 	static get OPENMETRICS_CONTENT_TYPE() {
 		return 'application/openmetrics-text; version=1.0.0; charset=utf-8';
-	}
-
-	static get ESCAPE_STRING_REPLACE_MAP() {
-		return {
-			'\\': '\\\\',
-			'\n': '\\n',
-		};
-	}
-
-	static get ESCAPE_LABEL_VALUE_REPLACE_MAP() {
-		return Object.assign({}, Registry.ESCAPE_STRING_REPLACE_MAP, {
-			'"': '\\\\"',
-		});
-	}
-
-	static get ESCAPE_REPLACE_REGEXP() {
-		return /\\|\n|"/g;
 	}
 
 	constructor(regContentType = Registry.PROMETHEUS_CONTENT_TYPE) {
@@ -256,14 +251,14 @@ function escapeLabelValue(str) {
 		return str;
 	}
 
-	return escapeString(str, Registry.ESCAPE_LABEL_VALUE_REPLACE_MAP);
+	return escapeString(str, ESCAPE_LABEL_VALUE_REPLACE_MAP);
 }
 function escapeString(str, extraReplaceDict) {
 	const fullDict = extraReplaceDict
 		? extraReplaceDict
-		: Registry.ESCAPE_STRING_REPLACE_MAP;
+		: ESCAPE_STRING_REPLACE_MAP;
 
-	return str.replace(Registry.ESCAPE_REPLACE_REGEXP, REPLACE_FUNC(fullDict));
+	return str.replace(ESCAPE_REPLACE_REGEXP, REPLACE_FUNC(fullDict));
 }
 function standardizeCounterName(name) {
 	return name.replace(/_total$/, '');

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 'use strict';
 
 const { getValueAsString } = require('./util');
@@ -29,10 +30,6 @@ class Registry {
 	}
 
 	static get ESCAPE_REPLACE_REGEXP() {
-		// return new RegExp(
-		// 	Object.keys(Registry.ESCAPE_LABEL_VALUE_REPLACE_MAP).join('|'),
-		// 	'g',
-		// );
 		return /\\|\n|"/g;
 	}
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -2,6 +2,10 @@
 
 const { getValueAsString } = require('./util');
 
+function REPLACE_FUNC(dict) {
+	return char => dict[char] || '';
+}
+
 class Registry {
 	static get PROMETHEUS_CONTENT_TYPE() {
 		return 'text/plain; version=0.0.4; charset=utf-8';
@@ -9,6 +13,27 @@ class Registry {
 
 	static get OPENMETRICS_CONTENT_TYPE() {
 		return 'application/openmetrics-text; version=1.0.0; charset=utf-8';
+	}
+
+	static get ESCAPE_STRING_REPLACE_MAP() {
+		return {
+			'\\': '\\\\',
+			'\n': '\\n',
+		};
+	}
+
+	static get ESCAPE_LABEL_VALUE_REPLACE_MAP() {
+		return Object.assign({}, Registry.ESCAPE_STRING_REPLACE_MAP, {
+			'"': '\\\\"',
+		});
+	}
+
+	static get ESCAPE_REPLACE_REGEXP() {
+		// return new RegExp(
+		// 	Object.keys(Registry.ESCAPE_LABEL_VALUE_REPLACE_MAP).join('|'),
+		// 	'g',
+		// );
+		return /\\|\n|"/g;
 	}
 
 	constructor(regContentType = Registry.PROMETHEUS_CONTENT_TYPE) {
@@ -234,10 +259,15 @@ function escapeLabelValue(str) {
 	if (typeof str !== 'string') {
 		return str;
 	}
-	return escapeString(str).replace(/"/g, '\\"');
+
+	return escapeString(str, Registry.ESCAPE_LABEL_VALUE_REPLACE_MAP);
 }
-function escapeString(str) {
-	return str.replace(/\\/g, '\\\\').replace(/\n/g, '\\n');
+function escapeString(str, extraReplaceDict) {
+	const fullDict = extraReplaceDict
+		? extraReplaceDict
+		: Registry.ESCAPE_STRING_REPLACE_MAP;
+
+	return str.replace(Registry.ESCAPE_REPLACE_REGEXP, REPLACE_FUNC(fullDict));
 }
 function standardizeCounterName(name) {
 	return name.replace(/_total$/, '');

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 'use strict';
 
 const { getValueAsString } = require('./util');


### PR DESCRIPTION
Do all replacements for escaping in a single pass (less large string copies due to chained replace calls).

* Note that `prom-client@v15.0.0-1` (which was a really good improvement) is sometimes on-par or a bit better than this, but not by much, and I think in terms of memory this is a bit more efficient (for long strings) so perhaps there's a place for a different strategy for different inputs, but I didn't want to get into that complexity here.

@shappir you [improvement](https://github.com/siimon/prom-client/pull/548) was really good, I was trying to also address allocations here (chained `replace`), would actually love your take here as well, since it's possible the best solution is some combination.

<img width="537" alt="image" src="https://github.com/siimon/prom-client/assets/925010/3d63275c-da0a-47af-ade1-a33e00e05a3b">
<img width="770" alt="image" src="https://github.com/siimon/prom-client/assets/925010/5355d25e-e662-4135-bda4-92f84218d537">
