### PR TITLE
Mcollina perf improvements migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Expanded benchmarking code
+- Expanded benchmarks and using new benchmarking library
 - new WorkerRegistry to provide equivalent support to AggregatorRegistry
 
 ## [15.1.3] - 2024-06-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - ci: switch out deprecated benchmark-regression library for replacement
 - AggregatorRegistry renamed to ClusterRegistry, old name deprecated
 - chore: update faceoff to 1.1
+- perf: Avoid array conversion in getMetricsAsJSON by directly iterating over metric values (~1.3% faster)
+- perf: Optimize string escaping for better metrics serialization
 
 ### Added
 

--- a/benchmarks/defaultMetrics.js
+++ b/benchmarks/defaultMetrics.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const Path = require('path');
+const { createRequire } = require('node:module');
+const { getLabelCombinations } = require('./utils/labels');
+
+let count = 1;
+
+module.exports = function setupSuites(benchmark) {
+	benchmark.suite('osMemoryHeap', suite => {
+		suite.add(
+			'new',
+			(client, { labels, metric: osMemoryHeap, registry }) =>
+				osMemoryHeap(registry, {
+					prefix: `heap${count++}`,
+					help: 'HeapUsed',
+					labels,
+				}),
+			{
+				setup: (client, location) =>
+					loadMetrics(client, location, 'osMemoryHeap'),
+				teardown,
+			},
+		);
+
+		suite.add('collect', async (client, { registry }) => registry.metrics(), {
+			setup: (client, location) => {
+				const ctx = loadMetrics(client, location, 'osMemoryHeap');
+				const { metric: osMemoryHeap, labels, registry } = ctx;
+
+				osMemoryHeap(registry, {
+					prefix: `heap${count++}`,
+					help: 'HeapUsed',
+					labels,
+				});
+
+				return { registry };
+			},
+			teardown,
+		});
+	});
+};
+
+function loadMetrics(client, location, metricName) {
+	const require = createRequire(location);
+	const fromModule = Path.join(location, `./lib/metrics/${metricName}`);
+	const combinations = getLabelCombinations([1], ['region', 'env']);
+
+	return {
+		metric: require(fromModule),
+		labels: combinations[0],
+		registry: new client.Registry(),
+	};
+}
+
+function teardown(client, { registry }) {
+	registry.clear();
+}

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -24,6 +24,7 @@ benchmarks.suite('histogram', require('./histogram'));
 benchmarks.suite('util', require('./util'));
 benchmarks.suite('summary', require('./summary'));
 benchmarks.suite('registry', require('./registry'));
+benchmarks.suite('default metrics', require('./defaultMetrics'));
 benchmarks.suite('cluster', require('./cluster'));
 
 benchmarks

--- a/benchmarks/util.js
+++ b/benchmarks/util.js
@@ -5,7 +5,7 @@ const Path = require('path');
 module.exports = setupUtilSuite;
 
 function setupUtilSuite(suite) {
-	const skip = ['prom-client@latest', 'prom-client@trunk'];
+	const skip = ['prom-client@latest'];
 
 	suite.add(
 		'hashObject',

--- a/index.js
+++ b/index.js
@@ -38,4 +38,3 @@ exports.ClusterRegistry = require('./lib/cluster');
 exports.WorkerRegistry = require('./lib/worker');
 /** @deprecated */
 exports.AggregatorRegistry = exports.ClusterRegistry;
-exports[Symbol('util')] = require('./lib/util');

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -137,7 +137,7 @@ class Registry {
 
 		const promises = [];
 
-		for (const metric of this.getMetricsAsArray()) {
+		for (const metric of this._metrics.values()) {
 			promises.push(metric.get());
 		}
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -293,11 +293,46 @@ function escapeLabelValue(str) {
 	if (typeof str !== 'string') {
 		return str;
 	}
-	return escapeString(str).replace(/"/g, '\\"');
+
+	let result = '';
+	for (let i = 0; i < str.length; i++) {
+		const char = str[i];
+		switch (char) {
+			case '\\':
+				result += '\\\\';
+				break;
+			case '\n':
+				result += '\\n';
+				break;
+			case '"':
+				result += '\\"';
+				break;
+			default:
+				result += char;
+		}
+	}
+
+	return result;
 }
+
 function escapeString(str) {
-	return str.replace(/\\/g, '\\\\').replace(/\n/g, '\\n');
+	let result = '';
+	for (let i = 0; i < str.length; i++) {
+		const char = str[i];
+		switch (char) {
+			case '\\':
+				result += '\\\\';
+				break;
+			case '\n':
+				result += '\\n';
+				break;
+			default:
+				result += char;
+		}
+	}
+	return result;
 }
+
 function standardizeCounterName(name) {
 	return name.replace(/_total$/, '');
 }


### PR DESCRIPTION
This represents a cherry-pick of the changes in #727 with a few modifications to separate the testing changes and account for PRs of mine that already merged. 

In most cases I preserved @mcollina 's commits, in some cases with deletions to split problem code from otherwise serviceable code.

Unfortunately this has removed:

- The Commit to migrate the tests. This turned out to be illuminating because dropping it turned up multiple regressions
- CLAUDE.md
- the tdigest changes have a net negative effect on the most commonly called function: `push()` - false economy
- the findBounds() changes do not satisfy the unit tests on trunk, and are setting the wrong fields (fencepost error?)
- the keyFrom changes are generating '|undefined|' values 
  - this undermines the memory improvements of the previous code in favor of microbenchmarks
  - I only seeing a few % performance improvement in the microbenchmarks, and the space tradeoff will eat those
- osMemoryHeapLinux.js is ignoring the inline comment claiming this is a non-blocking operation, and depends on the order in which the stats are evaluated and thus may be brittle
- The LabelMap key sorting change is breaking a test.
  - If this class is not being exposed in the public API, that may be okay. I need to double check. This should be in its own PR if true. But I'm unclear how much it's actually helping.
  - It does improve constructor time but those are not actually fired that often, and we trade off a potential data sharing problem.  
  - Removing list comprehensions is not a substantial performance improvement and a substantial reduction in code legibility. Dropped or chopped several commits which simply changed to for loops.
 - The async optimization includes code that assumes that collect() calls are made in a certain order. The rest of this could also be a separate PR but I didn't want to tangle with it.

## Conclusion

I think there are two or three commits that warrant their own pull requests to discuss the merits of each as a separate commit. Migrating out of Jest is interesting but not something that should be done by Claude as it is clearly not doing any red-green-refactoring on the tests to validate that they are still testing anything. Also there are 5 more months of Node 20 to deal with before `describe()` works. And asserts have the worst DX of any matcher library. I would use chai.expect instead (and have on other projects). 

What is retained here are the things that have no obvious bugs and improved the code quality, regardless of whether they had much net effect on performance.

## Special mention: 

### optimizing for empty labels.

This is a bad plan.

Stats with no labels are already many times faster than stats *with* labels (though the benchmarks misreport it as 600x, it's much smaller), and before I did the label code rework that multiplier was much higher. Since prometheus really is fairly useless with stats with zero labels (not even server name or app version??), there is absolutely no value in my mind in making 0-labels 25% faster if it makes stats with labels 1% slower. You will have thousands of the latter and a handful of the former.

I looked at this several times and opted to go the opposite direction to speed up labels, which the release version is IIRC more like 900x slower. Matteo did not quite have all of these changes when he started his. 

## Net effect

Once you factor in some changes that Matteo noticed but which were already in my other pull requests that have since merged, removing code with bugs, and importantly **after you switch to using trunk as the baseline to eliminate cross-branch confusion**,  the net effect here is small. But these are the changes that seemed like they might help in real world scenarios instead of just in microbenchmarks.

Final outcome, with latest removed to reduce confusion. Mostly in the noise floor with a few possible % here and there.

```
counter ⇒ new

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████─▕ 927,137 ops/sec | 10 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 947,534 ops/sec | 14 samples (1.02x faster)

counter ⇒ inc

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏█████████████████████████▕ 15,241,474 ops/sec | 10 samples (baseline)
 ⇒ prom-client@current       ▏████████████████████████─▕ 14,653,285 ops/sec | 12 samples (1.04x slower)

counter ⇒ inc with labels

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏█████████████████████████▕ 25,284 ops/sec |  9 samples (baseline)
 ⇒ prom-client@current       ▏████████████████████████▌▕ 25,071 ops/sec | 10 samples (1.01x slower)

gauge ⇒ inc

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏███████████████████████▌─▕ 16,650,650 ops/sec |  8 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 17,447,399 ops/sec | 13 samples (1.05x faster)

gauge ⇒ inc with labels

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏█████████████████████████▕ 140,215 ops/sec | 10 samples (baseline)
 ⇒ prom-client@current       ▏████████████████████████▌▕ 139,564 ops/sec | 11 samples (1.00x slower)

histogram ⇒ observe#1 with 64

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏███████████████████████▌─▕ 124,410 ops/sec | 11 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 130,695 ops/sec | 12 samples (1.05x faster)

histogram ⇒ observe#2 with 8

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏█████████████████████████▕ 97,870 ops/sec | 11 samples (baseline)
 ⇒ prom-client@current       ▏████████████████████████─▕ 94,061 ops/sec | 10 samples (1.04x slower)

histogram ⇒ observe#2 with 4 and 2 with 2

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████▌▕ 51,122 ops/sec |  9 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 51,717 ops/sec | 11 samples (1.01x faster)

histogram ⇒ observe#2 with 2 and 2 with 4

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████▌▕ 50,296 ops/sec | 10 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 50,696 ops/sec | 10 samples (1.01x faster)

histogram ⇒ observe#6 with 2

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏█████████████████████████▕ 39,667 ops/sec | 11 samples (baseline)
 ⇒ prom-client@current       ▏████████████████████████▌▕ 39,603 ops/sec | 10 samples (1.00x slower)

histogram ⇒ startTimer#1 with 64

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████▌▕ 60,210 ops/sec | 11 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 61,351 ops/sec | 10 samples (1.02x faster)

histogram ⇒ startTimer#2 with 8

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████▌▕ 52,742 ops/sec | 11 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 53,690 ops/sec | 10 samples (1.02x faster)

histogram ⇒ startTimer#2 with 4 and 2 with 2

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████▌▕ 34,852 ops/sec |  9 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 35,461 ops/sec | 11 samples (1.02x faster)

histogram ⇒ startTimer#2 with 2 and 2 with 4

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████▌▕ 34,517 ops/sec |  9 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 34,907 ops/sec | 11 samples (1.01x faster)

histogram ⇒ startTimer#6 with 2

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████─▕ 29,454 ops/sec | 11 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 30,463 ops/sec |  9 samples (1.03x faster)

util ⇒ hashObject

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏█████████████████████████▕ 4,261,424 ops/sec | 10 samples (baseline)
 ⇒ prom-client@current       ▏████████████████████████▌▕ 4,208,851 ops/sec |  8 samples (1.01x slower)

util ⇒ LabelMap.validate()

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏█████████████████████████▕ 16,797,115 ops/sec | 12 samples (baseline)
 ⇒ prom-client@current       ▏████████████████████████▌▕ 16,512,785 ops/sec | 10 samples (1.02x slower)

util ⇒ LabelMap.keyFrom()

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████▌▕ 7,209,639 ops/sec | 13 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 7,227,734 ops/sec | 12 samples (1.00x faster)

summary ⇒ observe#1 with 64

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏█████████████████████████▕ 105,703 ops/sec | 11 samples (baseline)
 ⇒ prom-client@current       ▏████████████████████████▌▕ 103,763 ops/sec | 10 samples (1.02x slower)

summary ⇒ observe#2 with 8

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████▌▕ 80,878 ops/sec |  9 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 81,213 ops/sec | 10 samples (1.00x faster)

summary ⇒ observe#2 with 4 and 2 with 2

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏█████████████████████████▕ 46,491 ops/sec | 10 samples (baseline)
 ⇒ prom-client@current       ▏████████████████████████▌▕ 45,926 ops/sec | 10 samples (1.01x slower)

summary ⇒ observe#2 with 2 and 2 with 4

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏█████████████████████████▕ 44,956 ops/sec | 10 samples (baseline)
 ⇒ prom-client@current       ▏████████████████████████▌▕ 44,600 ops/sec | 11 samples (1.01x slower)

summary ⇒ observe#6 with 2

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████▌▕ 36,361 ops/sec | 11 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 36,595 ops/sec | 10 samples (1.01x faster)

registry ⇒ getMetricsAsJSON() no labels

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏█████████████████████████▕ 427,999 ops/sec | 11 samples (baseline)
 ⇒ prom-client@current       ▏████████████████████████─▕ 416,444 ops/sec | 11 samples (1.03x slower)

registry ⇒ getMetricsAsJSON() 1 x 64

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████▌▕ 8,138 ops/sec | 10 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 8,211 ops/sec |  9 samples (1.01x faster)

registry ⇒ getMetricsAsJSON() 2 x 4

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏█████████████████████████▕ 25,853 ops/sec | 11 samples (baseline)
 ⇒ prom-client@current       ▏████████████████████████▌▕ 25,838 ops/sec |  9 samples (1.00x slower)

registry ⇒ getMetricsAsJSON() 2 x 8

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏█████████████████████████▕ 7,343 ops/sec | 10 samples (baseline)
 ⇒ prom-client@current       ▏████████████████████████▌▕ 7,286 ops/sec | 10 samples (1.01x slower)

registry ⇒ getMetricsAsJSON() 6 x 2

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████▌▕ 4,646 ops/sec | 10 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 4,689 ops/sec | 10 samples (1.01x faster)

registry ⇒ getMetricsAsJSON() 2 x 4, 2 defaults

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████▌▕ 16,838 ops/sec | 11 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 17,069 ops/sec | 10 samples (1.01x faster)

registry ⇒ getMetricsAsJSON() 2 x 2, 4 defaults

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏█████████████████████████▕ 66,602 ops/sec |  9 samples (baseline)
 ⇒ prom-client@current       ▏████████████████████████▌▕ 66,161 ops/sec | 11 samples (1.01x slower)

registry ⇒ metrics() no labels

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████▌▕ 166,510 ops/sec | 10 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 169,287 ops/sec | 10 samples (1.02x faster)

registry ⇒ metrics() no labels and openMetrics

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████─▕ 161,218 ops/sec | 11 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 165,202 ops/sec | 12 samples (1.02x faster)

registry ⇒ metrics() 1 x 64

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████─▕ 2,840 ops/sec | 10 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 2,921 ops/sec |  9 samples (1.03x faster)

registry ⇒ metrics() 1 x 64 and openMetrics

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████─▕ 2,833 ops/sec | 10 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 2,923 ops/sec |  9 samples (1.03x faster)

registry ⇒ metrics() 2 x 4

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████▌▕ 10,901 ops/sec | 10 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 11,082 ops/sec | 10 samples (1.02x faster)

registry ⇒ metrics() 2 x 4 and openMetrics

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏█████████████████████████▕ 10,829 ops/sec | 10 samples (baseline)
 ⇒ prom-client@current       ▏████████████████████████▌▕ 10,662 ops/sec |  9 samples (1.02x slower)

registry ⇒ metrics() 2 x 8

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████─▕ 3,110 ops/sec |  9 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 3,218 ops/sec | 10 samples (1.03x faster)

registry ⇒ metrics() 2 x 8 and openMetrics

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████▌▕ 3,139 ops/sec | 10 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 3,157 ops/sec |  9 samples (1.01x faster)

registry ⇒ metrics() 6 x 2

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████─▕ 2,449 ops/sec | 10 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 2,544 ops/sec | 10 samples (1.04x faster)

registry ⇒ metrics() 6 x 2 and openMetrics

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████─▕ 2,443 ops/sec |  9 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 2,528 ops/sec | 10 samples (1.03x faster)

registry ⇒ metrics() 2 x 4, 2 defaults

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████▌▕ 6,914 ops/sec |  9 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 6,961 ops/sec | 10 samples (1.01x faster)

registry ⇒ metrics() 2 x 4, 2 defaults and openMetrics

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████─▕ 6,906 ops/sec | 10 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 7,102 ops/sec | 10 samples (1.03x faster)

registry ⇒ metrics() 2 x 2, 4 defaults

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████─▕ 26,211 ops/sec | 11 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 26,875 ops/sec |  8 samples (1.03x faster)

registry ⇒ metrics() 2 x 2, 4 defaults and openMetrics

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████─▕ 26,328 ops/sec | 11 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 27,376 ops/sec |  9 samples (1.04x faster)

cluster ⇒ aggregate()

Summary (vs. baseline):
 ⇒ prom-client@trunk         ▏████████████████████████─▕ 8.46 ops/sec | 11 samples (baseline)
 ⇒ prom-client@current       ▏█████████████████████████▕ 8.64 ops/sec | 11 samples (1.02x faster)


No significant regressions found.
```