### PR TITLE
perf: Utilize Maps for metric collection 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,15 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking
 
 - Drop support for Node.js versions 16, 18, 21 and 23
+- Metric internal storage ('hashMap') changed to Map from Object. If you have
+  subclassed the built-in metric types you may need to adjust your code.
 
 ### Changed
 
-- Improve types for no lables
+- Improve types for no labels
+- Faster stats gathering with lower memory overhead
 
 ### Added
-
-[unreleased]: https://github.com/siimon/prom-client/compare/v15.1.3...HEAD
 
 ## [15.1.3] - 2024-06-27
 

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -85,13 +85,15 @@ class Counter extends Metric {
 
 	updateExemplar(exemplarLabels, value, hash) {
 		if (exemplarLabels === this.defaultExemplarLabelSet) return;
-		if (!isObject(this.hashMap[hash].exemplar)) {
-			this.hashMap[hash].exemplar = new Exemplar();
+
+		const entry = this.hashMap.get(hash);
+		if (!isObject(entry.exemplar)) {
+			entry.exemplar = new Exemplar();
 		}
-		this.hashMap[hash].exemplar.validateExemplarLabelSet(exemplarLabels);
-		this.hashMap[hash].exemplar.labelSet = exemplarLabels;
-		this.hashMap[hash].exemplar.value = value ? value : 1;
-		this.hashMap[hash].exemplar.timestamp = nowTimestamp();
+		entry.exemplar.validateExemplarLabelSet(exemplarLabels);
+		entry.exemplar.labelSet = exemplarLabels;
+		entry.exemplar.value = value ? value : 1;
+		entry.exemplar.timestamp = nowTimestamp();
 	}
 
 	/**
@@ -99,7 +101,7 @@ class Counter extends Metric {
 	 * @returns {void}
 	 */
 	reset() {
-		this.hashMap = {};
+		this.hashMap = new Map();
 		if (this.labelNames.length === 0) {
 			setValue(this.hashMap, 0);
 		}
@@ -115,7 +117,7 @@ class Counter extends Metric {
 			help: this.help,
 			name: this.name,
 			type: this.type,
-			values: Object.values(this.hashMap),
+			values: Array.from(this.hashMap.values()),
 			aggregator: this.aggregator,
 		};
 	}
@@ -135,10 +137,10 @@ class Counter extends Metric {
 }
 
 function setValue(hashMap, value, labels = {}, hash = '') {
-	if (hashMap[hash]) {
-		hashMap[hash].value += value;
+	if (hashMap.get(hash)) {
+		hashMap.get(hash).value += value;
 	} else {
-		hashMap[hash] = { value, labels };
+		hashMap.set(hash, { value, labels });
 	}
 	return hashMap;
 }

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -39,7 +39,7 @@ class Gauge extends Metric {
 	 * @returns {void}
 	 */
 	reset() {
-		this.hashMap = {};
+		this.hashMap = new Map();
 		if (this.labelNames.length === 0) {
 			setValue(this.hashMap, 0, {});
 		}
@@ -114,14 +114,14 @@ class Gauge extends Metric {
 			help: this.help,
 			name: this.name,
 			type: this.type,
-			values: Object.values(this.hashMap),
+			values: Array.from(this.hashMap.values()),
 			aggregator: this.aggregator,
 		};
 	}
 
 	_getValue(labels) {
 		const hash = hashObject(labels || {}, this.sortedLabelNames);
-		return this.hashMap[hash] ? this.hashMap[hash].value : 0;
+		return this.hashMap.get(hash) ? this.hashMap.get(hash).value : 0;
 	}
 
 	labels(...args) {

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -244,6 +244,8 @@ function observe(labels) {
 				this.bucketValues,
 				this.bucketExemplars,
 			);
+
+			this.hashMap.set(hash, valueFromMap);
 		}
 
 		const b = findBound(this.upperBounds, labelValuePair.value);
@@ -254,8 +256,6 @@ function observe(labels) {
 		if (Object.prototype.hasOwnProperty.call(valueFromMap.bucketValues, b)) {
 			valueFromMap.bucketValues[b] += 1;
 		}
-
-		this.hashMap.set(hash, valueFromMap);
 	};
 }
 

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -54,13 +54,11 @@ class Histogram extends Metric {
 		Object.freeze(this.upperBounds);
 
 		if (this.labelNames.length === 0) {
-			this.hashMap = {
-				[hashObject({})]: createBaseValues(
-					{},
-					this.bucketValues,
-					this.bucketExemplars,
-				),
-			};
+			this.hashMap = new Map();
+			this.hashMap.set(
+				hashObject({}),
+				createBaseValues({}, this.bucketValues, this.bucketExemplars),
+			);
 		}
 	}
 
@@ -87,7 +85,7 @@ class Histogram extends Metric {
 		if (Object.keys(exemplarLabels).length === 0) return;
 		const hash = hashObject(labels, this.sortedLabelNames);
 		const bound = findBound(this.upperBounds, value);
-		const { bucketExemplars } = this.hashMap[hash];
+		const { bucketExemplars } = this.hashMap.get(hash);
 		let exemplar = bucketExemplars[bound];
 		if (!isObject(exemplar)) {
 			exemplar = new Exemplar();
@@ -110,7 +108,7 @@ class Histogram extends Metric {
 			const v = this.collect();
 			if (v instanceof Promise) await v;
 		}
-		const data = Object.values(this.hashMap);
+		const data = Array.from(this.hashMap.values());
 		const values = data
 			.map(extractBucketValuesForExport(this))
 			.reduce(addSumAndCountForExport(this), []);
@@ -125,7 +123,7 @@ class Histogram extends Metric {
 	}
 
 	reset() {
-		this.hashMap = {};
+		this.hashMap = new Map();
 	}
 
 	/**
@@ -135,10 +133,9 @@ class Histogram extends Metric {
 	 */
 	zero(labels) {
 		const hash = hashObject(labels, this.sortedLabelNames);
-		this.hashMap[hash] = createBaseValues(
-			labels,
-			this.bucketValues,
-			this.bucketExemplars,
+		this.hashMap.set(
+			hash,
+			createBaseValues(labels, this.bucketValues, this.bucketExemplars),
 		);
 	}
 
@@ -240,7 +237,7 @@ function observe(labels) {
 		}
 
 		const hash = hashObject(labelValuePair.labels, this.sortedLabelNames);
-		let valueFromMap = this.hashMap[hash];
+		let valueFromMap = this.hashMap.get(hash);
 		if (!valueFromMap) {
 			valueFromMap = createBaseValues(
 				labelValuePair.labels,
@@ -258,7 +255,7 @@ function observe(labels) {
 			valueFromMap.bucketValues[b] += 1;
 		}
 
-		this.hashMap[hash] = valueFromMap;
+		this.hashMap.set(hash, valueFromMap);
 	};
 }
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -12,7 +12,7 @@ class Registry {
 	}
 
 	constructor(regContentType = Registry.PROMETHEUS_CONTENT_TYPE) {
-		this._metrics = {};
+		this._metrics = new Map();
 		this._collectors = [];
 		this._defaultLabels = {};
 		if (
@@ -24,8 +24,14 @@ class Registry {
 		this._contentType = regContentType;
 	}
 
+	/**
+	 * Return all metrics
+	 *
+	 * @returns {object[]}
+	 */
+
 	getMetricsAsArray() {
-		return Object.values(this._metrics);
+		return Array.from(this._metrics.values());
 	}
 
 	async getMetricsAsString(metrics) {
@@ -99,17 +105,20 @@ class Registry {
 	}
 
 	registerMetric(metric) {
-		if (this._metrics[metric.name] && this._metrics[metric.name] !== metric) {
+		if (
+			this._metrics.has(metric.name) &&
+			this._metrics.get(metric.name) !== metric
+		) {
 			throw new Error(
 				`A metric with the name ${metric.name} has already been registered.`,
 			);
 		}
 
-		this._metrics[metric.name] = metric;
+		this._metrics.set(metric.name, metric);
 	}
 
 	clear() {
-		this._metrics = {};
+		this._metrics = new Map();
 		this._defaultLabels = {};
 	}
 
@@ -145,15 +154,15 @@ class Registry {
 	}
 
 	removeSingleMetric(name) {
-		delete this._metrics[name];
+		this._metrics.delete(name);
 	}
 
 	getSingleMetricAsString(name) {
-		return this.getMetricsAsString(this._metrics[name]);
+		return this.getMetricsAsString(this._metrics.get(name));
 	}
 
 	getSingleMetric(name) {
-		return this._metrics[name];
+		return this._metrics.get(name);
 	}
 
 	setDefaultLabels(labels) {
@@ -161,8 +170,8 @@ class Registry {
 	}
 
 	resetMetrics() {
-		for (const metric in this._metrics) {
-			this._metrics[metric].reset();
+		for (const metric of this._metrics.values()) {
+			metric.reset();
 		}
 	}
 

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -177,6 +177,8 @@ function observe(labels) {
 				count: 0,
 				sum: 0,
 			};
+
+			this.hashMap.set(hash, summaryOfLabel);
 		}
 
 		summaryOfLabel.td.push(labelValuePair.value);
@@ -185,7 +187,6 @@ function observe(labels) {
 			summaryOfLabel.td.compress();
 		}
 		summaryOfLabel.sum += labelValuePair.value;
-		this.hashMap.set(hash, summaryOfLabel);
 	};
 }
 

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -16,7 +16,7 @@ class Summary extends Metric {
 		super(config, {
 			percentiles: [0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999],
 			compressCount: DEFAULT_COMPRESS_COUNT,
-			hashMap: {},
+			hashMap: new Map(),
 		});
 
 		this.type = 'summary';
@@ -27,14 +27,13 @@ class Summary extends Metric {
 		}
 
 		if (this.labelNames.length === 0) {
-			this.hashMap = {
-				[hashObject({})]: {
-					labels: {},
-					td: new timeWindowQuantiles(this.maxAgeSeconds, this.ageBuckets),
-					count: 0,
-					sum: 0,
-				},
-			};
+			this.hashmap = new Map();
+			this.hashMap.set(hashObject({}), {
+				labels: {},
+				td: new timeWindowQuantiles(this.maxAgeSeconds, this.ageBuckets),
+				count: 0,
+				sum: 0,
+			});
 		}
 	}
 
@@ -53,14 +52,14 @@ class Summary extends Metric {
 			const v = this.collect();
 			if (v instanceof Promise) await v;
 		}
-		const hashKeys = Object.keys(this.hashMap);
+		const hashKeys = this.hashMap.keys();
 		const values = [];
 
-		hashKeys.forEach(hashKey => {
-			const s = this.hashMap[hashKey];
+		for (const hashKey of hashKeys) {
+			const s = this.hashMap.get(hashKey);
 			if (s) {
 				if (this.pruneAgedBuckets && s.td.size() === 0) {
-					delete this.hashMap[hashKey];
+					this.hashMap.delete(hashKey);
 				} else {
 					extractSummariesForExport(s, this.percentiles).forEach(v => {
 						values.push(v);
@@ -69,7 +68,7 @@ class Summary extends Metric {
 					values.push(getCountForExport(s, this));
 				}
 			}
-		});
+		}
 
 		return {
 			name: this.name,
@@ -81,12 +80,11 @@ class Summary extends Metric {
 	}
 
 	reset() {
-		const data = Object.values(this.hashMap);
-		data.forEach(s => {
+		for (const s of this.hashMap.values()) {
 			s.td.reset();
 			s.count = 0;
 			s.sum = 0;
-		});
+		}
 	}
 
 	/**
@@ -171,7 +169,7 @@ function observe(labels) {
 		}
 
 		const hash = hashObject(labelValuePair.labels, this.sortedLabelNames);
-		let summaryOfLabel = this.hashMap[hash];
+		let summaryOfLabel = this.hashMap.get(hash);
 		if (!summaryOfLabel) {
 			summaryOfLabel = {
 				labels: labelValuePair.labels,
@@ -187,7 +185,7 @@ function observe(labels) {
 			summaryOfLabel.td.compress();
 		}
 		summaryOfLabel.sum += labelValuePair.value;
-		this.hashMap[hash] = summaryOfLabel;
+		this.hashMap.set(hash, summaryOfLabel);
 	};
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -14,24 +14,42 @@ exports.getValueAsString = function getValueString(value) {
 	}
 };
 
+/**
+ * @function removeLabels
+ * @param {Map} hashMap
+ * @param {string[]} labels
+ * @param {string[]} sortedLabelNames
+ */
 exports.removeLabels = function removeLabels(
 	hashMap,
 	labels,
 	sortedLabelNames,
 ) {
-	const hash = hashObject(labels, sortedLabelNames);
-	delete hashMap[hash];
+	hashMap.delete(hashObject(labels, sortedLabelNames));
 };
 
+/**
+ * @function setValue
+ * @param {Map} hashMap
+ * @param {*} value
+ * @param {object} labels
+ */
 exports.setValue = function setValue(hashMap, value, labels) {
 	const hash = hashObject(labels);
-	hashMap[hash] = {
+	hashMap.set(hash, {
 		value: typeof value === 'number' ? value : 0,
 		labels: labels || {},
-	};
+	});
 	return hashMap;
 };
 
+/**
+ * @function setValueDelta
+ * @param {Map} hashMap
+ * @param {*} deltaValue
+ * @param {object} labels
+ * @returns {Map}
+ */
 exports.setValueDelta = function setValueDelta(
 	hashMap,
 	deltaValue,
@@ -39,14 +57,19 @@ exports.setValueDelta = function setValueDelta(
 	hash = '',
 ) {
 	const value = typeof deltaValue === 'number' ? deltaValue : 0;
-	if (hashMap[hash]) {
-		hashMap[hash].value += value;
+	if (hashMap.get(hash)) {
+		hashMap.get(hash).value += value;
 	} else {
-		hashMap[hash] = { value, labels };
+		hashMap.set(hash, { value, labels });
 	}
 	return hashMap;
 };
 
+/**
+ * @param {string[]} labelNames
+ * @param {any[]} args
+ * @returns {object}
+ */
 exports.getLabels = function (labelNames, args) {
 	if (typeof args[0] === 'object') {
 		return args[0];


### PR DESCRIPTION
As of sometime around the middle of Node 16, the performance of Map for long-lived, mutable objects exceeded that of {}. I believe this gap is more pronounced in Node 18 as well.

The deal is that the representation for Objects that repeatedly change turns into a weird chain that occupies (in my benchmarks at least) ~40% more memory. So once v8 made Map.set/get faster than map[], we all should have switched to Maps and Sets.

Between the slightly faster functions and the lower memory pressure this can create a notable improvement.

Making a change like this on my last project for a long lived cache resulted in much better memory behavior and also about a 5% improvement in TTFB - just from changing a popular lookup table.

Note that the final change in this PR constitutes a change for anyone making their own subclasses, and therefore is probably breaking. Let me know if you want me to split this into two PRs, but that's where the bulk of the changes show up. The Registry just doesn't change frequently enough.

```
✓ registry ➭ getMetricsAsJSON#1 with 64 is 736.6% faster.
✓ registry ➭ getMetricsAsJSON#2 with 8 is 753.0% faster.
✓ registry ➭ getMetricsAsJSON#2 with 4 and 2 with 2 is 416.9% faster.
✓ registry ➭ getMetricsAsJSON#2 with 2 and 2 with 4 is 2829% faster.
✓ registry ➭ getMetricsAsJSON#6 with 2 is 956.4% faster.
✓ registry ➭ metrics#1 with 64 is 440.3% faster.
✓ registry ➭ metrics#2 with 8 is 1283% faster.
✓ registry ➭ metrics#2 with 4 and 2 with 2 is 1282% faster.
✓ registry ➭ metrics#2 with 2 and 2 with 4 is 1512% faster.
✓ registry ➭ metrics#6 with 2 is 107.3% faster.
```
