### PR TITLE
Reorder number formatting tests to reflect likelihood.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Improve types for no labels
 - Faster stats gathering with lower memory overhead
+- Simplified number format logic
 
 ### Added
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,16 +1,16 @@
 'use strict';
 
 exports.getValueAsString = function getValueString(value) {
+	if (Number.isFinite(value)) {
+		return `${value}`;
+	}
+
 	if (Number.isNaN(value)) {
 		return 'Nan';
-	} else if (!Number.isFinite(value)) {
-		if (value < 0) {
-			return '-Inf';
-		} else {
-			return '+Inf';
-		}
+	} else if (value < 0) {
+		return '-Inf';
 	} else {
-		return `${value}`;
+		return '+Inf';
 	}
 };
 


### PR DESCRIPTION
It seems to me that the likelihood is that most metrics contain a number, so testing for NaN right out of the box is an odd choice for a function on the hot path.

There's also a triple negative for the happy path and that's not very happy.  If it's a finite number, return immediately. Otherwise faff about with what to send.