### PR TITLE
feat: update default type for metrics to `NoLabelNameType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Improve types for no lables
+
 ### Added
 
 [unreleased]: https://github.com/siimon/prom-client/compare/v15.1.3...HEAD

--- a/index.d.ts
+++ b/index.d.ts
@@ -171,7 +171,7 @@ export class AggregatorRegistry<
 	): void;
 }
 
-type NoLabelNameType = never
+type NoLabelNameType = never;
 
 /**
  * General metric type
@@ -219,8 +219,8 @@ type MetricValueWithName<T extends string> = MetricValue<T> & {
 };
 
 type LabelValues<T extends string> = T extends NoLabelNameType
-  ? Partial<Record<string, never>>
-  : Partial<Record<T, string | number>>
+	? Partial<Record<string, never>>
+	: Partial<Record<T, string | number>>;
 
 interface MetricConfiguration<T extends string> {
 	name: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -171,10 +171,12 @@ export class AggregatorRegistry<
 	): void;
 }
 
+type NoLabelNameType = never
+
 /**
  * General metric type
  */
-export type Metric<T extends string = string> =
+export type Metric<T extends string = NoLabelNameType> =
 	| Counter<T>
 	| Gauge<T>
 	| Summary<T>
@@ -216,7 +218,9 @@ type MetricValueWithName<T extends string> = MetricValue<T> & {
 	metricName?: string;
 };
 
-type LabelValues<T extends string> = Partial<Record<T, string | number>>;
+type LabelValues<T extends string> = T extends NoLabelNameType
+  ? Partial<Record<string, never>>
+  : Partial<Record<T, string | number>>
 
 interface MetricConfiguration<T extends string> {
 	name: string;
@@ -251,7 +255,7 @@ export interface ObserveDataWithExemplar<T extends string> {
 /**
  * A counter is a cumulative metric that represents a single numerical value that only ever goes up
  */
-export class Counter<T extends string = string> {
+export class Counter<T extends string = NoLabelNameType> {
 	/**
 	 * @param configuration Configuration when creating a Counter metric. Name and Help is required.
 	 */
@@ -331,7 +335,7 @@ export interface GaugeConfiguration<T extends string>
 /**
  * A gauge is a metric that represents a single numerical value that can arbitrarily go up and down.
  */
-export class Gauge<T extends string = string> {
+export class Gauge<T extends string = NoLabelNameType> {
 	/**
 	 * @param configuration Configuration when creating a Gauge metric. Name and Help is mandatory
 	 */
@@ -472,7 +476,7 @@ export interface HistogramConfiguration<T extends string>
 /**
  * A histogram samples observations (usually things like request durations or response sizes) and counts them in configurable buckets
  */
-export class Histogram<T extends string = string> {
+export class Histogram<T extends string = NoLabelNameType> {
 	/**
 	 * @param configuration Configuration when creating the Histogram. Name and Help is mandatory
 	 */
@@ -599,7 +603,7 @@ export interface SummaryConfiguration<T extends string>
 /**
  * A summary samples observations
  */
-export class Summary<T extends string = string> {
+export class Summary<T extends string = NoLabelNameType> {
 	/**
 	 * @param configuration Configuration when creating Summary metric. Name and Help is mandatory
 	 */


### PR DESCRIPTION
## Purpose

Consider the following code:

```ts
const histogram = new Histogram({
  name: 'example',
  help: 'Example',
  buckets: [0, 1, 4],
})

const timer = histogram.startTimer()
timer({ 'should_not_pass_because_there_is_no_label_name_defined': 'oops' })
```

This example passes the type checker because `Histogram<T>`'s `T` inferred by `TypeScript` is `string`, which allows `timer` to accept any `Record<string, string | number>` when there's no label defined.

## Changes in this PR

The generic `Metric<T extends string>` type now defaults its label name generic `T` to `NoLabelNameType`. This provides better type inference for metrics that do not have labels.