### PR TITLE
Performance: New storage engine for stats, with improved key management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking
 
 - Drop support for Node.js versions 16, 18, 21 and 23
-- Metric internal storage ('hashMap') changed to Map from Object. If you have
+- Metric internal storage ('hashMap') changed to a separate object, LabelMap. If you have
   subclassed the built-in metric types you may need to adjust your code.
 
 ### Changed
@@ -23,6 +23,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - perf: Sped up Map accesses
 - perf: Remove truthy conditionals in hot code paths
 - perf: Improve performance of registry defaultLabels during metric processing
+- perf: New, more space-efficient storage engine, 20-45% faster stats recording
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Fix memory leak in cluster.js by deleting all expired requests
 - perf: Sped up Map accesses
 - perf: Remove truthy conditionals in hot code paths
+- perf: Improve performance of registry defaultLabels during metric processing
 
 ### Added
 

--- a/benchmarks/counter.js
+++ b/benchmarks/counter.js
@@ -4,7 +4,21 @@ const { getLabelNames, labelCombinationFactory } = require('./utils/labels');
 
 module.exports = setupCounterSuite;
 
+let count = 1;
+
 function setupCounterSuite(suite) {
+	suite.add(
+		'new',
+		(client, labelNames) =>
+			new client.Counter({
+				name: `Counter${count++}`,
+				help: 'Counter',
+				labelNames,
+			}),
+		{
+			setup: () => getLabelNames(4),
+		},
+	);
 	suite.add(
 		'inc',
 		labelCombinationFactory([], (client, { Counter }, labels) =>

--- a/benchmarks/counter.js
+++ b/benchmarks/counter.js
@@ -8,6 +8,24 @@ let count = 1;
 
 function setupCounterSuite(suite) {
 	suite.add(
+		'new',
+		(client, { labelNames, registry }) =>
+			new client.Counter({
+				name: `Counter${count++}`,
+				help: 'Counter',
+				labelNames,
+				registers: [registry],
+			}),
+		{
+			setup: client => {
+				return {
+					labelNames: getLabelNames(4),
+					registry: new client.Registry(),
+				};
+			},
+		},
+	);
+	suite.add(
 		'inc',
 		labelCombinationFactory([], (client, { Counter }, labels) =>
 			Counter.inc(labels, 1),
@@ -21,19 +39,6 @@ function setupCounterSuite(suite) {
 			Counter.inc(labels, 1),
 		),
 		{ teardown, setup: setup(3) },
-	);
-
-	suite.add(
-		'new',
-		(client, labelNames) =>
-			new client.Counter({
-				name: `Counter${count++}`,
-				help: 'Counter',
-				labelNames,
-			}),
-		{
-			setup: () => getLabelNames(4),
-		},
 	);
 }
 

--- a/benchmarks/counter.js
+++ b/benchmarks/counter.js
@@ -8,18 +8,6 @@ let count = 1;
 
 function setupCounterSuite(suite) {
 	suite.add(
-		'new',
-		(client, labelNames) =>
-			new client.Counter({
-				name: `Counter${count++}`,
-				help: 'Counter',
-				labelNames,
-			}),
-		{
-			setup: () => getLabelNames(4),
-		},
-	);
-	suite.add(
 		'inc',
 		labelCombinationFactory([], (client, { Counter }, labels) =>
 			Counter.inc(labels, 1),
@@ -33,6 +21,19 @@ function setupCounterSuite(suite) {
 			Counter.inc(labels, 1),
 		),
 		{ teardown, setup: setup(3) },
+	);
+
+	suite.add(
+		'new',
+		(client, labelNames) =>
+			new client.Counter({
+				name: `Counter${count++}`,
+				help: 'Counter',
+				labelNames,
+			}),
+		{
+			setup: () => getLabelNames(4),
+		},
 	);
 }
 

--- a/benchmarks/gauge.js
+++ b/benchmarks/gauge.js
@@ -5,13 +5,10 @@ const { getLabelNames, labelCombinationFactory } = require('./utils/labels');
 module.exports = setupGaugeSuite;
 
 function setupGaugeSuite(suite) {
-	suite.add(
-		'inc',
-		labelCombinationFactory([], (client, { Gauge }, labels) =>
-			Gauge.inc(labels, 1),
-		),
-		{ teardown, setup: setup(0) },
-	);
+	suite.add('inc', (client, { Gauge }) => Gauge.inc(1), {
+		teardown,
+		setup: setup(0),
+	});
 
 	suite.add(
 		'inc with labels',

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -47,8 +47,8 @@ const benchmarks = createRegressionBenchmark(
 benchmarks.suite('counter', require('./counter'));
 benchmarks.suite('gauge', require('./gauge'));
 benchmarks.suite('histogram', require('./histogram'));
-benchmarks.suite('registry', require('./registry'));
 benchmarks.suite('summary', require('./summary'));
+benchmarks.suite('registry', require('./registry'));
 benchmarks.suite('cluster', require('./cluster'));
 
 benchmarks

--- a/benchmarks/registry.js
+++ b/benchmarks/registry.js
@@ -6,6 +6,7 @@ module.exports = setupRegistrySuite;
 
 function setupRegistrySuite(suite) {
 	const labelSetups = [
+		{ name: 'no labels', counts: [] },
 		{ name: '1 x 64', counts: [64] },
 		{ name: '2 x 4', counts: [4, 4] },
 		{ name: '2 x 8', counts: [8, 8] },
@@ -16,14 +17,14 @@ function setupRegistrySuite(suite) {
 
 	labelSetups.forEach(({ name, counts, defaults }) => {
 		suite.add(
-			`getMetricsAsJSON#${name}`,
+			`getMetricsAsJSON() ${name}`,
 			(client, registry) => registry.getMetricsAsJSON(),
 			{ setup: setup(counts, defaults, false) },
 		);
 	});
 
 	labelSetups.forEach(({ name, counts, defaults }) => {
-		suite.add(`metrics#${name}`, (client, registry) => registry.metrics(), {
+		suite.add(`metrics() ${name}`, (client, registry) => registry.metrics(), {
 			setup: setup(counts, defaults, false),
 		});
 		suite.add(
@@ -62,8 +63,8 @@ function setup(labelCounts, defaultLabels, open) {
 
 		const labelCombinations = getLabelCombinations(labelCounts);
 
-		labelCombinations.forEach(labels => histogram.observe(labels, 1));
-		labelCombinations.forEach(labels => counter.inc(labels, 1));
+		labelCombinations.forEach(labels => histogram.observe({ ...labels }, 1));
+		labelCombinations.forEach(labels => counter.inc({ ...labels }, 1));
 
 		return registry;
 	};

--- a/benchmarks/utils/labels.js
+++ b/benchmarks/utils/labels.js
@@ -1,6 +1,35 @@
 'use strict';
 
-const letters = 'abcdefghijklmnopqrstuvwxyz'.split('');
+const VALUES = {
+	method: [
+		'get',
+		'post',
+		'put',
+		'delete',
+		'delete',
+		'head',
+		'options',
+		'patch',
+	],
+	status: [100, 200, 201, 301, 400, 401, 403, 404, 500, 502],
+	account: ['user', 'admin', 'guest', 'bot'],
+	region: ['us-west-1', 'us-east-1', 'us-west4', 'us-east1', 'europe-north1'],
+	type: ['desktop', 'mobile', 'tablet', 'kiosk', 'watch', 'pos'],
+	env: ['development', 'production', 'staging', 'qa'],
+	protocol: ['http', 'https'],
+	campaign: [
+		'easter',
+		'valentines',
+		'christmas',
+		'thanksgiving',
+		'labor_day',
+		'new_years',
+		'halloween',
+	],
+	label1: [2, 4, 6, 8, 10, 12, 14, 16],
+	label2: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+	label3: 'abcdefghijklmnopqrst'.split('').reverse(),
+};
 
 module.exports = {
 	getLabelNames,
@@ -9,7 +38,7 @@ module.exports = {
 };
 
 function getLabelNames(count) {
-	return letters.slice(0, count);
+	return Object.keys(VALUES).slice(0, count);
 }
 
 const flatten = (a, b) => [].concat(...a.map(c => b.map(d => [].concat(c, d))));
@@ -17,13 +46,31 @@ const cartesianProduct = (a, b, ...c) =>
 	b ? cartesianProduct(flatten(a, b), ...c) : a;
 const times = a => Array.from(Array(a)).map((_, x) => x);
 
-function getLabelCombinations(
-	labelValues,
-	labelNames = getLabelNames(labelValues.length),
-) {
-	labelValues = labelValues.length > 1 ? labelValues : labelValues.concat(1);
-	const labelValuesArray = labelValues.map(times);
-	const labelValueCombinations = cartesianProduct(...labelValuesArray);
+function getLabelCombinations(labelValues, labelNames) {
+	if (labelValues.length === 0) {
+		return [{}];
+	}
+
+	labelNames ??= getLabelNames(labelValues.length);
+
+	const labelValuesArray = labelNames.map((label, i) => {
+		const count = labelValues[i] ?? 1;
+
+		let values = VALUES[label] ?? [];
+		if (values.length >= count) {
+			values = values.slice(0, count);
+		} else {
+			values = values.concat(times(count - values.length));
+		}
+
+		return values;
+	});
+
+	if (labelValues.length === 1) {
+		labelValuesArray.push([undefined]);
+	}
+
+	const labelValueCombinations = cartesianProduct(...labelValuesArray) ?? [];
 	return labelValueCombinations.map(values =>
 		labelNames.reduce((acc, label, i) => {
 			acc[label] = values[i];

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -5,7 +5,6 @@
 
 const util = require('util');
 const { isObject, getLabels, nowTimestamp, LabelMap } = require('./util');
-const { validateLabel } = require('./validation');
 const { Metric } = require('./metric');
 const Exemplar = require('./exemplar');
 
@@ -31,9 +30,7 @@ class Counter extends Metric {
 	 * @returns {void}
 	 */
 	incWithoutExemplar(labels, value) {
-		if (isObject(labels)) {
-			validateLabel(this.labelNames, labels);
-		} else {
+		if (!isObject(labels)) {
 			value = labels;
 			labels = {};
 		}
@@ -47,6 +44,7 @@ class Counter extends Metric {
 
 		if (value === null || value === undefined) value = 1;
 
+		this.store.validate(labels);
 		this.store.setDelta(labels, value);
 	}
 
@@ -120,7 +118,7 @@ class Counter extends Metric {
 
 	remove(...args) {
 		const labels = getLabels(this.labelNames, args) || {};
-		validateLabel(this.labelNames, labels);
+		this.store.validate(labels); //TODO: this isn't really necessary is it?
 		this.store.remove(labels);
 	}
 }

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -4,13 +4,7 @@
 'use strict';
 
 const util = require('util');
-const {
-	hashObject,
-	isObject,
-	getLabels,
-	removeLabels,
-	nowTimestamp,
-} = require('./util');
+const { isObject, getLabels, nowTimestamp, LabelMap } = require('./util');
 const { validateLabel } = require('./validation');
 const { Metric } = require('./metric');
 const Exemplar = require('./exemplar');
@@ -34,12 +28,10 @@ class Counter extends Metric {
 	 * Increment counter.
 	 * @param {object} labels - What label you want to be incremented
 	 * @param {number} value - Value to increment, if omitted increment with 1
-	 * @returns {object} results - object with information about the inc operation
+	 * @returns {void}
 	 */
 	incWithoutExemplar(labels, value) {
-		let hash = '';
 		if (isObject(labels)) {
-			hash = hashObject(labels, this.sortedLabelNames);
 			validateLabel(this.labelNames, labels);
 		} else {
 			value = labels;
@@ -55,9 +47,7 @@ class Counter extends Metric {
 
 		if (value === null || value === undefined) value = 1;
 
-		setValue(this.hashMap, value, labels, hash);
-
-		return { labelHash: hash };
+		this.store.setDelta(labels, value);
 	}
 
 	/**
@@ -79,17 +69,16 @@ class Counter extends Metric {
 		value = this.defaultValue,
 		exemplarLabels = this.defaultExemplarLabelSet,
 	} = {}) {
-		const res = this.incWithoutExemplar(labels, value);
-		this.updateExemplar(exemplarLabels, value, res.labelHash);
+		this.incWithoutExemplar(labels, value);
+		this.updateExemplar(labels, exemplarLabels, value);
 	}
 
-	updateExemplar(exemplarLabels, value, hash) {
+	updateExemplar(labels, exemplarLabels, value) {
 		if (exemplarLabels === this.defaultExemplarLabelSet) return;
 
-		const entry = this.hashMap.get(hash);
-		if (!isObject(entry.exemplar)) {
-			entry.exemplar = new Exemplar();
-		}
+		const entry = this.store.entry(labels);
+
+		entry.exemplar ??= new Exemplar();
 		entry.exemplar.validateExemplarLabelSet(exemplarLabels);
 		entry.exemplar.labelSet = exemplarLabels;
 		entry.exemplar.value = value ? value : 1;
@@ -101,9 +90,9 @@ class Counter extends Metric {
 	 * @returns {void}
 	 */
 	reset() {
-		this.hashMap = new Map();
+		this.store = new LabelMap(this.labelNames);
 		if (this.labelNames.length === 0) {
-			setValue(this.hashMap, 0);
+			this.store.set({}, 0);
 		}
 	}
 
@@ -117,7 +106,7 @@ class Counter extends Metric {
 			help: this.help,
 			name: this.name,
 			type: this.type,
-			values: Array.from(this.hashMap.values()),
+			values: Array.from(this.store.values()),
 			aggregator: this.aggregator,
 		};
 	}
@@ -132,19 +121,8 @@ class Counter extends Metric {
 	remove(...args) {
 		const labels = getLabels(this.labelNames, args) || {};
 		validateLabel(this.labelNames, labels);
-		return removeLabels.call(this, this.hashMap, labels, this.sortedLabelNames);
+		this.store.remove(labels);
 	}
-}
-
-function setValue(hashMap, value, labels = {}, hash = '') {
-	const entry = hashMap.get(hash);
-
-	if (entry !== undefined) {
-		entry.value += value;
-	} else {
-		hashMap.set(hash, { value, labels });
-	}
-	return hashMap;
 }
 
 module.exports = Counter;

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -5,15 +5,7 @@
 
 const util = require('util');
 
-const {
-	setValue,
-	setValueDelta,
-	getLabels,
-	hashObject,
-	isObject,
-	removeLabels,
-} = require('./util');
-const { validateLabel } = require('./validation');
+const { getLabels, isObject, LabelMap } = require('./util');
 const { Metric } = require('./metric');
 
 class Gauge extends Metric {
@@ -39,9 +31,9 @@ class Gauge extends Metric {
 	 * @returns {void}
 	 */
 	reset() {
-		this.hashMap = new Map();
+		this.store = new LabelMap(this.labelNames);
 		if (this.labelNames.length === 0) {
-			setValue(this.hashMap, 0, {});
+			this.store.set({}, 0);
 		}
 	}
 
@@ -54,8 +46,7 @@ class Gauge extends Metric {
 	inc(labels, value) {
 		value = getValueArg(labels, value);
 		labels = getLabelArg(labels);
-		if (value === undefined) value = 1;
-		setDelta(this, labels, value);
+		setDelta(this, labels, value ?? 1);
 	}
 
 	/**
@@ -67,8 +58,7 @@ class Gauge extends Metric {
 	dec(labels, value) {
 		value = getValueArg(labels, value);
 		labels = getLabelArg(labels);
-		if (value === undefined) value = 1;
-		setDelta(this, labels, -value);
+		setDelta(this, labels, -(value ?? 1));
 	}
 
 	/**
@@ -114,19 +104,18 @@ class Gauge extends Metric {
 			help: this.help,
 			name: this.name,
 			type: this.type,
-			values: Array.from(this.hashMap.values()),
+			values: Array.from(this.store.values()),
 			aggregator: this.aggregator,
 		};
 	}
 
 	_getValue(labels) {
-		const hash = hashObject(labels || {}, this.sortedLabelNames);
-		return this.hashMap.get(hash) ? this.hashMap.get(hash).value : 0;
+		return this.store.get(labels ?? {}) ?? 0;
 	}
 
 	labels(...args) {
 		const labels = getLabels(this.labelNames, args);
-		validateLabel(this.labelNames, labels);
+		this.store.validate(labels);
 		return {
 			inc: this.inc.bind(this, labels),
 			dec: this.dec.bind(this, labels),
@@ -138,8 +127,8 @@ class Gauge extends Metric {
 
 	remove(...args) {
 		const labels = getLabels(this.labelNames, args);
-		validateLabel(this.labelNames, labels);
-		removeLabels.call(this, this.hashMap, labels, this.sortedLabelNames);
+		this.store.validate(labels);
+		this.store.remove(labels);
 	}
 }
 
@@ -148,8 +137,8 @@ function set(gauge, labels, value) {
 		throw new TypeError(`Value is not a valid number: ${util.format(value)}`);
 	}
 
-	validateLabel(gauge.labelNames, labels);
-	setValue(gauge.hashMap, value, labels);
+	gauge.store.validate(labels);
+	gauge.store.set(labels, value);
 }
 
 function setDelta(gauge, labels, delta) {
@@ -157,9 +146,8 @@ function setDelta(gauge, labels, delta) {
 		throw new TypeError(`Delta is not a valid number: ${util.format(delta)}`);
 	}
 
-	validateLabel(gauge.labelNames, labels);
-	const hash = hashObject(labels, gauge.sortedLabelNames);
-	setValueDelta(gauge.hashMap, delta, labels, hash);
+	gauge.store.validate(labels);
+	gauge.store.setDelta(labels, delta);
 }
 
 function getLabelArg(labels) {

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -44,9 +44,9 @@ class Gauge extends Metric {
 	 * @returns {void}
 	 */
 	inc(labels, value) {
-		value = getValueArg(labels, value);
+		value = getValueArg(labels, value) ?? 1;
 		labels = getLabelArg(labels);
-		setDelta(this, labels, value ?? 1);
+		setDelta(this, labels, value);
 	}
 
 	/**
@@ -56,9 +56,9 @@ class Gauge extends Metric {
 	 * @returns {void}
 	 */
 	dec(labels, value) {
-		value = getValueArg(labels, value);
+		value = getValueArg(labels, value) ?? 1;
 		labels = getLabelArg(labels);
-		setDelta(this, labels, -(value ?? 1));
+		setDelta(this, labels, -value);
 	}
 
 	/**

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -4,14 +4,7 @@
 'use strict';
 
 const util = require('util');
-const {
-	getLabels,
-	hashObject,
-	isObject,
-	removeLabels,
-	nowTimestamp,
-} = require('./util');
-const { validateLabel } = require('./validation');
+const { getLabels, isObject, nowTimestamp, LabelMap } = require('./util');
 const { Metric } = require('./metric');
 const Exemplar = require('./exemplar');
 
@@ -54,9 +47,9 @@ class Histogram extends Metric {
 		Object.freeze(this.upperBounds);
 
 		if (this.labelNames.length === 0) {
-			this.hashMap = new Map();
-			this.hashMap.set(
-				hashObject({}),
+			this.store = new LabelMap(this.labelNames);
+			this.store.merge(
+				{},
 				createBaseValues({}, this.bucketValues, this.bucketExemplars),
 			);
 		}
@@ -83,9 +76,8 @@ class Histogram extends Metric {
 
 	updateExemplar(labels, value, exemplarLabels) {
 		if (Object.keys(exemplarLabels).length === 0) return;
-		const hash = hashObject(labels, this.sortedLabelNames);
 		const bound = findBound(this.upperBounds, value);
-		const { bucketExemplars } = this.hashMap.get(hash);
+		const { bucketExemplars } = this.store.entry(labels);
 		let exemplar = bucketExemplars[bound];
 		if (!isObject(exemplar)) {
 			exemplar = new Exemplar();
@@ -108,7 +100,7 @@ class Histogram extends Metric {
 			const v = this.collect();
 			if (v instanceof Promise) await v;
 		}
-		const data = Array.from(this.hashMap.values());
+		const data = Array.from(this.store.values());
 		const values = data
 			.map(extractBucketValuesForExport(this))
 			.reduce(addSumAndCountForExport(this), []);
@@ -123,7 +115,7 @@ class Histogram extends Metric {
 	}
 
 	reset() {
-		this.hashMap = new Map();
+		this.store = new LabelMap(this.labelNames);
 	}
 
 	/**
@@ -132,9 +124,9 @@ class Histogram extends Metric {
 	 * @returns {void}
 	 */
 	zero(labels) {
-		const hash = hashObject(labels, this.sortedLabelNames);
-		this.hashMap.set(
-			hash,
+		this.store.validate(labels);
+		this.store.merge(
+			labels,
 			createBaseValues(labels, this.bucketValues, this.bucketExemplars),
 		);
 	}
@@ -159,7 +151,7 @@ class Histogram extends Metric {
 
 	labels(...args) {
 		const labels = getLabels(this.labelNames, args);
-		validateLabel(this.labelNames, labels);
+		this.store.validate(labels);
 		return {
 			observe: value => observe(this, labels, value),
 			startTimer: () => startTimer(this, labels),
@@ -168,8 +160,8 @@ class Histogram extends Metric {
 
 	remove(...args) {
 		const labels = getLabels(this.labelNames, args);
-		validateLabel(this.labelNames, labels);
-		removeLabels.call(this, this.hashMap, labels, this.sortedLabelNames);
+		this.store.validate(labels);
+		this.store.remove(labels);
 	}
 }
 
@@ -225,32 +217,32 @@ function findBound(upperBounds, value) {
 function observe(histogram, labels, value) {
 	const labelValuePair = convertLabelsAndValues(labels, value);
 
-	validateLabel(histogram.labelNames, labelValuePair.labels);
 	if (!Number.isFinite(labelValuePair.value)) {
 		throw new TypeError(
 			`Value is not a valid number: ${util.format(labelValuePair.value)}`,
 		);
 	}
 
-	const hash = hashObject(labelValuePair.labels, histogram.sortedLabelNames);
-	let valueFromMap = histogram.hashMap.get(hash);
-	if (!valueFromMap) {
-		valueFromMap = createBaseValues(
+	histogram.store.validate(labelValuePair.labels);
+	let entry = histogram.store.entry(labelValuePair.labels);
+	if (entry === undefined) {
+		entry = histogram.store.merge(
 			labelValuePair.labels,
-			histogram.bucketValues,
-			histogram.bucketExemplars,
+			createBaseValues(
+				labelValuePair.labels,
+				histogram.bucketValues,
+				histogram.bucketExemplars,
+			),
 		);
-
-		histogram.hashMap.set(hash, valueFromMap);
 	}
 
 	const b = findBound(histogram.upperBounds, labelValuePair.value);
 
-	valueFromMap.sum += labelValuePair.value;
-	valueFromMap.count += 1;
+	entry.sum += labelValuePair.value;
+	entry.count += 1;
 
-	if (Object.hasOwn(valueFromMap.bucketValues, b)) {
-		valueFromMap.bucketValues[b] += 1;
+	if (Object.hasOwn(entry.bucketValues, b)) {
+		entry.bucketValues[b] += 1;
 	}
 }
 

--- a/lib/metric.js
+++ b/lib/metric.js
@@ -50,6 +50,7 @@ class Metric {
 			this.sortedLabelNames = [];
 		}
 
+		// TODO: Bad things happen when you call functions on half-initialized objects, yo
 		this.reset();
 
 		for (const register of this.registers) {

--- a/lib/metricAggregators.js
+++ b/lib/metricAggregators.js
@@ -21,23 +21,26 @@ function AggregatorFactory(aggregatorFn) {
 		const byLabels = new Grouper();
 		metrics.forEach(metric => {
 			metric.values.forEach(value => {
-				const key = hashObject(value.labels);
-				byLabels.add(`${value.metricName}_${key}`, value);
+				const key = value.metricName ?? '';
+				const group = byLabels.getOrAdd(key, () => new Grouper());
+
+				group.add(hashObject(value.labels), value);
 			});
 		});
 		// Apply aggregator function to gathered metrics.
-		byLabels.forEach(values => {
-			if (values.length === 0) return;
-			const valObj = {
-				value: aggregatorFn(values),
-				labels: values[0].labels,
-			};
+		byLabels.forEach(group => {
+			group.forEach(values => {
+				const valObj = {
+					value: aggregatorFn(values),
+					labels: values[0].labels,
+				};
 
-			if (values[0].metricName !== undefined) {
-				valObj.metricName = values[0].metricName;
-			}
-			// NB: Timestamps are omitted.
-			result.values.push(valObj);
+				if (values[0].metricName !== undefined) {
+					valObj.metricName = values[0].metricName;
+				}
+				// NB: Timestamps are omitted.
+				result.values.push(valObj);
+			});
 		});
 		return result;
 	};

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -45,8 +45,10 @@ class Registry {
 		const type = `# TYPE ${name} ${metric.type}`;
 		const values = [help, type];
 
-		const defaultLabels =
-			Object.keys(this._defaultLabels).length > 0 ? this._defaultLabels : null;
+		let defaultLabelNames = Object.keys(this._defaultLabels);
+		if (defaultLabelNames.length === 0) {
+			defaultLabelNames = undefined;
+		}
 
 		const isOpenMetrics =
 			this.contentType === Registry.OPENMETRICS_CONTENT_TYPE;
@@ -58,8 +60,13 @@ class Registry {
 				metricName = `${metricName}_total`;
 			}
 
-			if (defaultLabels !== undefined) {
-				labels = { ...labels, ...defaultLabels, ...labels };
+			if (defaultLabelNames !== undefined) {
+				// Make a copy before mutating
+				labels = { ...labels };
+
+				for (const labelName of defaultLabelNames) {
+					labels[labelName] ??= this._defaultLabels[labelName];
+				}
 			}
 
 			// We have to flatten these separately to avoid duplicate labels appearing
@@ -122,7 +129,10 @@ class Registry {
 
 	async getMetricsAsJSON() {
 		const metrics = [];
-		const defaultLabelNames = Object.keys(this._defaultLabels);
+		let defaultLabelNames = Object.keys(this._defaultLabels);
+		if (defaultLabelNames.length === 0) {
+			defaultLabelNames = undefined;
+		}
 
 		const promises = [];
 
@@ -133,10 +143,10 @@ class Registry {
 		const resolves = await Promise.all(promises);
 
 		for (const item of resolves) {
-			if (item.values && defaultLabelNames.length > 0) {
+			if (defaultLabelNames !== undefined && item.values !== undefined) {
 				for (const val of item.values) {
 					// Make a copy before mutating
-					val.labels = Object.assign({}, val.labels);
+					val.labels = { ...val.labels };
 
 					for (const labelName of defaultLabelNames) {
 						val.labels[labelName] ??= this._defaultLabels[labelName];

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -4,7 +4,7 @@
 'use strict';
 
 const util = require('util');
-const { getLabels, hashObject, removeLabels } = require('./util');
+const { getLabels, LabelMap } = require('./util');
 const { validateLabel } = require('./validation');
 const { Metric } = require('./metric');
 const timeWindowQuantiles = require('./timeWindowQuantiles');
@@ -16,24 +16,25 @@ class Summary extends Metric {
 		super(config, {
 			percentiles: [0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999],
 			compressCount: DEFAULT_COMPRESS_COUNT,
-			hashMap: new Map(),
+			store: new LabelMap(),
 		});
 
 		this.type = 'summary';
+		this.store = new LabelMap(this.labelNames);
 
+		if (this.labelNames.length === 0) {
+			this.store.set(
+				{},
+				{
+					td: new timeWindowQuantiles(this.maxAgeSeconds, this.ageBuckets),
+					count: 0,
+					sum: 0,
+				},
+			);
+		}
 		for (const label of this.labelNames) {
 			if (label === 'quantile')
 				throw new Error('quantile is a reserved label keyword');
-		}
-
-		if (this.labelNames.length === 0) {
-			this.hashmap = new Map();
-			this.hashMap.set(hashObject({}), {
-				labels: {},
-				td: new timeWindowQuantiles(this.maxAgeSeconds, this.ageBuckets),
-				count: 0,
-				sum: 0,
-			});
 		}
 	}
 
@@ -52,21 +53,16 @@ class Summary extends Metric {
 			const v = this.collect();
 			if (v instanceof Promise) await v;
 		}
-		const hashKeys = this.hashMap.keys();
 		const values = [];
 
-		for (const hashKey of hashKeys) {
-			const s = this.hashMap.get(hashKey);
-			if (s) {
-				if (this.pruneAgedBuckets && s.td.size() === 0) {
-					this.hashMap.delete(hashKey);
-				} else {
-					extractSummariesForExport(s, this.percentiles).forEach(v => {
-						values.push(v);
-					});
-					values.push(getSumForExport(s, this));
-					values.push(getCountForExport(s, this));
-				}
+		for (const entry of this.store.values()) {
+			const s = entry.value;
+			if (this.pruneAgedBuckets && s.td.size() === 0) {
+				this.store.remove(entry.labels);
+			} else {
+				values.push(...extractSummariesForExport(s, this.percentiles));
+				values.push(getSumForExport(s, this));
+				values.push(getCountForExport(s, this));
 			}
 		}
 
@@ -80,7 +76,8 @@ class Summary extends Metric {
 	}
 
 	reset() {
-		for (const s of this.hashMap.values()) {
+		for (const entry of this.store.values()) {
+			const s = entry.value;
 			s.td.reset();
 			s.count = 0;
 			s.sum = 0;
@@ -113,7 +110,7 @@ class Summary extends Metric {
 	remove(...args) {
 		const labels = getLabels(this.labelNames, args);
 		validateLabel(this.labelNames, labels);
-		removeLabels.call(this, this.hashMap, labels, this.sortedLabelNames);
+		this.store.remove(labels);
 	}
 }
 
@@ -168,18 +165,14 @@ function observe(labels) {
 			);
 		}
 
-		const hash = hashObject(labelValuePair.labels, this.sortedLabelNames);
-		let summaryOfLabel = this.hashMap.get(hash);
-		if (!summaryOfLabel) {
-			summaryOfLabel = {
+		const summaryOfLabel = this.store.getOrAdd(labelValuePair.labels, () => {
+			return {
 				labels: labelValuePair.labels,
 				td: new timeWindowQuantiles(this.maxAgeSeconds, this.ageBuckets),
 				count: 0,
 				sum: 0,
 			};
-
-			this.hashMap.set(hash, summaryOfLabel);
-		}
+		});
 
 		summaryOfLabel.td.push(labelValuePair.value);
 		summaryOfLabel.count++;

--- a/lib/util.js
+++ b/lib/util.js
@@ -136,6 +136,89 @@ exports.nowTimestamp = function nowTimestamp() {
 	return Date.now() / 1000;
 };
 
+class LabelMap extends Map {
+	#sortedLabelNames;
+
+	constructor(labelNames = []) {
+		super();
+
+		this.#sortedLabelNames = labelNames.slice().sort();
+	}
+
+	/**
+	 * @function setValue
+	 * @param {object} labels
+	 * @param {*} value
+	 */
+	set(labels, value) {
+		const val = typeof value === 'number' ? value : 0;
+		const key = this.keyFrom(labels);
+		const entry = this.get(key);
+
+		if (entry !== undefined) {
+			entry.value = val;
+		} else {
+			super.set(key, { value: val, labels });
+		}
+
+		return this;
+	}
+
+	/**
+	 * @function setDelta
+	 * @param {object} labels
+	 * @param {*} value
+	 * @returns {Map}
+	 */
+	setDelta(labels, value) {
+		const val = typeof value === 'number' ? value : 0;
+		const key = this.keyFrom(labels);
+		const entry = this.get(key);
+
+		if (entry !== undefined) {
+			entry.value += val;
+		} else {
+			super.set(key, { value: val, labels });
+		}
+
+		return this;
+	}
+
+	/**
+	 * @function remove
+	 * @param {string[]} labels
+	 */
+	remove(labels) {
+		this.delete(this.keyFrom(labels));
+	}
+
+	/**
+	 * Generate a sparse key for this Map.
+	 * @protected
+	 * @param labels {object}
+	 * @returns {string}
+	 */
+	keyFrom(labels = {}) {
+		const keys = Object.keys(labels);
+
+		if (keys.length === 0) {
+			return '';
+		}
+
+		const arr = new Array(keys.length);
+
+		for (let i = 0; i < this.#sortedLabelNames.length; i++) {
+			const labelName = this.#sortedLabelNames[i];
+
+			arr[i] = labels[labelName];
+		}
+
+		return arr.join('|');
+	}
+}
+
+exports.LabelMap = LabelMap;
+
 class Grouper extends Map {
 	/**
 	 * Adds the `value` to the `key`'s array of values.

--- a/lib/util.js
+++ b/lib/util.js
@@ -150,15 +150,14 @@ class LabelMap extends Map {
 	 * @param {object} labels
 	 * @param {*} value
 	 */
-	set(labels, value) {
-		const val = typeof value === 'number' ? value : 0;
+	set(labels, value = 0) {
 		const key = this.keyFrom(labels);
 		const entry = this.get(key);
 
 		if (entry !== undefined) {
-			entry.value = val;
+			entry.value = value;
 		} else {
-			super.set(key, { value: val, labels });
+			super.set(key, { value, labels });
 		}
 
 		return this;
@@ -170,18 +169,39 @@ class LabelMap extends Map {
 	 * @param {*} value
 	 * @returns {Map}
 	 */
-	setDelta(labels, value) {
-		const val = typeof value === 'number' ? value : 0;
+	setDelta(labels, value = 0) {
 		const key = this.keyFrom(labels);
 		const entry = this.get(key);
 
 		if (entry !== undefined) {
-			entry.value += val;
+			entry.value += value;
 		} else {
-			super.set(key, { value: val, labels });
+			super.set(key, { value, labels });
 		}
 
 		return this;
+	}
+
+	/**
+	 * Returns a record or creates one if it does not exist
+	 *
+	 * If there is no record at the location of the key, the init() function is
+	 * called to create an object to put there. This allows for nested structures.
+	 *
+	 * @param {object} labels labels for the new entry
+	 * @param {[Function]} init function to generate an empty record
+	 * @returns {*} the existing value or the result of init()
+	 */
+	getOrAdd(labels, init) {
+		const key = this.keyFrom(labels);
+		let entry = this.get(key);
+
+		if (entry === undefined) {
+			entry = { value: init(), labels };
+			super.set(key, entry);
+		}
+
+		return entry.value;
 	}
 
 	/**

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const util = require('util');
+
 exports.getValueAsString = function getValueString(value) {
 	if (Number.isFinite(value)) {
 		return `${value}`;
@@ -146,11 +148,11 @@ exports.nowTimestamp = function nowTimestamp() {
  * Lookup table for stats by labels.
  */
 class LabelMap {
-	#sortedLabelNames;
+	#labelNames;
 	#map = new Map();
 
 	constructor(labelNames = []) {
-		this.#sortedLabelNames = labelNames.slice().sort();
+		this.#labelNames = new Set(labelNames.slice().sort());
 	}
 
 	/**
@@ -258,6 +260,25 @@ class LabelMap {
 	}
 
 	/**
+	 * Determine if the given labels are all legal.
+	 * @param labels {object=}
+	 * @returns {boolean}
+	 */
+	validate(labels) {
+		if (labels !== undefined) {
+			for (const name in labels) {
+				if (!this.#labelNames.has(name)) {
+					throw new Error(
+						`Added label "${name}" is not included in initial labelset: ${util.inspect(Array.from(this.#labelNames))}`,
+					);
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
 	 * Return all of the entries in this collection.
 	 * @returns {Iterator<StatsEntry>}
 	 */
@@ -280,10 +301,9 @@ class LabelMap {
 
 		const arr = new Array(keys.length);
 
-		for (let i = 0; i < this.#sortedLabelNames.length; i++) {
-			const labelName = this.#sortedLabelNames[i];
-
-			arr[i] = labels[labelName];
+		let index = 0;
+		for (const labelName of this.#labelNames) {
+			arr[index++] = labels[labelName];
 		}
 
 		return arr.join('|');

--- a/lib/util.js
+++ b/lib/util.js
@@ -136,12 +136,20 @@ exports.nowTimestamp = function nowTimestamp() {
 	return Date.now() / 1000;
 };
 
-class LabelMap extends Map {
+/**
+ * @typedef StatsEntry {}
+ * @property value {*}
+ * @property labels {object}
+ */
+
+/**
+ * Lookup table for stats by labels.
+ */
+class LabelMap {
 	#sortedLabelNames;
+	#map = new Map();
 
 	constructor(labelNames = []) {
-		super();
-
 		this.#sortedLabelNames = labelNames.slice().sort();
 	}
 
@@ -149,15 +157,16 @@ class LabelMap extends Map {
 	 * @function setValue
 	 * @param {object} labels
 	 * @param {*} value
+	 * @returns {LabelMap}
 	 */
 	set(labels, value = 0) {
 		const key = this.keyFrom(labels);
-		const entry = this.get(key);
+		const entry = this.#map.get(key);
 
 		if (entry !== undefined) {
 			entry.value = value;
 		} else {
-			super.set(key, { value, labels });
+			this.#map.set(key, { value, labels });
 		}
 
 		return this;
@@ -167,19 +176,28 @@ class LabelMap extends Map {
 	 * @function setDelta
 	 * @param {object} labels
 	 * @param {*} value
-	 * @returns {Map}
+	 * @returns {LabelMap}
 	 */
 	setDelta(labels, value = 0) {
 		const key = this.keyFrom(labels);
-		const entry = this.get(key);
+		const entry = this.#map.get(key);
 
 		if (entry !== undefined) {
 			entry.value += value;
 		} else {
-			super.set(key, { value, labels });
+			this.#map.set(key, { value, labels });
 		}
 
 		return this;
+	}
+
+	/**
+	 * Get an entry from the store.
+	 * @param labels
+	 * @returns {*}
+	 */
+	get(labels) {
+		return this.#map.get(this.keyFrom(labels))?.value;
 	}
 
 	/**
@@ -194,22 +212,46 @@ class LabelMap extends Map {
 	 */
 	getOrAdd(labels, init) {
 		const key = this.keyFrom(labels);
-		let entry = this.get(key);
+		let entry = this.#map.get(key);
 
 		if (entry === undefined) {
 			entry = { value: init(), labels };
-			super.set(key, entry);
+			this.#map.set(key, entry);
 		}
 
 		return entry.value;
 	}
 
 	/**
+	 * Clear all records.
+	 */
+	clear() {
+		this.#map.clear();
+	}
+
+	/**
+	 * Size of the collection.
+	 * @returns {number}
+	 */
+	get size() {
+		return this.#map.size;
+	}
+
+	/**
+	 * Remove entries for a label.
 	 * @function remove
-	 * @param {string[]} labels
+	 * @param {object} labels
 	 */
 	remove(labels) {
-		this.delete(this.keyFrom(labels));
+		this.#map.delete(this.keyFrom(labels));
+	}
+
+	/**
+	 * Return all of the entries in this collection.
+	 * @returns {Iterator<StatsEntry>}
+	 */
+	values() {
+		return this.#map.values();
 	}
 
 	/**

--- a/lib/util.js
+++ b/lib/util.js
@@ -148,7 +148,10 @@ exports.nowTimestamp = function nowTimestamp() {
  * Lookup table for stats by labels.
  */
 class LabelMap {
+	/** @type {Set<string>} */
 	#labelNames;
+
+	/** @type {Map<string, StatsEntry>} */
 	#map = new Map();
 
 	constructor(labelNames = []) {
@@ -233,6 +236,26 @@ class LabelMap {
 	 */
 	entry(labels) {
 		return this.#map.get(this.keyFrom(labels));
+	}
+
+	/**
+	 * Support for additional fields on the storage record.
+	 * @param labels {object} lookup key
+	 * @param values {object}
+	 * @returns {object}
+	 */
+	merge(labels, values) {
+		const key = this.keyFrom(labels);
+
+		let entry = this.#map.get(key);
+		if (entry !== undefined) {
+			Object.assign(entry, values, { labels });
+		} else {
+			entry = { ...values, labels };
+			this.#map.set(key, entry);
+		}
+
+		return entry;
 	}
 
 	/**

--- a/lib/util.js
+++ b/lib/util.js
@@ -223,6 +223,17 @@ class LabelMap {
 	}
 
 	/**
+	 * Return the raw entry.
+	 * Used internally by some Metrics. You should probably not call this directly.
+	 * @protected
+	 * @param labels {object}
+	 * @returns {StatsEntry}
+	 */
+	entry(labels) {
+		return this.#map.get(this.keyFrom(labels));
+	}
+
+	/**
 	 * Clear all records.
 	 */
 	clear() {

--- a/lib/util.js
+++ b/lib/util.js
@@ -151,6 +151,26 @@ class Grouper extends Map {
 			this.set(key, [value]);
 		}
 	}
+
+	/**
+	 * Returns a child record or creates one if it does not exist
+	 *
+	 * If there is no record at the location of the key, the init() function is
+	 * called to create an object to put there. This allows for nested structures.
+	 *
+	 * @param {*} key Key to verify
+	 * @param {[Function]} init function to generate an empty record
+	 * @returns {undefined} undefined
+	 */
+	getOrAdd(key, init = () => []) {
+		let entry = this.get(key);
+		if (entry === undefined) {
+			entry = init();
+			this.set(key, entry);
+		}
+
+		return entry;
+	}
 }
 
 exports.Grouper = Grouper;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"node": "^20 || ^22 || >=24"
 	},
 	"scripts": {
-		"benchmarks": "node --max-old-space-size=8192 ./benchmarks/index.js",
+		"benchmarks": "node --max-old-space-size=9000 ./benchmarks/index.js",
 		"test": "npm run lint && npm run check-prettier && npm run compile-typescript && npm run test-unit -- --coverage",
 		"lint": "eslint .",
 		"test-unit": "jest",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"node": "^20 || ^22 || >=24"
 	},
 	"scripts": {
-		"benchmarks": "node --max-heap-size=9000 ./benchmarks/index.js",
+		"benchmarks": "node --max-heap-size=5000 ./benchmarks/index.js",
 		"test": "npm run lint && npm run check-prettier && npm run compile-typescript && npm run test-unit -- --coverage",
 		"lint": "eslint .",
 		"test-unit": "jest",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"node": "^20 || ^22 || >=24"
 	},
 	"scripts": {
-		"benchmarks": "node --max-old-space-size=9000 ./benchmarks/index.js",
+		"benchmarks": "node --max-heap-size=9000 ./benchmarks/index.js",
 		"test": "npm run lint && npm run check-prettier && npm run compile-typescript && npm run test-unit -- --coverage",
 		"lint": "eslint .",
 		"test-unit": "jest",

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -273,6 +273,7 @@ describe.each([
 	});
 
 	async function expectValue(val) {
-		expect((await instance.get()).values[0].value).toEqual(val);
+		const result = await instance.get();
+		expect(result.values[0].value).toEqual(val);
 	}
 });

--- a/test/utilTest.js
+++ b/test/utilTest.js
@@ -141,6 +141,25 @@ describe('utils', () => {
 			});
 		});
 
+		describe('entry()', () => {
+			it('does not error on missing entry', () => {
+				const map = new LabelMap(['b', 'c', 'a']);
+
+				expect(map.entry({ foo: 'bar' })).toBeUndefined();
+			});
+
+			it('returns the entry', () => {
+				const map = new LabelMap(['b', 'c', 'a']);
+
+				map.set({ b: 22 }, 10);
+
+				expect(map.entry({ b: 22 })).toStrictEqual({
+					value: 10,
+					labels: { b: 22 },
+				});
+			});
+		});
+
 		describe('remove()', () => {
 			it('can remove records', () => {
 				const map = new LabelMap(['b', 'c', 'a']);

--- a/test/utilTest.js
+++ b/test/utilTest.js
@@ -18,6 +18,152 @@ describe('utils', () => {
 		});
 	});
 
+	describe('LabelMap', () => {
+		const { LabelMap } = require('../lib/util');
+
+		it('can be instantiated', () => {
+			const map = new LabelMap(['d', 'b', 'a']);
+
+			expect(map.size).toEqual(0);
+		});
+
+		describe('keyFrom()', () => {
+			it('handles reordered labels', () => {
+				const map = new LabelMap(['b', 'c', 'a']);
+
+				const result = map.keyFrom({ a: 1, c: 200, b: 'post' });
+
+				expect(result).toEqual('1|post|200');
+			});
+
+			it('allows sparse labels ', () => {
+				const map = new LabelMap(['b', 'c', 'a', 'd']);
+
+				const result = map.keyFrom({ d: 'a|b' });
+
+				expect(result).toEqual('|||a|b');
+			});
+		});
+
+		describe('set()', () => {
+			it('can create new records', () => {
+				const map = new LabelMap(['b', 'c', 'a']);
+
+				map.set({ a: 2 }, 3);
+
+				expect(map.size).toEqual(1);
+				expect(map.get('2||')).toStrictEqual({ value: 3, labels: { a: 2 } });
+			});
+
+			it('can update existing values', () => {
+				const map = new LabelMap(['b', 'c', 'a']);
+
+				// And supports chaining
+				map.set({ a: 2 }, 3).set({ a: 2 }, 4);
+
+				expect(map.size).toEqual(1);
+				expect(map.get('2||')).toStrictEqual({ value: 4, labels: { a: 2 } });
+			});
+
+			it('creates separate records for each label combination', () => {
+				const map = new LabelMap(['b', 'c', 'a']);
+
+				map.set({ a: 2 }, 3).set({ a: 3 }, 3);
+
+				expect(map.size).toEqual(2);
+				expect(map.get('2||')).toStrictEqual({ value: 3, labels: { a: 2 } });
+			});
+		});
+
+		describe('setDetla()', () => {
+			it('can create new records', () => {
+				const map = new LabelMap(['b', 'c', 'a']);
+
+				map.setDelta({ a: 2 }, 3);
+
+				expect(map.size).toEqual(1);
+				expect(map.get('2||')).toStrictEqual({ value: 3, labels: { a: 2 } });
+			});
+
+			it('can update existing values', () => {
+				const map = new LabelMap(['b', 'c', 'a']);
+
+				map.setDelta({ a: 2 }, 3).setDelta({ a: 2 }, 4);
+
+				expect(map.size).toEqual(1);
+				expect(map.get('2||')).toStrictEqual({
+					value: 3 + 4,
+					labels: { a: 2 },
+				});
+			});
+
+			it('creates separate records for each label combination', () => {
+				const map = new LabelMap(['b', 'c', 'a']);
+
+				map.setDelta({ a: 2 }, 3);
+				map.setDelta({ a: 3 }, 3);
+
+				expect(map.size).toEqual(2);
+				expect(map.get('2||')).toStrictEqual({ value: 3, labels: { a: 2 } });
+			});
+		});
+
+		describe('remove()', () => {
+			it('can create new records', () => {
+				const map = new LabelMap(['b', 'c', 'a']);
+
+				map.setDelta({ a: 2 }, 3);
+
+				expect(map.size).toEqual(1);
+				expect(map.get('2||')).toStrictEqual({ value: 3, labels: { a: 2 } });
+			});
+
+			it('can update existing values', () => {
+				const map = new LabelMap(['b', 'c', 'a']);
+
+				map.setDelta({ a: 2 }, 3).setDelta({ a: 2 }, 4);
+
+				expect(map.size).toEqual(1);
+				expect(map.get('2||')).toStrictEqual({
+					value: 3 + 4,
+					labels: { a: 2 },
+				});
+			});
+
+			it('creates separate records for each label combination', () => {
+				const map = new LabelMap(['b', 'c', 'a']);
+
+				map.setDelta({ a: 2 }, 3);
+				map.setDelta({ a: 3 }, 3);
+
+				expect(map.size).toEqual(2);
+				expect(map.get('2||')).toStrictEqual({ value: 3, labels: { a: 2 } });
+			});
+		});
+
+		describe('clear()', () => {
+			it('resets the collection', () => {
+				const map = new LabelMap(['b', 'c', 'a']);
+
+				map.set({ a: 2 }, 3).set({ a: 3 }, 4);
+				map.clear();
+
+				expect(map.size).toEqual(0);
+			});
+
+			it('can still add new records after clear()ing', () => {
+				const map = new LabelMap(['b', 'c', 'a']);
+
+				map.set({ a: 2 }, 3);
+				map.clear();
+				map.set({ a: 3 }, 4);
+
+				expect(map.size).toEqual(1);
+				expect(map.get('3||')).toStrictEqual({ value: 4, labels: { a: 3 } });
+			});
+		});
+	});
+
 	describe('Grouper', () => {
 		const { Grouper } = require('../lib/util');
 

--- a/test/utilTest.js
+++ b/test/utilTest.js
@@ -17,4 +17,72 @@ describe('utils', () => {
 			);
 		});
 	});
+
+	describe('Grouper', () => {
+		const { Grouper } = require('../lib/util');
+
+		it('can be instantiated', () => {
+			const grouper = new Grouper();
+
+			expect(grouper.size).toEqual(0);
+		});
+
+		it('supports same constructor syntax as Map', () => {
+			const grouper = new Grouper([['name', []]]);
+
+			expect(grouper.size).toEqual(1);
+			expect(grouper.has('name')).toBe(true);
+		});
+
+		describe('add()', () => {
+			it('can create new records', () => {
+				const grouper = new Grouper([['name', [2]]]);
+
+				grouper.add('name', 3);
+
+				expect(grouper.size).toEqual(1);
+				expect(grouper.get('name')).toStrictEqual([2, 3]);
+			});
+
+			it('creates separate records for each key', () => {
+				const grouper = new Grouper([['name', [2]]]);
+
+				grouper.add('other', 3);
+
+				expect(grouper.size).toEqual(2);
+				expect(grouper.get('other')).toStrictEqual([3]);
+			});
+		});
+
+		describe('getOrAdd()', () => {
+			it('returns existing values', () => {
+				const grouper = new Grouper([['name', [2, 3]]]);
+				const callback = jest.fn();
+
+				const actual = grouper.getOrAdd('name', callback);
+
+				expect(actual).toStrictEqual([2, 3]);
+				expect(callback).not.toHaveBeenCalled();
+			});
+
+			it('adds on missing record', () => {
+				const grouper = new Grouper([['name', [2, 3]]]);
+				const callback = jest.fn(() => 4);
+
+				const actual = grouper.getOrAdd('blah', callback);
+
+				expect(actual).toStrictEqual(4);
+				expect(grouper.get('blah')).toStrictEqual(4);
+				expect(callback).toHaveBeenCalled();
+			});
+
+			it('defaults to inserting an empty array', () => {
+				const grouper = new Grouper([['name', [2, 3]]]);
+				const actual = grouper.getOrAdd('blah');
+
+				expect(actual).toStrictEqual([]);
+				expect(grouper.get('blah')).toStrictEqual([]);
+			});
+		});
+	});
 });

--- a/test/utilTest.js
+++ b/test/utilTest.js
@@ -251,6 +251,34 @@ describe('utils', () => {
 				]);
 			});
 		});
+
+		describe('merge()', () => {
+			it('creates an entry if missing', () => {
+				const map = new LabelMap(['method', 'region', 'version']);
+
+				const result = map.merge(
+					{ method: 'head' },
+					{ a: 'foo', labels: { b: 2 } },
+				);
+				expect(result).toBeDefined();
+
+				expect(map.entry({ method: 'head' })).toBe(result);
+			});
+
+			it('merges in values', () => {
+				const map = new LabelMap(['method', 'region', 'version']);
+
+				const result = map.merge(
+					{ method: 'head' },
+					{ a: 'foo', labels: { b: 2 } },
+				);
+
+				expect(result).toStrictEqual({
+					labels: { method: 'head' },
+					a: 'foo',
+				});
+			});
+		});
 	});
 
 	describe('Grouper', () => {

--- a/test/utilTest.js
+++ b/test/utilTest.js
@@ -182,6 +182,22 @@ describe('utils', () => {
 			});
 		});
 
+		describe('validate()', () => {
+			it('should not throw on known label', () => {
+				const map = new LabelMap(['exists']);
+
+				expect(() => map.validate({ exists: null })).not.toThrow();
+			});
+
+			it('should throw on unknown label', () => {
+				const map = new LabelMap(['exists']);
+
+				expect(() => map.validate({ somethingElse: null })).toThrow(
+					'Added label "somethingElse" is not included in initial labelset: [ \'exists\' ]',
+				);
+			});
+		});
+
 		describe('getOrAdd()', () => {
 			it('returns existing values', () => {
 				const map = new LabelMap(['b', 'c', 'a']);

--- a/test/utilTest.js
+++ b/test/utilTest.js
@@ -141,6 +141,36 @@ describe('utils', () => {
 			});
 		});
 
+		describe('getOrAdd()', () => {
+			it('returns existing values', () => {
+				const map = new LabelMap(['b', 'c', 'a']);
+				const callback = jest.fn();
+
+				map.set({ c: 200 }, [2, 3]);
+
+				const actual = map.getOrAdd({ c: 200 }, callback);
+
+				expect(actual).toStrictEqual([2, 3]);
+				expect(callback).not.toHaveBeenCalled();
+			});
+
+			it('adds on missing record', () => {
+				const map = new LabelMap(['b', 'c', 'a']);
+				const callback = jest.fn(() => 4);
+
+				map.set({ c: 200 }, [2, 3]);
+
+				const actual = map.getOrAdd({ c: 401 }, callback);
+
+				expect(actual).toStrictEqual(4);
+				expect(map.get('||401')).toStrictEqual({
+					labels: { c: 401 },
+					value: 4,
+				});
+				expect(callback).toHaveBeenCalled();
+			});
+		});
+
 		describe('clear()', () => {
 			it('resets the collection', () => {
 				const map = new LabelMap(['b', 'c', 'a']);


### PR DESCRIPTION
This change consolidates a lot of util code into a single object that can guarantee that the functionality is all used consistently, which gets the metrics out of the job of managing labelNames and their sorting.

This results in a 20-45% improvement in benchmark time for most of the metric types. Gauges with no labels act weird, but if you disable the counter tests this mostly goes away, suggesting testing artifacts. The benefits are more substantial for metrics with label (which IME is 'every singe metric you have', but may result in a slight decline in the no-label path.

However, since the no-label path has historically been **nearly 500 times faster** than the label scenario, this is not a real problem. The amortized cost of the entire system is greatly reduced by optimizing for the common case over the rare.

### What's it do?

This PR introduces a data structure that owns both the labels and the metrics that correspond with them. It encapsulates all of the lifecycle operations in a single class, which means internal implementation details can be adjusted in the future to explore further improvements. For example, moving `validateLabels` into the receiving functions and changing the key structure in arbitrary ways, including possibly turning it into an array to reduce string fragment duplication.

The brunt of this PR, besides adding lots of additional benchmarks and culling some other ones to keep the total run time not insane, is this:

- All possible keys for a metric are known at creation time
- new values can show up arbitrarily
- the store becomes a cartesian product of all values for the given keys
 
You can think of this as a matrix or a table

```
| label1        |        label2 |        label3 |
| ------------- | ------------- | ------------- | 
|      -        |      200      |     'get'     |
|    orange     |       -       |       -       |
|     blue      |      403      |       -       |
```
The keys are a sparse list of hits with `''` serving as all empty elements, resulting in the following keys for the example above:
- `|200|get` instead of `label2:200,label3:get,`
- `orange||` instead of `label1:orange,`
- `blue|403|` instead of `label1:blue,label2:403,`

In my experience the tags can be at least as long as the values, and a substantial fraction of tags that can be set will be set, so I believe this will be a net substantial reduction in memory usage.

Structured this way, we can experiment with different solutions. A tree structure? sorting keys by a different order, etc.

#### What about pipes in the data causing key collisions?

The existing system has the same problem with ':', but worse, because both the keys and values can contain colons. which is a legal character in key names in prometheus., For pipes to cause a problem here, you need two consecutive columns with repeating values, such that for instance 'a' and 'a|b' are legal values in one column, and 'c' and 'b|c' are legal values in the consecutive columns. Essentially you need to generate extra pipes with common substrings in two columns to cause the values to collide.

If this is seen as a problem, we could prometheus-escape the values before inserting them, but that will erode a little of the performance gain by causing an encode on every read operation. We could investigate other options at a later date, as the key structure is, as I mentioned already, now an internal implementation detail.


Note that this branch shares some benchmark-related commits in common with #683 and #680. If either of those merge, this PR will get a lot smaller.