### PR TITLE
fix: correctly get and set top level `contentType` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Enable `bun.js` by catching `NotImplemented` error (Fixes [#570](https://github.com/siimon/prom-client/issues/570))
+- Correctly read and set `contentType` top level export
 
 ### Added
+
+- Enable `bun.js` by catching `NotImplemented` error (Fixes [#570](https://github.com/siimon/prom-client/issues/570))
 
 [unreleased]: https://github.com/siimon/prom-client/compare/v15.1.0...HEAD
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -81,7 +81,7 @@ export class Registry<RegistryContentType = PrometheusContentType> {
 	/**
 	 * Gets the Content-Type of the metrics for use in the response headers.
 	 */
-	contentType: RegistryContentType;
+	readonly contentType: RegistryContentType;
 
 	/**
 	 * Set the content type of a registry. Used to change between Prometheus and

--- a/index.d.ts
+++ b/index.d.ts
@@ -104,8 +104,8 @@ export type Collector = () => void;
 export const register: Registry;
 
 /**
- * HTTP Content-Type for metrics response headers, defaults to Prometheus text
- * format.
+ * HTTP Content-Type for metrics response headers for the default registry,
+ * defaults to Prometheus text format.
  */
 export const contentType: RegistryContentType;
 

--- a/index.js
+++ b/index.js
@@ -17,10 +17,8 @@ Object.defineProperty(exports, 'contentType', {
 		exports.register.setContentType(value);
 	},
 });
-exports.prometheusContentType =
-	require('./lib/registry').PROMETHEUS_CONTENT_TYPE;
-exports.openMetricsContentType =
-	require('./lib/registry').OPENMETRICS_CONTENT_TYPE;
+exports.prometheusContentType = exports.Registry.PROMETHEUS_CONTENT_TYPE;
+exports.openMetricsContentType = exports.Registry.OPENMETRICS_CONTENT_TYPE;
 exports.validateMetricName = require('./lib/validation').validateMetricName;
 
 exports.Counter = require('./lib/counter');

--- a/index.js
+++ b/index.js
@@ -10,8 +10,10 @@ exports.Registry = require('./lib/registry');
 Object.defineProperty(exports, 'contentType', {
 	configurable: false,
 	enumerable: true,
-	get: () => exports.register.contentType,
-	set: value => {
+	get() {
+		return exports.register.contentType;
+	},
+	set(value) {
 		exports.register.setContentType(value);
 	},
 });

--- a/index.js
+++ b/index.js
@@ -7,7 +7,14 @@
 
 exports.register = require('./lib/registry').globalRegistry;
 exports.Registry = require('./lib/registry');
-exports.contentType = require('./lib/registry').globalRegistry.contentType;
+Object.defineProperty(exports, 'contentType', {
+	configurable: false,
+	enumerable: true,
+	get: () => exports.register.contentType,
+	set: value => {
+		exports.register.setContentType(value);
+	},
+});
 exports.prometheusContentType =
 	require('./lib/registry').PROMETHEUS_CONTENT_TYPE;
 exports.openMetricsContentType =


### PR DESCRIPTION
It currently just reads the default prop, and then no longer affect or reflect reality