### PR TITLE
Update to 1.0 version of faceoff.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"eslint-plugin-n": "^17.20.0",
 		"eslint-plugin-prettier": "^5.0.1",
 		"express": "^5.1.0",
-		"faceoff": "^0.10.0",
+		"faceoff": "^1.0.0",
 		"globals": "^16.2.0",
 		"husky": "^9.0.0",
 		"jest": "^30.0.2",


### PR DESCRIPTION
bench-node landed my PR to expose output formatting without console.log, and I am now using that instead of monkey patching console.