### PR TITLE
Update to faceoff 1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - ci: Run benchmarks for pull requests
 - ci: switch out deprecated benchmark-regression library for replacement
 - AggregatorRegistry renamed to ClusterRegistry, old name deprecated
+- chore: update faceoff to 1.1
 
 ### Added
 

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -12,11 +12,10 @@ const debug = require('debug')('benchmark');
  * 2018, that situation is unlikely to change soon.
  */
 
-const currentClient = require('..');
 const benchmarks = new Benchmark({
 	'prom-client@latest': 'prom-client@latest',
 	'prom-client@trunk': 'git@github.com:siimon/prom-client',
-	'prom-client@current': currentClient,
+	'prom-client@current': { location: process.cwd() },
 });
 
 benchmarks.suite('counter', require('./counter'));

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"eslint-plugin-n": "^17.20.0",
 		"eslint-plugin-prettier": "^5.0.1",
 		"express": "^5.1.0",
-		"faceoff": "^0.10.0",
+		"faceoff": "^1.1.0",
 		"globals": "^16.2.0",
 		"husky": "^9.0.0",
 		"jest": "^30.0.2",


### PR DESCRIPTION
faceoff 1.1 introduced a breaking change in the API that affects prom-client.  This PR fixes the issue.