### PR TITLE
chore: update lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"globals": "^16.2.0",
 		"husky": "^9.0.0",
 		"jest": "^30.0.2",
-		"lint-staged": "^13.1.0",
+		"lint-staged": "^15.5.2",
 		"nock": "^13.0.5",
 		"prettier": "3.6.2",
 		"typescript": "^5.0.4",


### PR DESCRIPTION
[`v14`](https://github.com/lint-staged/lint-staged/releases/tag/v14.0.0) dropped Node 14, and [`v15`](https://github.com/lint-staged/lint-staged/releases/tag/v15.0.0) dropped Node 16.

[`v16`](https://github.com/lint-staged/lint-staged/releases/tag/v16.0.0) has more scary changes that I don't wanna bother testing for 😅 