### PR TITLE
chore: update prettier and husky

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,7 @@
 	"plugins": ["prettier"],
 	"extends": [
 		"eslint:recommended",
-		"plugin:node/recommended",
+		"plugin:n/recommended",
 		"plugin:prettier/recommended"
 	],
 	"env": {
@@ -78,7 +78,7 @@
 			"rules": {
 				"no-shadow": "off",
 				"@typescript-eslint/no-shadow": "warn",
-				"node/no-unsupported-features/es-syntax": "off"
+				"n/no-unsupported-features/es-syntax": "off"
 			}
 		},
 		{

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no-install lint-staged

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -14,6 +14,6 @@ benchmarks.suite('gauge', require('./gauge'));
 benchmarks.suite('summary', require('./summary'));
 benchmarks.run().catch(err => {
 	console.error(err.stack);
-	// eslint-disable-next-line no-process-exit
+	// eslint-disable-next-line n/no-process-exit
 	process.exit(1);
 });

--- a/lib/metrics/eventLoopLag.js
+++ b/lib/metrics/eventLoopLag.js
@@ -5,7 +5,6 @@ const Gauge = require('../gauge');
 // Check if perf_hooks module is available
 let perf_hooks;
 try {
-	/* eslint-disable node/no-unsupported-features/node-builtins */
 	perf_hooks = require('perf_hooks');
 } catch {
 	// node version is too old

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -47,7 +47,7 @@ class Pushgateway {
 }
 async function useGateway(method, job, groupings) {
 	// `URL` first added in v6.13.0
-	// eslint-disable-next-line node/no-deprecated-api
+	// eslint-disable-next-line n/no-deprecated-api
 	const gatewayUrlParsed = url.parse(this.gatewayUrl);
 	const gatewayUrlPath =
 		gatewayUrlParsed.pathname && gatewayUrlParsed.pathname !== '/'
@@ -58,9 +58,9 @@ async function useGateway(method, job, groupings) {
 		: '';
 	const path = `${gatewayUrlPath}/metrics${jobPath}`;
 
-	// eslint-disable-next-line node/no-deprecated-api
+	// eslint-disable-next-line n/no-deprecated-api
 	const target = url.resolve(this.gatewayUrl, path);
-	// eslint-disable-next-line node/no-deprecated-api
+	// eslint-disable-next-line n/no-deprecated-api
 	const requestParams = url.parse(target);
 	const httpModule = isHttps(requestParams.href) ? https : http;
 	const options = Object.assign(requestParams, this.requestOptions, {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@typescript-eslint/parser": "^6.21.0",
 		"eslint": "^8.32.0",
 		"eslint-config-prettier": "^9.1.0",
-		"eslint-plugin-node": "^11.0.0",
+		"eslint-plugin-n": "^16.0.0",
 		"eslint-plugin-prettier": "^5.0.1",
 		"express": "^4.13.3",
 		"husky": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 		"test-unit": "jest",
 		"run-prettier": "prettier . .eslintrc",
 		"check-prettier": "npm run run-prettier -- --check",
-		"compile-typescript": "tsc --project ."
+		"compile-typescript": "tsc --project .",
+		"prepare": "husky"
 	},
 	"repository": {
 		"type": "git",
@@ -41,11 +42,11 @@
 		"eslint-plugin-node": "^11.0.0",
 		"eslint-plugin-prettier": "^5.0.1",
 		"express": "^4.13.3",
-		"husky": "^8.0.3",
+		"husky": "^9.0.0",
 		"jest": "^29.3.1",
 		"lint-staged": "^13.1.0",
 		"nock": "^13.0.5",
-		"prettier": "3.1.1",
+		"prettier": "3.3.2",
 		"typescript": "^5.0.4"
 	},
 	"dependencies": {
@@ -58,9 +59,9 @@
 		"testRegex": ".*Test\\.js$"
 	},
 	"lint-staged": {
-		"*.js": "eslint --fix",
-		"*.{ts,md,json,yml}": "prettier --write",
-		".{eslintrc,travis.yml}": "prettier --write"
+		"*.{js,ts}": "eslint --fix",
+		"*.{md,json,yml}": "prettier --write",
+		".travis.yml": "prettier --write"
 	},
 	"prettier": {
 		"singleQuote": true,


### PR DESCRIPTION
Why not

Also migrates from `eslint-plugin-node` to `eslint-plugin-n` as the former is unmaintained and replaced