### PR TITLE
fix: avoid updating exemplar values during subsequent metric changes

### DIFF
--- a/lib/counter.js
+++ b/lib/counter.js
@@ -85,6 +85,7 @@ class Counter extends Metric {
 	}
 
 	updateExemplar(exemplarLabels, value, hash) {
+		if (exemplarLabels === this.defaultExemplarLabelSet) return;
 		if (!isObject(this.hashMap[hash].exemplar)) {
 			this.hashMap[hash].exemplar = new Exemplar();
 		}

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -84,6 +84,7 @@ class Histogram extends Metric {
 	}
 
 	updateExemplar(labels, value, exemplarLabels) {
+		if (exemplarLabels === this.defaultExemplarLabelSet) return;
 		const hash = hashObject(labels, this.sortedLabelNames);
 		const bound = findBound(this.upperBounds, value);
 		const { bucketExemplars } = this.hashMap[hash];


### PR DESCRIPTION
## Problem

The current exemplars implementation expects that every time we update a metric, we will have fresh exemplar labels to set together with the metric. However, setups that have a low sampling rate for their exemplar labels (e.g. trace ids), this means that this implementation would be reseting exemplar labels.

This also creates a lot of noise in graphing solutions like Grafana as there are lots of exemplars displayed without any contextual data attached to them.

## Solution

Before setting an exemplar, or even creating a brand new one, we first will check whether the the exemplar labels were configured with anything other that isn't the default empty object. If there are no exemplar labels, then we simply short circuit the function.

Note, this likely means that we could get rid off the `defaultExemplarLabelSet` field and just handle the `undefined` value, but I wanted to have the least amount of changes in the PR.


_fixes https://github.com/siimon/prom-client/issues/616_

---

@SimenB 