### PR TITLE
fix: enable bun.js by catching NotImplemented error

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Node.js CI
+name: CI
 
 on:
   push:
@@ -11,7 +11,7 @@ on:
       - '**'
 
 jobs:
-  build:
+  nodejs:
     name: Test on Node.js v${{ matrix.node-version }} and OS ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -40,3 +40,15 @@ jobs:
         run: npm i
       - name: Test
         run: npm run test
+  bun:
+    name: Test on Bun
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - name: Install Dependencies
+        run: bun install
+      - name: Test
+        run: bun test-unit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking
 
 ### Changed
-- Enable `bun.js` by catching `NotImplemented` error thrown in `perf_hooks.monitorEventLoopDelay`
+
+- Enable `bun.js` by catching `NotImplemented` error (Fixes [#570](https://github.com/siimon/prom-client/issues/570))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking
 
 ### Changed
+- Enable `bun.js` by catching `NotImplemented` error thrown in `perf_hooks.monitorEventLoopDelay`
 
 ### Added
 

--- a/lib/metrics/eventLoopLag.js
+++ b/lib/metrics/eventLoopLag.js
@@ -63,8 +63,12 @@ module.exports = (registry, config = {}) => {
 
 				histogram.reset();
 			};
-		} catch {
-			// bun has `perf_hooks.monitorEventLoopDelay` defined but throws "NotImplemented" when called
+		} catch (e) {
+			if (e.code === 'ERR_NOT_IMPLEMENTED') {
+				return; // Bun
+			}
+
+			throw e;
 		}
 	}
 

--- a/lib/metrics/eventLoopLag.js
+++ b/lib/metrics/eventLoopLag.js
@@ -37,32 +37,35 @@ module.exports = (registry, config = {}) => {
 	const labelNames = Object.keys(labels);
 	const registers = registry ? [registry] : undefined;
 
-	let collect;
-	if (!perf_hooks || !perf_hooks.monitorEventLoopDelay) {
-		collect = () => {
-			const start = process.hrtime();
-			setImmediate(reportEventloopLag, start, lag, labels);
-		};
-	} else {
-		const histogram = perf_hooks.monitorEventLoopDelay({
-			resolution: config.eventLoopMonitoringPrecision,
-		});
-		histogram.enable();
+	let collect = () => {
+		const start = process.hrtime();
+		setImmediate(reportEventloopLag, start, lag, labels);
+	};
 
-		collect = () => {
-			const start = process.hrtime();
-			setImmediate(reportEventloopLag, start, lag, labels);
+	if (perf_hooks && perf_hooks.monitorEventLoopDelay) {
+		try {
+			const histogram = perf_hooks.monitorEventLoopDelay({
+				resolution: config.eventLoopMonitoringPrecision,
+			});
+			histogram.enable();
 
-			lagMin.set(labels, histogram.min / 1e9);
-			lagMax.set(labels, histogram.max / 1e9);
-			lagMean.set(labels, histogram.mean / 1e9);
-			lagStddev.set(labels, histogram.stddev / 1e9);
-			lagP50.set(labels, histogram.percentile(50) / 1e9);
-			lagP90.set(labels, histogram.percentile(90) / 1e9);
-			lagP99.set(labels, histogram.percentile(99) / 1e9);
+			collect = () => {
+				const start = process.hrtime();
+				setImmediate(reportEventloopLag, start, lag, labels);
 
-			histogram.reset();
-		};
+				lagMin.set(labels, histogram.min / 1e9);
+				lagMax.set(labels, histogram.max / 1e9);
+				lagMean.set(labels, histogram.mean / 1e9);
+				lagStddev.set(labels, histogram.stddev / 1e9);
+				lagP50.set(labels, histogram.percentile(50) / 1e9);
+				lagP90.set(labels, histogram.percentile(90) / 1e9);
+				lagP99.set(labels, histogram.percentile(99) / 1e9);
+
+				histogram.reset();
+			};
+		} catch {
+			// bun has `perf_hooks.monitorEventLoopDelay` defined but throws "NotImplemented" when called
+		}
 	}
 
 	const lag = new Gauge({

--- a/lib/metrics/heapSpacesSizeAndUsed.js
+++ b/lib/metrics/heapSpacesSizeAndUsed.js
@@ -11,6 +11,11 @@ METRICS.forEach(metricType => {
 });
 
 module.exports = (registry, config = {}) => {
+	try {
+		v8.getHeapSpaceStatistics();
+	} catch {
+		return; // Bun
+	}
 	const registers = registry ? [registry] : undefined;
 	const namePrefix = config.prefix ? config.prefix : '';
 

--- a/lib/metrics/heapSpacesSizeAndUsed.js
+++ b/lib/metrics/heapSpacesSizeAndUsed.js
@@ -13,8 +13,11 @@ METRICS.forEach(metricType => {
 module.exports = (registry, config = {}) => {
 	try {
 		v8.getHeapSpaceStatistics();
-	} catch {
-		return; // Bun
+	} catch (e) {
+		if (e.code === 'ERR_NOT_IMPLEMENTED') {
+			return; // Bun
+		}
+		throw e;
 	}
 	const registers = registry ? [registry] : undefined;
 	const namePrefix = config.prefix ? config.prefix : '';


### PR DESCRIPTION
Catch [error thrown by bun.js](https://github.com/oven-sh/bun/blob/801e475c72b3573a91e0fb4c3afdd53b437770e1/src/js/node/perf_hooks.ts#L158) when calling `perf_hooks.monitorEventLoopDelay`

Following up on https://github.com/siimon/prom-client/pull/599 - bun.js already introduced some of the missing APIs (or created stubs) so to the best of my knowledge this is the last thing which is required to make default gc stats work for bun (at least it worked for me with this change).

Error is also reported in bun's repository - https://github.com/oven-sh/bun/issues/4708#issuecomment-2030436691

Fixes https://github.com/siimon/prom-client/issues/570
Closes https://github.com/siimon/prom-client/issues/623