### PR TITLE
Fix for memory leak and avoid processing expired responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Improve types for no labels
 - Faster stats gathering with lower memory overhead
 - Simplified number format logic
+- Fix memory leak in cluster.js by deleting all expired requests
 
 ### Added
 

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -47,8 +47,14 @@ class AggregatorRegistry extends Registry {
 			function done(err, result) {
 				if (settled) return;
 				settled = true;
-				if (err) reject(err);
-				else resolve(result);
+
+				requests.delete(requestId);
+
+				if (err !== undefined) {
+					reject(err);
+				} else {
+					resolve(result);
+				}
 			}
 
 			const request = {
@@ -79,7 +85,7 @@ class AggregatorRegistry extends Registry {
 			if (request.pending === 0) {
 				// No workers were up
 				clearTimeout(request.errorTimeout);
-				process.nextTick(() => done(null, ''));
+				process.nextTick(() => done(undefined, ''));
 			}
 		});
 	}
@@ -171,6 +177,10 @@ function addListeners() {
 			if (message.type === GET_METRICS_RES) {
 				const request = requests.get(message.requestId);
 
+				if (request === undefined) {
+					return;
+				}
+
 				if (message.error) {
 					request.done(new Error(message.error));
 					return;
@@ -181,12 +191,11 @@ function addListeners() {
 
 				if (request.pending === 0) {
 					// finalize
-					requests.delete(message.requestId);
 					clearTimeout(request.errorTimeout);
 
 					const registry = AggregatorRegistry.aggregate(request.responses);
 					const promString = registry.metrics();
-					request.done(null, promString);
+					request.done(undefined, promString);
 				}
 			}
 		});

--- a/test/clusterTest.js
+++ b/test/clusterTest.js
@@ -254,4 +254,21 @@ describe.each([
 			});
 		});
 	});
+
+	describe('message handling', () => {
+		it('does not error out on unexpected (or late) responses', () => {
+			jest.resetModules();
+
+			require('../lib/cluster');
+
+			//Emulate a response that has been deleted from requests
+			const unexpected = {
+				type: 'prom-client:getMetricsRes',
+				metrics: ['{}'],
+				requestId: -3,
+			};
+
+			expect(() => cluster.emit('message', {}, unexpected)).not.toThrow();
+		});
+	});
 });


### PR DESCRIPTION
Fix for memory leak and excess computation caused by responses showing
up after the timeout has exceeded.

This introduces some load shedding capability for if the cluster primary cannot keep up with the responses from the cluster.

Make done() unconditionally responsible for calling requests.delete()

This should also handle memory leaks where a cluster member crashes before sending a reply to a collection request.

fixes #677, improves #628
