### PR TITLE
perf: improve the memory usage of histogram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 *.log
 coverage/
 package-lock.json
+*.heapsnapshot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Improve the memory usage of histogram when disable `enableExemplars` option
+- Improve the memory usage of histograms when the `enableExemplars` option is disabled
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Improve the memory usage of histogram when disable `enableExemplars` option
+
 ### Added
 
 ## [15.1.0] - 2023-12-15

--- a/example/histogram-large-memory.js
+++ b/example/histogram-large-memory.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const v8 = require('v8');
+const { register, Histogram } = require('..');
+
+// Create more metrics
+
+async function run() {
+	const labelNames = Array(10).map((_, idx) => `label_${idx}`);
+
+	const getRandomLabels = () =>
+		labelNames.reduce((acc, label) => {
+			return { ...acc, [label]: `value_${Math.random()}` };
+		}, {});
+
+	for (let i = 0; i < 100000; i++) {
+		const h = new Histogram({
+			name: `test_histogram_${i}`,
+			help: `Example of a histogram ${i}`,
+			buckets: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1],
+			labelNames,
+		});
+		h.observe(getRandomLabels(), Math.random());
+	}
+
+	await register.metrics();
+
+	global.gc();
+
+	v8.writeHeapSnapshot();
+}
+
+run();

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -26,13 +26,6 @@ class Histogram extends Metric {
 		this.defaultExemplarLabelSet = {};
 		this.enableExemplars = false;
 
-		if (config.enableExemplars) {
-			this.enableExemplars = true;
-			this.observe = this.observeWithExemplar;
-		} else {
-			this.observe = this.observeWithoutExemplar;
-		}
-
 		for (const label of this.labelNames) {
 			if (label === 'le') {
 				throw new Error('le is a reserved label keyword');
@@ -45,13 +38,19 @@ class Histogram extends Metric {
 			return acc;
 		}, {});
 
-		this.bucketExemplars = this.upperBounds.reduce((acc, upperBound) => {
-			acc[upperBound] = null;
-			return acc;
-		}, {});
+		if (config.enableExemplars) {
+			this.enableExemplars = true;
+			this.bucketExemplars = this.upperBounds.reduce((acc, upperBound) => {
+				acc[upperBound] = null;
+				return acc;
+			}, {});
+			Object.freeze(this.bucketExemplars);
+			this.observe = this.observeWithExemplar;
+		} else {
+			this.observe = this.observeWithoutExemplar;
+		}
 
 		Object.freeze(this.bucketValues);
-		Object.freeze(this.bucketExemplars);
 		Object.freeze(this.upperBounds);
 
 		if (this.labelNames.length === 0) {
@@ -263,13 +262,16 @@ function observe(labels) {
 }
 
 function createBaseValues(labels, bucketValues, bucketExemplars) {
-	return {
+	const result = {
 		labels,
 		bucketValues: { ...bucketValues },
-		bucketExemplars: { ...bucketExemplars },
 		sum: 0,
 		count: 0,
 	};
+	if (bucketExemplars) {
+		result.bucketExemplars = { ...bucketExemplars };
+	}
+	return result;
 }
 
 function convertLabelsAndValues(labels, value) {
@@ -294,7 +296,9 @@ function extractBucketValuesForExport(histogram) {
 				{ le: upperBound },
 				acc,
 				name,
-				bucketData.bucketExemplars[upperBound],
+				bucketData.bucketExemplars
+					? bucketData.bucketExemplars[upperBound]
+					: null,
 				bucketData.labels,
 			);
 		});
@@ -312,7 +316,7 @@ function addSumAndCountForExport(histogram) {
 				infLabel,
 				d.data.count,
 				`${histogram.name}_bucket`,
-				d.data.bucketExemplars['-1'],
+				d.data.bucketExemplars ? d.data.bucketExemplars['-1'] : null,
 				d.data.labels,
 			),
 			setValuePair(


### PR DESCRIPTION
We have a use case where it generates a huge amount of histograms, each has more than 10 labels, we found the memory usage is quite high, under this scenario, we did an experiment and found that removing bucketExemplars field from histograms could save about `27%` memory usage for each histogram instance, hope the maintainers could review and consider it
![SeaTalk_IMG_20240111_195229](https://github.com/siimon/prom-client/assets/1160705/191abe7c-776f-453d-93e4-619cf7b29543)
