### PR TITLE
Additional performance improvements for cluster mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Expanded benchmarking code
+
 ## [15.1.3] - 2024-06-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Faster stats gathering with lower memory overhead
 - Simplified number format logic
 - Sped up Map accesses
+- Optimize hashObject to assume labels
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Improve types for no labels
 - Faster stats gathering with lower memory overhead
 - Simplified number format logic
+- Sped up Map accesses
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Simplified number format logic
 - Sped up Map accesses
 - Optimize hashObject to assume labels
+- Remove truthy conditionals in hot code paths
 
 ### Added
 

--- a/benchmarks/cluster.js
+++ b/benchmarks/cluster.js
@@ -14,7 +14,7 @@ function setupClusterSuite(suite) {
 
 async function setup(client) {
 	const { Counter, Histogram, Registry } = client;
-	const registers = [new Registry(), new Registry()];
+	const registers = new Array(8).fill(0).map(() => new Registry());
 
 	const labelNames =
 		'single letter labels make poor approximations of real label interpolation behavior for real metrics'.split(
@@ -45,5 +45,11 @@ async function setup(client) {
 		histogram.observe(labels, 1);
 	}
 
-	return Promise.all(registers.map(registry => registry.getMetricsAsJSON()));
+	const results = [];
+
+	for (const registry of registers) {
+		results.push(await registry.getMetricsAsJSON());
+	}
+
+	return results.concat(results);
 }

--- a/benchmarks/cluster.js
+++ b/benchmarks/cluster.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { getLabelCombinations } = require('./utils/labels');
+
+module.exports = setupClusterSuite;
+
+function setupClusterSuite(suite) {
+	suite.add(
+		`aggregate()`,
+		(client, data) => client.AggregatorRegistry.aggregate(data),
+		{ setup },
+	);
+}
+
+async function setup(client) {
+	const { Counter, Histogram, Registry } = client;
+	const registers = [new Registry(), new Registry()];
+
+	const labelNames =
+		'single letter labels make poor approximations of real label interpolation behavior for real metrics'.split(
+			' ',
+		);
+
+	const counter = new Counter({
+		name: 'counter',
+		help: 'counter',
+		labelNames,
+		registers,
+	});
+
+	const histogram = new Histogram({
+		name: 'histogram',
+		help: 'histogram',
+		labelNames,
+		registers,
+	});
+
+	const combinations = getLabelCombinations(
+		[3, 5, 2, 4, 8, 7, 1, 3],
+		labelNames,
+	);
+
+	for (const labels of combinations) {
+		counter.inc(labels, 1);
+		histogram.observe(labels, 1);
+	}
+
+	return Promise.all(registers.map(registry => registry.getMetricsAsJSON()));
+}

--- a/benchmarks/counter.js
+++ b/benchmarks/counter.js
@@ -15,10 +15,10 @@ function setupCounterSuite(suite) {
 
 	suite.add(
 		'inc with labels',
-		labelCombinationFactory([8, 8], (client, { Counter }, labels) =>
+		labelCombinationFactory([8, 8, 3], (client, { Counter }, labels) =>
 			Counter.inc(labels, 1),
 		),
-		{ teardown, setup: setup(2) },
+		{ teardown, setup: setup(3) },
 	);
 }
 

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -1,19 +1,63 @@
 'use strict';
 
 const createRegressionBenchmark = require('@clevernature/benchmark-regression');
+const { Benchmark } = require('benchmark');
+const debug = require('debug')('benchmark');
+
+/**
+ * Async suite workaround. benchmark-regression forwards no options to
+ * benchmark.js from its own suite() and run() functions.
+ * And as implemented, benchmark.js only supports async setup()
+ * and teardown() functions, not the test itself. Given that benchmark.js is
+ * now an archived project, and benchmark-regression hasn't landed a PR since
+ * 2018, that situation is unlikely to change soon.
+ */
+
+Benchmark.options.defer = true;
+Benchmark.options.onStart = event => {
+	const benchmark = event.target;
+	const name = benchmark.name;
+	const original = benchmark.fn;
+
+	debug(`Starting '${name}'`);
+
+	benchmark.fn = async deferred => {
+		try {
+			await original();
+		} catch (e) {
+			console.error(e);
+		} finally {
+			deferred.resolve();
+		}
+	};
+};
+Benchmark.options.onAbort = event => {
+	console.error(event);
+};
+Benchmark.options.onError = event => {
+	console.error(event);
+};
 
 const currentClient = require('..');
-const benchmarks = createRegressionBenchmark(currentClient, [
-	'prom-client@latest',
-]);
+const benchmarks = createRegressionBenchmark(
+	{ name: 'prom-client@current', module: currentClient },
+	['prom-client@latest'],
+);
 
-benchmarks.suite('registry', require('./registry'));
-benchmarks.suite('histogram', require('./histogram'));
 benchmarks.suite('counter', require('./counter'));
 benchmarks.suite('gauge', require('./gauge'));
+benchmarks.suite('histogram', require('./histogram'));
+benchmarks.suite('registry', require('./registry'));
 benchmarks.suite('summary', require('./summary'));
-benchmarks.run().catch(err => {
-	console.error(err.stack);
-	// eslint-disable-next-line n/no-process-exit
-	process.exit(1);
-});
+
+benchmarks
+	.run()
+	.then(() => {
+		debug('Process end');
+	})
+	.catch(err => {
+		console.error('Failure', err);
+		console.error(err.stack);
+		// eslint-disable-next-line n/no-process-exit
+		process.exit(1);
+	});

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -49,6 +49,7 @@ benchmarks.suite('gauge', require('./gauge'));
 benchmarks.suite('histogram', require('./histogram'));
 benchmarks.suite('registry', require('./registry'));
 benchmarks.suite('summary', require('./summary'));
+benchmarks.suite('cluster', require('./cluster'));
 
 benchmarks
 	.run()

--- a/benchmarks/utils/labels.js
+++ b/benchmarks/utils/labels.js
@@ -17,8 +17,10 @@ const cartesianProduct = (a, b, ...c) =>
 	b ? cartesianProduct(flatten(a, b), ...c) : a;
 const times = a => Array.from(Array(a)).map((_, x) => x);
 
-function getLabelCombinations(labelValues) {
-	const labelNames = getLabelNames(labelValues.length);
+function getLabelCombinations(
+	labelValues,
+	labelNames = getLabelNames(labelValues.length),
+) {
 	labelValues = labelValues.length > 1 ? labelValues : labelValues.concat(1);
 	const labelValuesArray = labelValues.map(times);
 	const labelValueCombinations = cartesianProduct(...labelValuesArray);

--- a/example/cluster.js
+++ b/example/cluster.js
@@ -6,7 +6,7 @@ const metricsServer = express();
 const AggregatorRegistry = require('../').AggregatorRegistry;
 const aggregatorRegistry = new AggregatorRegistry();
 
-if (cluster.isMaster) {
+if (cluster.isPrimary) {
 	for (let i = 0; i < 4; i++) {
 		cluster.fork();
 	}

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -165,7 +165,7 @@ function addListeners() {
 	if (listenersAdded) return;
 	listenersAdded = true;
 
-	if (cluster().isMaster) {
+	if (cluster().isPrimary) {
 		// Listen for worker responses to requests for local metrics
 		cluster().on('message', (worker, message) => {
 			if (message.type === GET_METRICS_RES) {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -176,7 +176,7 @@ function addListeners() {
 					return;
 				}
 
-				message.metrics.forEach(registry => request.responses.push(registry));
+				message.metrics.forEach(metric => request.responses.push(metric));
 				request.pending--;
 
 				if (request.pending === 0) {

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -137,8 +137,10 @@ class Counter extends Metric {
 }
 
 function setValue(hashMap, value, labels = {}, hash = '') {
-	if (hashMap.get(hash)) {
-		hashMap.get(hash).value += value;
+	const entry = hashMap.get(hash);
+
+	if (entry !== undefined) {
+		entry.value += value;
 	} else {
 		hashMap.set(hash, { value, labels });
 	}

--- a/lib/metricAggregators.js
+++ b/lib/metricAggregators.js
@@ -32,7 +32,8 @@ function AggregatorFactory(aggregatorFn) {
 				value: aggregatorFn(values),
 				labels: values[0].labels,
 			};
-			if (values[0].metricName) {
+
+			if (values[0].metricName !== undefined) {
 				valObj.metricName = values[0].metricName;
 			}
 			// NB: Timestamps are omitted.

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -105,10 +105,8 @@ class Registry {
 	}
 
 	registerMetric(metric) {
-		if (
-			this._metrics.has(metric.name) &&
-			this._metrics.get(metric.name) !== metric
-		) {
+		const existing = this._metrics.get(metric.name);
+		if (existing !== undefined && existing !== metric) {
 			throw new Error(
 				`A metric with the name ${metric.name} has already been registered.`,
 			);

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -58,7 +58,7 @@ class Registry {
 				metricName = `${metricName}_total`;
 			}
 
-			if (defaultLabels) {
+			if (defaultLabels !== undefined) {
 				labels = { ...labels, ...defaultLabels, ...labels };
 			}
 
@@ -139,8 +139,7 @@ class Registry {
 					val.labels = Object.assign({}, val.labels);
 
 					for (const labelName of defaultLabelNames) {
-						val.labels[labelName] =
-							val.labels[labelName] || this._defaultLabels[labelName];
+						val.labels[labelName] ??= this._defaultLabels[labelName];
 					}
 				}
 			}
@@ -223,7 +222,7 @@ function formatLabels(labels, exclude) {
 const sharedLabelCache = new WeakMap();
 function flattenSharedLabels(labels) {
 	const cached = sharedLabelCache.get(labels);
-	if (cached) {
+	if (cached !== undefined) {
 		return cached;
 	}
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -57,8 +57,10 @@ exports.setValueDelta = function setValueDelta(
 	hash = '',
 ) {
 	const value = typeof deltaValue === 'number' ? deltaValue : 0;
-	if (hashMap.get(hash)) {
-		hashMap.get(hash).value += value;
+	const entry = hashMap.get(hash);
+
+	if (entry !== undefined) {
+		entry.value += value;
 	} else {
 		hashMap.set(hash, { value, labels });
 	}
@@ -142,8 +144,9 @@ class Grouper extends Map {
 	 * @returns {undefined} undefined.
 	 */
 	add(key, value) {
-		if (this.has(key)) {
-			this.get(key).push(value);
+		const entry = this.get(key);
+		if (entry !== undefined) {
+			entry.push(value);
 		} else {
 			this.set(key, [value]);
 		}

--- a/lib/util.js
+++ b/lib/util.js
@@ -92,40 +92,27 @@ exports.getLabels = function (labelNames, args) {
 	return acc;
 };
 
-function fastHashObject(keys, labels) {
-	if (keys.length === 0) {
-		return '';
-	}
-
-	let hash = '';
-
-	for (let i = 0; i < keys.length; i++) {
-		const key = keys[i];
-		const value = labels[key];
-		if (value === undefined) continue;
-
-		hash += `${key}:${value},`;
-	}
-
-	return hash;
-}
-
 function hashObject(labels, labelNames) {
 	// We don't actually need a hash here. We just need a string that
 	// is unique for each possible labels object and consistent across
 	// calls with equivalent labels objects.
 
-	if (labelNames) {
-		return fastHashObject(labelNames, labels);
+	if (labelNames === undefined) {
+		labelNames = Object.keys(labels).sort();
 	}
 
-	const keys = Object.keys(labels);
-	if (keys.length > 1) {
-		keys.sort(); // need consistency across calls
+	let hash = '';
+
+	for (const key of labelNames) {
+		const value = labels[key];
+		if (value !== undefined) {
+			hash += `${key}:${value},`;
+		}
 	}
 
-	return fastHashObject(keys, labels);
+	return hash;
 }
+
 exports.hashObject = hashObject;
 
 exports.isObject = function isObject(obj) {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
 	"devDependencies": {
 		"@clevernature/benchmark-regression": "^1.0.0",
 		"@eslint/js": "^9.29.0",
+		"benchmark": "^2.1",
+		"debug": "^4.4.1",
 		"eslint": "^9.29.0",
 		"eslint-config-prettier": "^10.1.5",
 		"eslint-plugin-jsdoc": "^51.2.3",


### PR DESCRIPTION
Most of these improvements are on the worker side of the connection, but when combined with #679 should provide some
relief for people using this mode.

This PR includes:

- substantial additional code coverage in the benchmarks via addition of more scenarios
- a workaround for benchmark.js not allowing async test bodies (despite supporting async setup and teardown?)
- removal of truthy conditionals in hot paths
- removal of double lookups during map insertions
- reworking hashObject() to optimize for the common case, which is metrics with labels

There's a lot of jitter in these tests, but the common theme is that the benchmarks with no labels show a tiny regression versus the label paths showing 10+% improvements.

Given that the no-label path was previously almost 500x faster, that's a reasonable tradeoff. If prom-client is not fast enough for anyone, it will be someone using a lot of labels.

⚠ counter ➭ inc is 0.06717% acceptably slower.
✓ counter ➭ inc with labels is 25.43% faster.
✓ gauge ➭ inc is 2.639% faster.
✓ gauge ➭ inc with labels is 21.03% faster.
✓ histogram ➭ observe#1 with 64 is 16.87% faster.
✓ histogram ➭ observe#2 with 8 is 10.97% faster.
⚠ histogram ➭ observe#2 with 4 and 2 with 2 is 1.345% acceptably slower.
⚠ histogram ➭ observe#2 with 2 and 2 with 4 is 3.383% acceptably slower.
⚠ histogram ➭ observe#6 with 2 is 3.862% acceptably slower.
✓ registry ➭ getMetricsAsJSON#1 with 64 is 4.661% faster.
✓ registry ➭ getMetricsAsJSON#2 with 8 is 5.511% faster.
✓ registry ➭ getMetricsAsJSON#2 with 4 and 2 with 2 is 5.085% faster.
✓ registry ➭ getMetricsAsJSON#2 with 2 and 2 with 4 is 5.989% faster.
✓ registry ➭ getMetricsAsJSON#6 with 2 is 4.661% faster.
✓ registry ➭ metrics#1 with 64 is 7.167% faster.
✓ registry ➭ metrics#1 with 64 and openMetrics is 4.562% faster.
✓ registry ➭ metrics#2 with 8 is 3.493% faster.
✓ registry ➭ metrics#2 with 8 and openMetrics is 4.773% faster.
✓ registry ➭ metrics#2 with 4 and 2 with 2 is 5.141% faster.
✓ registry ➭ metrics#2 with 4 and 2 with 2 and openMetrics is 2.863% faster.
✓ registry ➭ metrics#2 with 2 and 2 with 4 is 4.577% faster.
✓ registry ➭ metrics#2 with 2 and 2 with 4 and openMetrics is 3.778% faster.
✓ registry ➭ metrics#6 with 2 is 2.311% faster.
✓ registry ➭ metrics#6 with 2 and openMetrics is 1.362% faster.
✓ summary ➭ observe#1 with 64 is 18.31% faster.
✓ summary ➭ observe#2 with 8 is 5.565% faster.
✓ summary ➭ observe#2 with 4 and 2 with 2 is 0.6756% faster.
⚠ summary ➭ observe#2 with 2 and 2 with 4 is 5.010% acceptably slower.
⚠ summary ➭ observe#6 with 2 is 4.731% acceptably slower.
✓ cluster ➭ aggregate() is 1.476% faster.

Author notes:

Originally this PR was meant to include full e2e benchmarks of the cluster code, however the two benchmark frameworks being used are not particularly cooperative in this respect. I spent more time trying to get those to work than I did on the rest of the work combined. In the end I had code that ran properly, however the variability in the run time was so great (due to coordinating multiple runs of the benchmark code across multiple processes), that none of the output was actionable. 

I believe this could be fixed with a single PR to benchmark-regressions to have it delegate setup() to benchmark.js, allowing the coordination overhead to occur between the measurement windows. However that project has been dormant for a very, very long time and I do not have any expectation of a PR being landed if offered.