### PR TITLE
chore(ci): run lint checks separately from tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,19 +16,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x, 21.x]
+        node-version: [16.x, 18.x, 20.x, 21.x, 22.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Restore dependencies cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache
         with:
           path: node_modules
@@ -39,12 +39,36 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm i
       - name: Test
-        run: npm run test
+        run: npm run test-unit
+  lint:
+    name: Run ESLint
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js LTS
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Restore dependencies cache
+        uses: actions/cache@v4
+        id: cache
+        with:
+          path: node_modules
+          key: ${{ matrix.os }}-${{ matrix.node-version }}-node_modules-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.node-version }}-node_modules-
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm i
+      - name: Test
+        run: npm run lint && npm run check-prettier && npm run compile-typescript
   bun:
     name: Test on Bun
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest


### PR DESCRIPTION
When there are lint failures, it's super noisy as all test runs fail (and they take longer than necessary). Splitting it out makes sense