### PR TITLE
Improve error message on labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Improve error message when number of registered labels mismatch with the number of labels provided
+
 ### Added
 
 [unreleased]: https://github.com/siimon/prom-client/compare/v15.1.2...HEAD

--- a/lib/util.js
+++ b/lib/util.js
@@ -54,7 +54,7 @@ exports.getLabels = function (labelNames, args) {
 
 	if (labelNames.length !== args.length) {
 		throw new Error(
-			`Invalid number of arguments: "${args.join()}" for label names: "${labelNames.join()}".`,
+			`Invalid number of arguments (${args.length}): "${args.join(', ')}" for label names (${labelNames.length}): "${labelNames.join(', ')}".`,
 		);
 	}
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -54,7 +54,7 @@ exports.getLabels = function (labelNames, args) {
 
 	if (labelNames.length !== args.length) {
 		throw new Error(
-			`Invalid number of arguments. Got ${args.join()}. Expected ${labelNames.join()}.`,
+			`Invalid number of arguments: "${args.join()}" for label names: "${labelNames.join()}".`,
 		);
 	}
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -53,7 +53,9 @@ exports.getLabels = function (labelNames, args) {
 	}
 
 	if (labelNames.length !== args.length) {
-		throw new Error('Invalid number of arguments');
+		throw new Error(
+			`Invalid number of arguments. Got ${args.join()}. Expected ${labelNames.join()}.`,
+		);
 	}
 
 	const acc = {};

--- a/lib/util.js
+++ b/lib/util.js
@@ -54,7 +54,9 @@ exports.getLabels = function (labelNames, args) {
 
 	if (labelNames.length !== args.length) {
 		throw new Error(
-			`Invalid number of arguments (${args.length}): "${args.join(', ')}" for label names (${labelNames.length}): "${labelNames.join(', ')}".`,
+			`Invalid number of arguments (${args.length}): "${args.join(
+				', ',
+			)}" for label names (${labelNames.length}): "${labelNames.join(', ')}".`,
 		);
 	}
 

--- a/test/__snapshots__/counterTest.js.snap
+++ b/test/__snapshots__/counterTest.js.snap
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`counter with OpenMetrics registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET" for label names: "method,endpoint"."`;
+exports[`counter with OpenMetrics registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments (1): "GET" for label names (2): "method, endpoint"."`;
 
-exports[`counter with OpenMetrics registry with params as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET" for label names: "method,endpoint"."`;
+exports[`counter with OpenMetrics registry with params as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments (1): "GET" for label names (2): "method, endpoint"."`;
 
 exports[`counter with OpenMetrics registry with params as object should not be possible to decrease a counter 1`] = `"It is not possible to decrease a counter"`;
 
 exports[`counter with OpenMetrics registry with params as object should throw an error when the value is not a number 1`] = `"Value is not a valid number: 3ms"`;
 
-exports[`counter with Prometheus registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET" for label names: "method,endpoint"."`;
+exports[`counter with Prometheus registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments (1): "GET" for label names (2): "method, endpoint"."`;
 
-exports[`counter with Prometheus registry with params as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET" for label names: "method,endpoint"."`;
+exports[`counter with Prometheus registry with params as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments (1): "GET" for label names (2): "method, endpoint"."`;
 
 exports[`counter with Prometheus registry with params as object should not be possible to decrease a counter 1`] = `"It is not possible to decrease a counter"`;
 

--- a/test/__snapshots__/counterTest.js.snap
+++ b/test/__snapshots__/counterTest.js.snap
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`counter with OpenMetrics registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`counter with OpenMetrics registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET" for label names: "method,endpoint"."`;
 
-exports[`counter with OpenMetrics registry with params as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`counter with OpenMetrics registry with params as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET" for label names: "method,endpoint"."`;
 
 exports[`counter with OpenMetrics registry with params as object should not be possible to decrease a counter 1`] = `"It is not possible to decrease a counter"`;
 
 exports[`counter with OpenMetrics registry with params as object should throw an error when the value is not a number 1`] = `"Value is not a valid number: 3ms"`;
 
-exports[`counter with Prometheus registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`counter with Prometheus registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET" for label names: "method,endpoint"."`;
 
-exports[`counter with Prometheus registry with params as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`counter with Prometheus registry with params as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET" for label names: "method,endpoint"."`;
 
 exports[`counter with Prometheus registry with params as object should not be possible to decrease a counter 1`] = `"It is not possible to decrease a counter"`;
 

--- a/test/__snapshots__/histogramTest.js.snap
+++ b/test/__snapshots__/histogramTest.js.snap
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`histogram with OpenMetrics registry with object as params with global registry labels should not allow different number of labels 1`] = `"Invalid number of arguments"`;
+exports[`histogram with OpenMetrics registry with object as params with global registry labels should not allow different number of labels 1`] = `"Invalid number of arguments: "get,500" for label names: "method"."`;
 
-exports[`histogram with OpenMetrics registry with object as params with global registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`histogram with OpenMetrics registry with object as params with global registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET,/foo" for label names: "method"."`;
 
 exports[`histogram with OpenMetrics registry with object as params with global registry should not allow le as a custom label 1`] = `"le is a reserved label keyword"`;
 
 exports[`histogram with OpenMetrics registry with object as params with global registry should not allow non numbers 1`] = `"Value is not a valid number: asd"`;
 
-exports[`histogram with Prometheus registry with object as params with global registry labels should not allow different number of labels 1`] = `"Invalid number of arguments"`;
+exports[`histogram with Prometheus registry with object as params with global registry labels should not allow different number of labels 1`] = `"Invalid number of arguments: "get,500" for label names: "method"."`;
 
-exports[`histogram with Prometheus registry with object as params with global registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`histogram with Prometheus registry with object as params with global registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET,/foo" for label names: "method"."`;
 
 exports[`histogram with Prometheus registry with object as params with global registry should not allow le as a custom label 1`] = `"le is a reserved label keyword"`;
 

--- a/test/__snapshots__/histogramTest.js.snap
+++ b/test/__snapshots__/histogramTest.js.snap
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`histogram with OpenMetrics registry with object as params with global registry labels should not allow different number of labels 1`] = `"Invalid number of arguments: "get,500" for label names: "method"."`;
+exports[`histogram with OpenMetrics registry with object as params with global registry labels should not allow different number of labels 1`] = `"Invalid number of arguments (2): "get, 500" for label names (1): "method"."`;
 
-exports[`histogram with OpenMetrics registry with object as params with global registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET,/foo" for label names: "method"."`;
+exports[`histogram with OpenMetrics registry with object as params with global registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments (2): "GET, /foo" for label names (1): "method"."`;
 
 exports[`histogram with OpenMetrics registry with object as params with global registry should not allow le as a custom label 1`] = `"le is a reserved label keyword"`;
 
 exports[`histogram with OpenMetrics registry with object as params with global registry should not allow non numbers 1`] = `"Value is not a valid number: asd"`;
 
-exports[`histogram with Prometheus registry with object as params with global registry labels should not allow different number of labels 1`] = `"Invalid number of arguments: "get,500" for label names: "method"."`;
+exports[`histogram with Prometheus registry with object as params with global registry labels should not allow different number of labels 1`] = `"Invalid number of arguments (2): "get, 500" for label names (1): "method"."`;
 
-exports[`histogram with Prometheus registry with object as params with global registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET,/foo" for label names: "method"."`;
+exports[`histogram with Prometheus registry with object as params with global registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments (2): "GET, /foo" for label names (1): "method"."`;
 
 exports[`histogram with Prometheus registry with object as params with global registry should not allow le as a custom label 1`] = `"le is a reserved label keyword"`;
 

--- a/test/__snapshots__/summaryTest.js.snap
+++ b/test/__snapshots__/summaryTest.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`summary with OpenMetrics registry global registry with param as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`summary with OpenMetrics registry global registry with param as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET" for label names: "method,endpoint"."`;
 
-exports[`summary with OpenMetrics registry global registry with param as object remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`summary with OpenMetrics registry global registry with param as object remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET" for label names: "method,endpoint"."`;
 
 exports[`summary with OpenMetrics registry global registry with param as object should validate labels when observing 1`] = `"Added label "baz" is not included in initial labelset: [ 'foo' ]"`;
 
-exports[`summary with Prometheus registry global registry with param as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`summary with Prometheus registry global registry with param as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET" for label names: "method,endpoint"."`;
 
-exports[`summary with Prometheus registry global registry with param as object remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`summary with Prometheus registry global registry with param as object remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET" for label names: "method,endpoint"."`;
 
 exports[`summary with Prometheus registry global registry with param as object should validate labels when observing 1`] = `"Added label "baz" is not included in initial labelset: [ 'foo' ]"`;

--- a/test/__snapshots__/summaryTest.js.snap
+++ b/test/__snapshots__/summaryTest.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`summary with OpenMetrics registry global registry with param as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET" for label names: "method,endpoint"."`;
+exports[`summary with OpenMetrics registry global registry with param as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments (1): "GET" for label names (2): "method, endpoint"."`;
 
-exports[`summary with OpenMetrics registry global registry with param as object remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET" for label names: "method,endpoint"."`;
+exports[`summary with OpenMetrics registry global registry with param as object remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments (1): "GET" for label names (2): "method, endpoint"."`;
 
 exports[`summary with OpenMetrics registry global registry with param as object should validate labels when observing 1`] = `"Added label "baz" is not included in initial labelset: [ 'foo' ]"`;
 
-exports[`summary with Prometheus registry global registry with param as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET" for label names: "method,endpoint"."`;
+exports[`summary with Prometheus registry global registry with param as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments (1): "GET" for label names (2): "method, endpoint"."`;
 
-exports[`summary with Prometheus registry global registry with param as object remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments: "GET" for label names: "method,endpoint"."`;
+exports[`summary with Prometheus registry global registry with param as object remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments (1): "GET" for label names (2): "method, endpoint"."`;
 
 exports[`summary with Prometheus registry global registry with param as object should validate labels when observing 1`] = `"Added label "baz" is not included in initial labelset: [ 'foo' ]"`;

--- a/test/utilTest.js
+++ b/test/utilTest.js
@@ -13,7 +13,7 @@ describe('utils', () => {
 			expect(() => {
 				getLabels(['label1', 'label2'], ['arg1']);
 			}).toThrowError(
-				'Invalid number of arguments: "arg1" for label names: "label1,label2".',
+				'Invalid number of arguments (1): "arg1" for label names (2): "label1, label2".',
 			);
 		});
 	});

--- a/test/utilTest.js
+++ b/test/utilTest.js
@@ -1,0 +1,20 @@
+'use strict';
+
+describe('utils', () => {
+	describe('getLabels', () => {
+		const getLabels = require('../lib/util').getLabels;
+
+		it('should not throw on missing argument', async () => {
+			const labels = getLabels(['label1', 'label2'], ['arg1', 'arg2']);
+			expect(labels).toEqual({ label1: 'arg1', label2: 'arg2' });
+		});
+
+		it('should throw on missing argument', async () => {
+			expect(() => {
+				getLabels(['label1', 'label2'], ['arg1']);
+			}).toThrowError(
+				'Invalid number of arguments: "arg1" for label names: "label1,label2".',
+			);
+		});
+	});
+});


### PR DESCRIPTION
This fix ensures consumers of the library get more insights into which labels are causing an error to occur. 

With the new error message it is easier for a developer to debug what happened in the case where you accidentally pass in a bad argument.

If `getLabels` gets called like this:
```js
getLabels(['label1', 'label2'], ['arg1']);
```
it used to throw...
```
Error: Invalid number of arguments
    at exports.getLabels 
```
now it throws this:
```
Error: Invalid number of arguments: "arg1" for label names: "label1,label2".
    at exports.getLabels 
```