### PR TITLE
feat: allow running in Bun, add to CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Node.js CI
+name: CI
 
 on:
   push:
@@ -11,7 +11,7 @@ on:
       - '**'
 
 jobs:
-  build:
+  nodejs:
     name: Test on Node.js v${{ matrix.node-version }} and OS ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -40,3 +40,16 @@ jobs:
         run: npm i
       - name: Test
         run: npm run test
+
+  bun:
+    name: Test on Bun
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - name: Install Dependencies
+        run: bun install
+      - name: Test
+        run: bun test-unit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - remove unnecessary loop from `osMemoryHeapLinux`
 - Improve performance of `hashObject` by using pre-sorted array of label names
 - Fix type of `collectDefaultMetrics.metricsList`
+- Allow running in Bun by skipping incompatible default metrics.
 
 ### Added
 

--- a/lib/metrics/gc.js
+++ b/lib/metrics/gc.js
@@ -6,8 +6,10 @@ let perf_hooks;
 try {
 	// eslint-disable-next-line
 	perf_hooks = require('perf_hooks');
+	new perf_hooks.PerformanceObserver();
 } catch {
-	// node version is too old
+	// node version is too old, or Bun
+	perf_hooks = false;
 }
 
 const NODEJS_GC_DURATION_SECONDS = 'nodejs_gc_duration_seconds';

--- a/lib/metrics/heapSpacesSizeAndUsed.js
+++ b/lib/metrics/heapSpacesSizeAndUsed.js
@@ -11,6 +11,12 @@ METRICS.forEach(metricType => {
 });
 
 module.exports = (registry, config = {}) => {
+	try {
+		v8.getHeapSpaceStatistics();
+	} catch {
+		return; // Bun
+	}
+
 	const registers = registry ? [registry] : undefined;
 	const namePrefix = config.prefix ? config.prefix : '';
 

--- a/test/metrics/gcTest.js
+++ b/test/metrics/gcTest.js
@@ -33,8 +33,10 @@ describe.each([
 		try {
 			// eslint-disable-next-line
 			perf_hooks = require('perf_hooks');
+			new perf_hooks.PerformanceObserver();
 		} catch {
-			// node version is too old
+			// node version is too old, or Bun
+			perf_hooks = false;
 		}
 
 		if (perf_hooks) {


### PR DESCRIPTION
Adds feature testing to more default metrics so that Bun (and possibly Deno) work. The metrics are all called `node_something_something` /shrug.

I think this is all that's required, but our tests didn't catch any failures without these changes. Appreciate any beta-testing from the community.

~For some reason, the tests are way slower in Bun (80 vs 5 seconds). idk how to use Bun's profiler with jest.~ evidently only on my WSL2 environment

https://github.com/oven-sh/bun/issues/4708 will obviate these changes.

Fixes #570