### PR TITLE
Reduce function indirection in histogram.js for easier debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Improve types for no labels
 - Faster stats gathering with lower memory overhead
 - Simplified number format logic
+- Simplified Histogram.observe() call stack
 
 ### Added
 

--- a/benchmarks/histogram.js
+++ b/benchmarks/histogram.js
@@ -45,6 +45,47 @@ function setupHistogramSuite(suite) {
 		),
 		{ teardown, setup: setup(6) },
 	);
+
+	suite.add(
+		'startTimer#1 with 64',
+		labelCombinationFactory([64], (client, { histogram }, labels) =>
+			histogram.startTimer(labels, 1)({}),
+		),
+		{ teardown, setup: setup(1) },
+	);
+
+	suite.add(
+		'startTimer#2 with 8',
+		labelCombinationFactory([8, 8], (client, { histogram }, labels) =>
+			histogram.startTimer(labels, 1)({}),
+		),
+		{ teardown, setup: setup(2) },
+	);
+
+	suite.add(
+		'startTimer#2 with 4 and 2 with 2',
+		labelCombinationFactory([4, 4, 2, 2], (client, { histogram }, labels) =>
+			histogram.startTimer(labels, 1)({}),
+		),
+		{ teardown, setup: setup(4) },
+	);
+
+	suite.add(
+		'startTimer#2 with 2 and 2 with 4',
+		labelCombinationFactory([2, 2, 4, 4], (client, { histogram }, labels) =>
+			histogram.startTimer(labels, 1)({}),
+		),
+		{ teardown, setup: setup(4) },
+	);
+
+	suite.add(
+		'startTimer#6 with 2',
+		labelCombinationFactory(
+			[2, 2, 2, 2, 2, 2],
+			(client, { histogram }, labels) => histogram.startTimer(labels, 1)({}),
+		),
+		{ teardown, setup: setup(6) },
+	);
 }
 
 function setup(labelCount) {

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -69,7 +69,7 @@ class Histogram extends Metric {
 	 * @returns {void}
 	 */
 	observeWithoutExemplar(labels, value) {
-		observe.call(this, labels === 0 ? 0 : labels || {})(value);
+		observe(this, labels === 0 ? 0 : labels || {}, value);
 	}
 
 	observeWithExemplar({
@@ -77,7 +77,7 @@ class Histogram extends Metric {
 		value,
 		exemplarLabels = this.defaultExemplarLabelSet,
 	} = {}) {
-		observe.call(this, labels === 0 ? 0 : labels || {})(value);
+		observe(this, labels === 0 ? 0 : labels || {}, value);
 		this.updateExemplar(labels, value, exemplarLabels);
 	}
 
@@ -153,16 +153,16 @@ class Histogram extends Metric {
 	 */
 	startTimer(labels, exemplarLabels) {
 		return this.enableExemplars
-			? startTimerWithExemplar.call(this, labels, exemplarLabels)()
-			: startTimer.call(this, labels)();
+			? startTimerWithExemplar(this, labels, exemplarLabels)
+			: startTimer(this, labels);
 	}
 
 	labels(...args) {
 		const labels = getLabels(this.labelNames, args);
 		validateLabel(this.labelNames, labels);
 		return {
-			observe: observe.call(this, labels),
-			startTimer: startTimer.call(this, labels),
+			observe: value => observe(this, labels, value),
+			startTimer: () => startTimer(this, labels),
 		};
 	}
 
@@ -173,35 +173,27 @@ class Histogram extends Metric {
 	}
 }
 
-function startTimer(startLabels) {
-	return () => {
-		const start = process.hrtime();
-		return endLabels => {
-			const delta = process.hrtime(start);
-			const value = delta[0] + delta[1] / 1e9;
-			this.observe(Object.assign({}, startLabels, endLabels), value);
-			return value;
-		};
+function startTimer(histogram, startLabels) {
+	const start = process.hrtime();
+	return endLabels => {
+		const delta = process.hrtime(start);
+		const value = delta[0] + delta[1] / 1e9;
+		histogram.observe(Object.assign({}, startLabels, endLabels), value);
+		return value;
 	};
 }
 
-function startTimerWithExemplar(startLabels, startExemplarLabels) {
-	return () => {
-		const start = process.hrtime();
-		return (endLabels, endExemplarLabels) => {
-			const delta = process.hrtime(start);
-			const value = delta[0] + delta[1] / 1e9;
-			this.observe({
-				labels: Object.assign({}, startLabels, endLabels),
-				value,
-				exemplarLabels: Object.assign(
-					{},
-					startExemplarLabels,
-					endExemplarLabels,
-				),
-			});
-			return value;
-		};
+function startTimerWithExemplar(histogram, startLabels, startExemplarLabels) {
+	const start = process.hrtime();
+	return (endLabels, endExemplarLabels) => {
+		const delta = process.hrtime(start);
+		const value = delta[0] + delta[1] / 1e9;
+		histogram.observe({
+			labels: Object.assign({}, startLabels, endLabels),
+			value,
+			exemplarLabels: Object.assign({}, startExemplarLabels, endExemplarLabels),
+		});
+		return value;
 	};
 }
 
@@ -225,38 +217,41 @@ function findBound(upperBounds, value) {
 	return -1;
 }
 
-function observe(labels) {
-	return value => {
-		const labelValuePair = convertLabelsAndValues(labels, value);
+/**
+ * @param {Histogram} histogram
+ * @param {object} labels - Object with labels where key is the label key and value is label value. Can only be one level deep
+ * @param {number} value - Value to observe in the histogram
+ */
+function observe(histogram, labels, value) {
+	const labelValuePair = convertLabelsAndValues(labels, value);
 
-		validateLabel(this.labelNames, labelValuePair.labels);
-		if (!Number.isFinite(labelValuePair.value)) {
-			throw new TypeError(
-				`Value is not a valid number: ${util.format(labelValuePair.value)}`,
-			);
-		}
+	validateLabel(histogram.labelNames, labelValuePair.labels);
+	if (!Number.isFinite(labelValuePair.value)) {
+		throw new TypeError(
+			`Value is not a valid number: ${util.format(labelValuePair.value)}`,
+		);
+	}
 
-		const hash = hashObject(labelValuePair.labels, this.sortedLabelNames);
-		let valueFromMap = this.hashMap.get(hash);
-		if (!valueFromMap) {
-			valueFromMap = createBaseValues(
-				labelValuePair.labels,
-				this.bucketValues,
-				this.bucketExemplars,
-			);
+	const hash = hashObject(labelValuePair.labels, histogram.sortedLabelNames);
+	let valueFromMap = histogram.hashMap.get(hash);
+	if (!valueFromMap) {
+		valueFromMap = createBaseValues(
+			labelValuePair.labels,
+			histogram.bucketValues,
+			histogram.bucketExemplars,
+		);
 
-			this.hashMap.set(hash, valueFromMap);
-		}
+		histogram.hashMap.set(hash, valueFromMap);
+	}
 
-		const b = findBound(this.upperBounds, labelValuePair.value);
+	const b = findBound(histogram.upperBounds, labelValuePair.value);
 
-		valueFromMap.sum += labelValuePair.value;
-		valueFromMap.count += 1;
+	valueFromMap.sum += labelValuePair.value;
+	valueFromMap.count += 1;
 
-		if (Object.hasOwn(valueFromMap.bucketValues, b)) {
-			valueFromMap.bucketValues[b] += 1;
-		}
-	};
+	if (Object.hasOwn(valueFromMap.bucketValues, b)) {
+		valueFromMap.bucketValues[b] += 1;
+	}
 }
 
 function createBaseValues(labels, bucketValues, bucketExemplars) {
@@ -279,8 +274,8 @@ function convertLabelsAndValues(labels, value) {
 				value,
 			}
 		: {
-				value: labels,
 				labels: {},
+				value: labels,
 			};
 }
 

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -253,7 +253,7 @@ function observe(labels) {
 		valueFromMap.sum += labelValuePair.value;
 		valueFromMap.count += 1;
 
-		if (Object.prototype.hasOwnProperty.call(valueFromMap.bucketValues, b)) {
+		if (Object.hasOwn(valueFromMap.bucketValues, b)) {
 			valueFromMap.bucketValues[b] += 1;
 		}
 	};

--- a/lib/metrics/helpers/processMetricsHelpers.js
+++ b/lib/metrics/helpers/processMetricsHelpers.js
@@ -10,7 +10,7 @@ function aggregateByObjectName(list) {
 			continue;
 		}
 
-		if (Object.hasOwnProperty.call(data, listElement.constructor.name)) {
+		if (Object.hasOwn(data, listElement.constructor.name)) {
 			data[listElement.constructor.name] += 1;
 		} else {
 			data[listElement.constructor.name] = 1;

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -212,10 +212,9 @@ class Registry {
 }
 
 function formatLabels(labels, exclude) {
-	const { hasOwnProperty } = Object.prototype;
 	const formatted = [];
 	for (const [name, value] of Object.entries(labels)) {
-		if (!exclude || !hasOwnProperty.call(exclude, name)) {
+		if (!exclude || !Object.hasOwn(exclude, name)) {
 			formatted.push(`${name}="${escapeLabelValue(value)}"`);
 		}
 	}


### PR DESCRIPTION
Also add missing benchmarks for startTimer(), since I'm mucking about in its innards.

In theory removing call() for arrow functions or straight calls improves performance, but I've never managed a benchmark that proves it. This change also reduces closure creation but GC is also difficult to benchmark. Make enough of these changes however and you can get yourself a little teeny tiny notch in your telemetry data that proves you did something (I think I clocked my test case at about .8%, because the calls were slow and so that added up to 5+ms). 

So these are officially just about improving single step debugging. 

One of the places where Prometheus can outshine OpenTelemetry is in trying to figure out why your metrics are confusing/missing/garbled. If you've ever tried to single-step through OTEL it's a maze of twisty little passages, all the same. prom-client has a fairly straightforward architecture and thus is already much better in this regard but I'm interested in making tools that need to 'just work' more approachable. 