### PR TITLE
chore: drop node 14

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking
 
-- drop support for Node.js versions 10, 12, 17 and 19
+- drop support for Node.js versions 10, 12, 14, 17 and 19
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"index.d.ts"
 	],
 	"engines": {
-		"node": ">=16"
+		"node": "^16 || ^18 || >=20"
 	},
 	"scripts": {
 		"benchmarks": "node ./benchmarks/index.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"index.d.ts"
 	],
 	"engines": {
-		"node": ">=14"
+		"node": ">=16"
 	},
 	"scripts": {
 		"benchmarks": "node ./benchmarks/index.js",


### PR DESCRIPTION
Node 16 is EOL now. I'm fine keeping that around, but also keeping v14 around seems unnecessary