### PR TITLE
Further refinement of key computation for performance and space.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Show the invalid name in the validation errors
 - perf: Improve performance of registry defaultLabels during metric processing
 - perf: New, more space-efficient storage engine, 20-45% faster stats recording
+- perf: Further improvement to key generation cost
 
 ### Added
 

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -48,6 +48,7 @@ benchmarks.suite('counter', require('./counter'));
 benchmarks.suite('gauge', require('./gauge'));
 benchmarks.suite('histogram', require('./histogram'));
 benchmarks.suite('summary', require('./summary'));
+benchmarks.suite('util', require('./util'));
 benchmarks.suite('registry', require('./registry'));
 benchmarks.suite('cluster', require('./cluster'));
 

--- a/benchmarks/util.js
+++ b/benchmarks/util.js
@@ -1,0 +1,75 @@
+'use strict';
+
+module.exports = setupUtilSuite;
+
+function setupUtilSuite(suite) {
+	suite.add(
+		'hashObject',
+		(client, Util) => {
+			if (Util === undefined) {
+				return;
+			}
+
+			Util.hashObject({
+				foo: 'longish',
+				user_agent: 'Chrome',
+				gateway: 'lb04',
+			});
+		},
+		{ setup: findUtil },
+	);
+
+	suite.add(
+		'LabelMap.validate()',
+		(client, labelMap) => {
+			if (labelMap === undefined) {
+				return;
+			}
+
+			labelMap.validate({
+				foo: 'longish:tag:goes:here',
+				user_agent: 'Chrome',
+				status_code: 503,
+			});
+		},
+		{ setup },
+	);
+
+	suite.add(
+		'LabelMap.keyFrom()',
+		(client, labelMap) => {
+			if (labelMap === undefined) {
+				return;
+			}
+
+			labelMap.keyFrom({
+				foo: 'longish',
+				user_agent: 'Chrome',
+				status_code: 503,
+			});
+		},
+		{ setup },
+	);
+}
+
+function setup(client) {
+	const Util = findUtil(client);
+
+	if (Util !== undefined) {
+		return new Util.LabelMap([
+			'foo',
+			'user_agent',
+			'gateway',
+			'method',
+			'status_code',
+		]);
+	}
+}
+
+function findUtil(client) {
+	for (const key of Object.getOwnPropertySymbols(client)) {
+		if (key.toString() === 'Symbol(util)') {
+			return client[key];
+		}
+	}
+}

--- a/index.js
+++ b/index.js
@@ -35,3 +35,4 @@ exports.collectDefaultMetrics = require('./lib/defaultMetrics');
 
 exports.aggregators = require('./lib/metricAggregators').aggregators;
 exports.AggregatorRegistry = require('./lib/cluster');
+exports[Symbol('util')] = require('./lib/util');

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -4,7 +4,13 @@
 'use strict';
 
 const util = require('util');
-const { getLabels, isObject, nowTimestamp, LabelMap } = require('./util');
+const {
+	getLabels,
+	isObject,
+	isEmpty,
+	nowTimestamp,
+	LabelMap,
+} = require('./util');
 const { Metric } = require('./metric');
 const Exemplar = require('./exemplar');
 
@@ -75,7 +81,7 @@ class Histogram extends Metric {
 	}
 
 	updateExemplar(labels, value, exemplarLabels) {
-		if (Object.keys(exemplarLabels).length === 0) return;
+		if (isEmpty(exemplarLabels)) return;
 		const bound = findBound(this.upperBounds, value);
 		const { bucketExemplars } = this.store.entry(labels);
 		let exemplar = bucketExemplars[bound];

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -5,7 +5,6 @@
 
 const util = require('util');
 const { getLabels, LabelMap } = require('./util');
-const { validateLabel } = require('./validation');
 const { Metric } = require('./metric');
 const timeWindowQuantiles = require('./timeWindowQuantiles');
 
@@ -100,7 +99,7 @@ class Summary extends Metric {
 
 	labels(...args) {
 		const labels = getLabels(this.labelNames, args);
-		validateLabel(this.labelNames, labels);
+		this.store.validate(labels);
 		return {
 			observe: observe.call(this, labels),
 			startTimer: startTimer.call(this, labels),
@@ -109,7 +108,7 @@ class Summary extends Metric {
 
 	remove(...args) {
 		const labels = getLabels(this.labelNames, args);
-		validateLabel(this.labelNames, labels);
+		this.store.validate(labels);
 		this.store.remove(labels);
 	}
 }
@@ -158,7 +157,7 @@ function observe(labels) {
 	return value => {
 		const labelValuePair = convertLabelsAndValues(labels, value);
 
-		validateLabel(this.labelNames, labels);
+		this.store.validate(labels);
 		if (!Number.isFinite(labelValuePair.value)) {
 			throw new TypeError(
 				`Value is not a valid number: ${util.format(labelValuePair.value)}`,

--- a/lib/util.js
+++ b/lib/util.js
@@ -322,14 +322,13 @@ class LabelMap {
 			return '';
 		}
 
-		const arr = new Array(keys.length);
+		let key = '';
 
-		let index = 0;
 		for (const labelName of this.#labelNames) {
-			arr[index++] = labels[labelName];
+			key = key.concat(labels[labelName] ?? '', '|');
 		}
 
-		return arr.join('|');
+		return key;
 	}
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -134,6 +134,16 @@ exports.isObject = function isObject(obj) {
 	return obj !== null && typeof obj === 'object';
 };
 
+function isEmpty(obj) {
+	for (const key in obj) {
+		return false;
+	}
+
+	return true;
+}
+
+exports.isEmpty = isEmpty;
+
 exports.nowTimestamp = function nowTimestamp() {
 	return Date.now() / 1000;
 };
@@ -316,9 +326,7 @@ class LabelMap {
 	 * @returns {string}
 	 */
 	keyFrom(labels = {}) {
-		const keys = Object.keys(labels);
-
-		if (keys.length === 0) {
+		if (isEmpty(labels)) {
 			return '';
 		}
 

--- a/test/utilTest.js
+++ b/test/utilTest.js
@@ -1,6 +1,34 @@
 'use strict';
 
 describe('utils', () => {
+	describe('isObject', () => {
+		const isObject = require('../lib/util').isObject;
+
+		it('should not throw on missing argument', () => {
+			isObject();
+		});
+
+		it('should return true for empty object', () => {
+			expect(isObject({})).toBe(true);
+		});
+	});
+
+	describe('isEmpty', () => {
+		const isEmpty = require('../lib/util').isEmpty;
+
+		it('should not throw on missing argument', () => {
+			isEmpty();
+		});
+
+		it('should return true for empty object', async () => {
+			expect(isEmpty({})).toBe(true);
+		});
+
+		it('should return false for an object with keys', async () => {
+			expect(isEmpty({ foo: undefined })).toBe(false);
+		});
+	});
+
 	describe('getLabels', () => {
 		const getLabels = require('../lib/util').getLabels;
 

--- a/test/utilTest.js
+++ b/test/utilTest.js
@@ -33,7 +33,7 @@ describe('utils', () => {
 
 				const result = map.keyFrom({ a: 1, c: 200, b: 'post' });
 
-				expect(result).toEqual('1|post|200');
+				expect(result).toEqual('1|post|200|');
 			});
 
 			it('allows sparse labels ', () => {
@@ -41,7 +41,7 @@ describe('utils', () => {
 
 				const result = map.keyFrom({ d: 'a|b' });
 
-				expect(result).toEqual('|||a|b');
+				expect(result).toEqual('|||a|b|');
 			});
 		});
 


### PR DESCRIPTION
This builds upon #687 to use the same changes made in previous PRs more consistently. 

- Avoid using Object.keys() to detect empty objects 
- keyFrom: Use the same string concatenation optimisation as hashObject

Before:
    
    ✓ summary ➭ observe#2 with 4 and 2 with 2 is 1.678% faster.
    ⚠ summary ➭ observe#2 with 2 and 2 with 4 is 0.2139% acceptably slower.
    - util ➭ LabelMap.keyFrom() ➭ prom-client@current x 5,451,368 ops/sec ±0.41% (86 runs sampled)
    
After:
    
    ✓ summary ➭ observe#2 with 4 and 2 with 2 is 15.81% faster.
    ✓ summary ➭ observe#2 with 2 and 2 with 4 is 11.08% faster.
    - util ➭ LabelMap.keyFrom() ➭ prom-client@current x 6,674,153 ops/sec ±0.43% (86 runs sampled)

   

Only 1162f5437f8e9c053d70c47dd2e983d71c568683 and on are new code (4 commits), the rest are from #687 which has not been merged for some reason.