### PR TITLE
Performance: simplified checking for reserved label keyword

### DIFF
--- a/lib/summary.js
+++ b/lib/summary.js
@@ -19,6 +19,9 @@ class Summary extends Metric {
 			store: new LabelMap(),
 		});
 
+		if (this.labelNames.includes('quantile'))
+			throw new Error('quantile is a reserved label keyword');
+
 		this.type = 'summary';
 		this.store = new LabelMap(this.labelNames);
 
@@ -31,10 +34,6 @@ class Summary extends Metric {
 					sum: 0,
 				},
 			);
-		}
-		for (const label of this.labelNames) {
-			if (label === 'quantile')
-				throw new Error('quantile is a reserved label keyword');
 		}
 	}
 


### PR DESCRIPTION
`this.labelNames` is array of string, so we can just use `includes` instead of `for of`.
Since this code was still throwing an error, I moved it up to ensure it completes earlier. The class instance still wouldn’t be created anyway, I moved it up.