### PR TITLE
feat: startTimer with exemplar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Allow Pushgateway to now require job names for compatibility with Gravel Gateway.
+- Allow `histogram.startTime()` to be used with exemplars.
 
 ## [15.0.0] - 2023-10-09
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -499,6 +499,19 @@ export class Histogram<T extends string = string> {
 	startTimer(labels?: LabelValues<T>): (labels?: LabelValues<T>) => number;
 
 	/**
+	 * Start a timer with exemplar. Calling the returned function will observe the duration in
+	 * seconds in the histogram.
+	 * @param labels Object with label keys and values
+	 * @param exemplarLabels Object with label keys and values for exemplars
+	 * @return Function to invoke when timer should be stopped. The value it
+	 * returns is the timed duration.
+	 */
+	startTimer(
+		labels?: LabelValues<T>,
+		exemplarLabels?: LabelValues<T>,
+	): (labels?: LabelValues<T>, exemplarLabels?: LabelValues<T>) => number;
+
+	/**
 	 * Reset histogram values
 	 */
 	reset(): void;

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -24,8 +24,10 @@ class Histogram extends Metric {
 		this.type = 'histogram';
 		this.defaultLabels = {};
 		this.defaultExemplarLabelSet = {};
+		this.enableExemplars = false;
 
 		if (config.enableExemplars) {
+			this.enableExemplars = true;
 			this.observe = this.observeWithExemplar;
 		} else {
 			this.observe = this.observeWithoutExemplar;
@@ -143,6 +145,7 @@ class Histogram extends Metric {
 	/**
 	 * Start a timer that could be used to logging durations
 	 * @param {object} labels - Object with labels where key is the label key and value is label value. Can only be one level deep
+	 * @param {object} exemplarLabels - Object with labels for exemplar where key is the label key and value is label value. Can only be one level deep
 	 * @returns {function} - Function to invoke when you want to stop the timer and observe the duration in seconds
 	 * @example
 	 * var end = histogram.startTimer();
@@ -151,8 +154,10 @@ class Histogram extends Metric {
 	 * 	console.log('Duration', duration);
 	 * });
 	 */
-	startTimer(labels) {
-		return startTimer.call(this, labels)();
+	startTimer(labels, exemplarLabels) {
+		return this.enableExemplars
+			? startTimerWithExemplar.call(this, labels, exemplarLabels)()
+			: startTimer.call(this, labels)();
 	}
 
 	labels(...args) {
@@ -178,6 +183,26 @@ function startTimer(startLabels) {
 			const delta = process.hrtime(start);
 			const value = delta[0] + delta[1] / 1e9;
 			this.observe(Object.assign({}, startLabels, endLabels), value);
+			return value;
+		};
+	};
+}
+
+function startTimerWithExemplar(startLabels, startExemplarLabels) {
+	return () => {
+		const start = process.hrtime();
+		return (endLabels, endExemplarLabels) => {
+			const delta = process.hrtime(start);
+			const value = delta[0] + delta[1] / 1e9;
+			this.observe({
+				labels: Object.assign({}, startLabels, endLabels),
+				value,
+				exemplarLabels: Object.assign(
+					{},
+					startExemplarLabels,
+					endExemplarLabels,
+				),
+			});
 			return value;
 		};
 	};


### PR DESCRIPTION
When using `Histogram.startTimer()` with 'enableExemplars' option set to true in order to record duration, it throws an error as following.
It supposed to work normally as it does when 'enableExemplars' option set to false.

![image](https://github.com/siimon/prom-client/assets/13795717/f5787454-b285-4fda-b025-ae758273b3d5)

Plus, it would be better if we could provide adding exemplarLabels just like we could do with `Histogram.observe()`.

I have added the feature with regarding test cases. Please feel free to give me any feedback.


