### PR TITLE
Improvements to defaultLabels in metrics, and matching benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Fix memory leak in cluster.js by deleting all expired requests
 - perf: Sped up Map accesses
 - perf: Remove truthy conditionals in hot code paths
+- perf: faster merge of registry defaultLabels during metric processing
 
 ### Added
 

--- a/benchmarks/utils/labels.js
+++ b/benchmarks/utils/labels.js
@@ -1,6 +1,35 @@
 'use strict';
 
-const letters = 'abcdefghijklmnopqrstuvwxyz'.split('');
+const VALUES = {
+	method: [
+		'get',
+		'post',
+		'put',
+		'delete',
+		'delete',
+		'head',
+		'options',
+		'patch',
+	],
+	status: [100, 200, 201, 301, 400, 401, 403, 404, 500, 502],
+	account: ['user', 'admin', 'guest', 'bot'],
+	region: ['us-west-1', 'us-east-1', 'us-west4', 'us-east1', 'europe-north1'],
+	type: ['desktop', 'mobile', 'tablet', 'kiosk', 'watch', 'pos'],
+	env: ['development', 'production', 'staging', 'qa'],
+	protocol: ['http', 'https'],
+	campaign: [
+		'easter',
+		'valentines',
+		'christmas',
+		'thanksgiving',
+		'labor_day',
+		'new_years',
+		'halloween',
+	],
+	label1: [2, 4, 6, 8, 10, 12, 14, 16],
+	label2: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+	label3: 'abcdefghijklmnopqrst'.split('').reverse(),
+};
 
 module.exports = {
 	getLabelNames,
@@ -9,7 +38,7 @@ module.exports = {
 };
 
 function getLabelNames(count) {
-	return letters.slice(0, count);
+	return Object.keys(VALUES).slice(0, count);
 }
 
 const flatten = (a, b) => [].concat(...a.map(c => b.map(d => [].concat(c, d))));
@@ -17,13 +46,31 @@ const cartesianProduct = (a, b, ...c) =>
 	b ? cartesianProduct(flatten(a, b), ...c) : a;
 const times = a => Array.from(Array(a)).map((_, x) => x);
 
-function getLabelCombinations(
-	labelValues,
-	labelNames = getLabelNames(labelValues.length),
-) {
-	labelValues = labelValues.length > 1 ? labelValues : labelValues.concat(1);
-	const labelValuesArray = labelValues.map(times);
-	const labelValueCombinations = cartesianProduct(...labelValuesArray);
+function getLabelCombinations(labelValues, labelNames) {
+	if (labelValues.length === 0) {
+		return [{}];
+	}
+
+	labelNames ??= getLabelNames(labelValues.length);
+
+	const labelValuesArray = labelNames.map((label, i) => {
+		const count = labelValues[i] ?? 1;
+
+		let values = VALUES[label] ?? [];
+		if (values.length >= count) {
+			values = values.slice(0, count);
+		} else {
+			values = values.concat(times(count - values.length));
+		}
+
+		return values;
+	});
+
+	if (labelValues.length === 1) {
+		labelValuesArray.push([undefined]);
+	}
+
+	const labelValueCombinations = cartesianProduct(...labelValuesArray) ?? [];
 	return labelValueCombinations.map(values =>
 		labelNames.reduce((acc, label, i) => {
 			acc[label] = values[i];

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -45,8 +45,10 @@ class Registry {
 		const type = `# TYPE ${name} ${metric.type}`;
 		const values = [help, type];
 
-		const defaultLabels =
-			Object.keys(this._defaultLabels).length > 0 ? this._defaultLabels : null;
+		let defaultLabelNames = Object.keys(this._defaultLabels);
+		if (defaultLabelNames.length === 0) {
+			defaultLabelNames = undefined;
+		}
 
 		const isOpenMetrics =
 			this.contentType === Registry.OPENMETRICS_CONTENT_TYPE;
@@ -58,8 +60,13 @@ class Registry {
 				metricName = `${metricName}_total`;
 			}
 
-			if (defaultLabels !== undefined) {
-				labels = { ...labels, ...defaultLabels, ...labels };
+			if (defaultLabelNames !== undefined) {
+				// Make a copy before mutating
+				labels = { ...labels };
+
+				for (const labelName of defaultLabelNames) {
+					labels[labelName] ??= this._defaultLabels[labelName];
+				}
 			}
 
 			// We have to flatten these separately to avoid duplicate labels appearing
@@ -122,7 +129,10 @@ class Registry {
 
 	async getMetricsAsJSON() {
 		const metrics = [];
-		const defaultLabelNames = Object.keys(this._defaultLabels);
+		let defaultLabelNames = Object.keys(this._defaultLabels);
+		if (defaultLabelNames.length === 0) {
+			defaultLabelNames = undefined;
+		}
 
 		const promises = [];
 
@@ -133,10 +143,10 @@ class Registry {
 		const resolves = await Promise.all(promises);
 
 		for (const item of resolves) {
-			if (item.values && defaultLabelNames.length > 0) {
+			if (defaultLabelNames !== undefined && item.values !== undefined) {
 				for (const val of item.values) {
 					// Make a copy before mutating
-					val.labels = Object.assign({}, val.labels);
+					val.labels = { ...val.labels };
 
 					for (const labelName of defaultLabelNames) {
 						val.labels[labelName] ??= this._defaultLabels[labelName];

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -140,9 +140,9 @@ class Registry {
 			promises.push(metric.get());
 		}
 
-		const resolves = await Promise.all(promises);
+		for (const promise of promises) {
+			const item = await promise;
 
-		for (const item of resolves) {
 			if (defaultLabelNames !== undefined && item.values !== undefined) {
 				for (const val of item.values) {
 					// Make a copy before mutating

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"node": "^20 || ^22 || >=24"
 	},
 	"scripts": {
-		"benchmarks": "node --max-old-space-size=8192 ./benchmarks/index.js",
+		"benchmarks": "node --max-old-space-size=9000 ./benchmarks/index.js",
 		"test": "npm run lint && npm run check-prettier && npm run compile-typescript && npm run test-unit -- --coverage",
 		"lint": "eslint .",
 		"test-unit": "jest",


### PR DESCRIPTION
This is about a 20% improvement in the getMetricsAs{String,JSON} functions, when defaultLabels are set.

Note that this PR shares some benchmark-only commits in common with #680 

Additional benchmark suites boost code coverage #676 

```
File                             | % Stmts | % Branch | % Funcs | % Lines |
---------------------------------|---------|----------|---------|---------|
All files                        |   52.36 |    29.55 |   49.14 |   53.05 |
```

No breaking changes