### PR TITLE
fix: avoid duplicate buckets in histogram

### DIFF
--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -32,7 +32,7 @@ class Histogram extends Metric {
 			}
 		}
 
-		this.upperBounds = this.buckets;
+		this.upperBounds = [...new Set(this.buckets)];
 		this.bucketValues = this.upperBounds.reduce((acc, upperBound) => {
 			acc[upperBound] = 0;
 			return acc;

--- a/test/histogramTest.js
+++ b/test/histogramTest.js
@@ -92,6 +92,20 @@ describe.each([
 				expect(values[1].labels.le).toEqual(5);
 				expect(values[2].labels.le).toEqual('+Inf');
 			});
+
+			it('should not have repeated LE buckets', async () => {
+				const histogram = new Histogram({
+					name: 'test_histogram_2',
+					help: 'test',
+					buckets: [1, 1, 5],
+				});
+				histogram.observe(6);
+				const values = (await histogram.get()).values;
+				expect(values[0].labels.le).toEqual(1);
+				expect(values[1].labels.le).toEqual(5);
+				expect(values[2].labels.le).toEqual('+Inf');
+			});
+
 			it('should group counts on each label set', async () => {
 				const histogram = new Histogram({
 					name: 'test_histogram_2',


### PR DESCRIPTION
Hello,

this is an user-introduced bug that drove me crazy debugging Prometheus itself.

prom-client allows you to define the same LE bucket label multiple times. This leads to wrong values and makes the histograms useless.

With this commit I remove the possible duplicates before setting the buckets to the upperBounds. Also included an unit  test.