### PR TITLE
Fix browser compatibility

### DIFF
--- a/lib/defaultMetrics.js
+++ b/lib/defaultMetrics.js
@@ -24,8 +24,10 @@ const metrics = {
 	processOpenFileDescriptors,
 	processMaxFileDescriptors,
 	eventLoopLag,
+
+	...(typeof process !== 'undefined' &&
 	// eslint-disable-next-line n/no-unsupported-features/node-builtins
-	...(typeof process.getActiveResourcesInfo === 'function'
+	typeof process.getActiveResourcesInfo === 'function'
 		? { processResources }
 		: {}),
 	processHandles,

--- a/lib/metrics/osMemoryHeap.js
+++ b/lib/metrics/osMemoryHeap.js
@@ -27,12 +27,15 @@ function notLinuxVariant(registry, config = {}) {
 	});
 }
 
+function isLinux() {
+	return typeof process !== 'undefined' && process.platform === 'linux';
+}
+
 module.exports = (registry, config) =>
-	process.platform === 'linux'
+	isLinux()
 		? linuxVariant(registry, config)
 		: notLinuxVariant(registry, config);
 
-module.exports.metricNames =
-	process.platform === 'linux'
-		? linuxVariant.metricNames
-		: [PROCESS_RESIDENT_MEMORY];
+module.exports.metricNames = isLinux()
+	? linuxVariant.metricNames
+	: [PROCESS_RESIDENT_MEMORY];

--- a/lib/metrics/processStartTime.js
+++ b/lib/metrics/processStartTime.js
@@ -1,7 +1,13 @@
 'use strict';
 
 const Gauge = require('../gauge');
-const startInSeconds = Math.round(Date.now() / 1000 - process.uptime());
+
+const uptime =
+	typeof process !== 'undefined' && typeof process.uptime === 'function'
+		? process.uptime()
+		: 0;
+
+const startInSeconds = Math.round(Date.now() / 1000 - uptime);
 
 const PROCESS_START_TIME = 'process_start_time_seconds';
 

--- a/lib/metrics/version.js
+++ b/lib/metrics/version.js
@@ -1,7 +1,12 @@
 'use strict';
 
 const Gauge = require('../gauge');
-const version = process.version;
+
+const version =
+	typeof process !== 'undefined' && typeof process.version === 'string'
+		? process.version
+		: 'v0.0.0'; // Fallback for environments where process.version is not available
+
 const versionSegments = version.slice(1).split('.').map(Number);
 
 const NODE_VERSION_INFO = 'nodejs_version_info';

--- a/test/browserCompatibilityTest.js
+++ b/test/browserCompatibilityTest.js
@@ -1,0 +1,49 @@
+'use strict';
+
+describe('Browser compatibility', () => {
+	const globalRegistry = require('../index').register;
+	let originalProcess;
+
+	beforeEach(() => {
+		originalProcess = global.process;
+	});
+
+	afterEach(() => {
+		global.process = originalProcess;
+		globalRegistry.clear();
+	});
+
+	it('should be able to import Counter, Gauge, and Histogram without process global', () => {
+		// Simulate browser environment by removing process global
+		delete global.process;
+
+		expect(() => {
+			const { Counter, Gauge, Histogram } = require('../index');
+
+			// Verify that the classes are available
+			expect(Counter).toBeDefined();
+			expect(Gauge).toBeDefined();
+			expect(Histogram).toBeDefined();
+
+			// Verify that we can create instances
+			const counter = new Counter({
+				name: 'test_counter',
+				help: 'Test counter',
+			});
+
+			const gauge = new Gauge({
+				name: 'test_gauge',
+				help: 'Test gauge',
+			});
+
+			const histogram = new Histogram({
+				name: 'test_histogram',
+				help: 'Test histogram',
+			});
+
+			expect(counter).toBeInstanceOf(Counter);
+			expect(gauge).toBeInstanceOf(Gauge);
+			expect(histogram).toBeInstanceOf(Histogram);
+		}).not.toThrow();
+	});
+});


### PR DESCRIPTION
Fixes https://github.com/siimon/prom-client/issues/685

Takes care when accessing `process` at the top-level in modules, so that merely importing these modules does not cause an error in browsers. Check the test file at the bottom - this test fails without these changes.