### PR TITLE
feat: allow specifying timeout for cluster metrics aggregation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -137,6 +137,7 @@ export class AggregatorRegistry<
 	/**
 	 * Gets aggregated metrics for all workers.
 	 * @param {ClusterMetricsOptions|undefined} options Additional options for cluster metrics aggregation
+	 * @param {number} [options.timeoutMs=5000] Timeout to wait for all workers to respond before error.
 	 * @return {Promise<string>} Promise that resolves with the aggregated
 	 * metrics.
 	 */
@@ -194,6 +195,7 @@ export enum MetricType {
 }
 
 export type ClusterMetricsOptions = {
+	/** Timeout to wait for all workers to respond before error. */
 	timeoutMs?: number;
 };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -136,10 +136,11 @@ export class AggregatorRegistry<
 > extends Registry<T> {
 	/**
 	 * Gets aggregated metrics for all workers.
+	 * @param {ClusterMetricsOptions|undefined} options Additional options for cluster metrics aggregation
 	 * @return {Promise<string>} Promise that resolves with the aggregated
 	 * metrics.
 	 */
-	clusterMetrics(): Promise<string>;
+	clusterMetrics(options?: ClusterMetricsOptions): Promise<string>;
 
 	/**
 	 * Creates a new Registry instance from an array of metrics that were
@@ -191,6 +192,10 @@ export enum MetricType {
 	Histogram,
 	Summary,
 }
+
+export type ClusterMetricsOptions = {
+	timeoutMs?: number;
+};
 
 type CollectFunction<T> = (this: T) => void | Promise<void>;
 

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -36,10 +36,11 @@ class AggregatorRegistry extends Registry {
 	/**
 	 * Gets aggregated metrics for all workers. The optional callback and
 	 * returned Promise resolve with the same value; either may be used.
+	 * @param {ClusterMetricsOptions|undefined} options Additional options for cluster metrics aggregation.
 	 * @return {Promise<string>} Promise that resolves with the aggregated
 	 *   metrics.
 	 */
-	clusterMetrics() {
+	clusterMetrics(options = { timeoutMs: 5000 }) {
 		const requestId = requestCtr++;
 
 		return new Promise((resolve, reject) => {
@@ -58,7 +59,7 @@ class AggregatorRegistry extends Registry {
 				errorTimeout: setTimeout(() => {
 					const err = new Error('Operation timed out.');
 					request.done(err);
-				}, 5000),
+				}, options.timeoutMs || 5000),
 			};
 			requests.set(requestId, request);
 

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -37,6 +37,7 @@ class AggregatorRegistry extends Registry {
 	 * Gets aggregated metrics for all workers. The optional callback and
 	 * returned Promise resolve with the same value; either may be used.
 	 * @param {ClusterMetricsOptions|undefined} options Additional options for cluster metrics aggregation.
+	 * @param {number} [options.timeoutMs=5000] Timeout to wait for all workers to respond before error.
 	 * @return {Promise<string>} Promise that resolves with the aggregated
 	 *   metrics.
 	 */


### PR DESCRIPTION
Adds ability to specify cluster metrics aggregation timeout.

Overriding hard-coded timeout as a workaround for #628 where scraping in larger projects end up in a timeout most of the time.