### PR TITLE
Replace usage of old node:url api with WHATWG one in pushgateway.js

### DIFF
--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -46,16 +46,6 @@ class Pushgateway {
 	}
 }
 
-function legacyUrlResolve(from, to) {
-	const resolvedUrl = new URL(to, new URL(from, 'resolve://'));
-	if (resolvedUrl.protocol === 'resolve:') {
-		// `from` is a relative URL.
-		const { pathname, search, hash } = resolvedUrl;
-		return pathname + search + hash;
-	}
-	return resolvedUrl.toString();
-}
-
 function legacyUrlFromWhatwgUrl(whatwgUrl) {
 	const legacyUrl = {
 		hash: whatwgUrl.hash,
@@ -84,18 +74,16 @@ function legacyUrlFromWhatwgUrl(whatwgUrl) {
 
 async function useGateway(method, job, groupings) {
 	// `URL` first added in v6.13.0
-	const gatewayUrlParsed = new url.URL(this.gatewayUrl);
+	const requestParams = new url.URL(this.gatewayUrl);
 	const gatewayUrlPath =
-		gatewayUrlParsed.pathname && gatewayUrlParsed.pathname !== '/'
-			? gatewayUrlParsed.pathname
+		requestParams.pathname && requestParams.pathname !== '/'
+			? requestParams.pathname
 			: '';
 	const jobPath = job
 		? `/job/${encodeURIComponent(job)}${generateGroupings(groupings)}`
 		: '';
-	const path = `${gatewayUrlPath}/metrics${jobPath}`;
+	requestParams.pathname = `${gatewayUrlPath}/metrics${jobPath}`;
 
-	const target = legacyUrlResolve(this.gatewayUrl, path);
-	const requestParams = new url.URL(target);
 	const httpModule = isHttps(requestParams.href) ? https : http;
 	const options = Object.assign(
 		legacyUrlFromWhatwgUrl(requestParams),

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -45,10 +45,46 @@ class Pushgateway {
 		return useGateway.call(this, 'DELETE', params.jobName, params.groupings);
 	}
 }
+
+function legacyUrlResolve(from, to) {
+	const resolvedUrl = new URL(to, new URL(from, 'resolve://'));
+	if (resolvedUrl.protocol === 'resolve:') {
+		// `from` is a relative URL.
+		const { pathname, search, hash } = resolvedUrl;
+		return pathname + search + hash;
+	}
+	return resolvedUrl.toString();
+}
+
+function legacyUrlFromWhatwgUrl(whatwgUrl) {
+	const legacyUrl = {
+		hash: whatwgUrl.hash,
+		host: whatwgUrl.host,
+		href: whatwgUrl.href,
+		pathname: whatwgUrl.pathname,
+		port: whatwgUrl.port,
+		protocol: whatwgUrl.protocol,
+		search: whatwgUrl.search,
+
+		// replaced
+		hostname: whatwgUrl.hostname.replace(/^\[|]$/, ''),
+		path: `${whatwgUrl.pathname}${whatwgUrl.search}`,
+	};
+
+	if (whatwgUrl.username) {
+		legacyUrl.auth = whatwgUrl.username;
+
+		if (whatwgUrl.password) {
+			legacyUrl.auth += `:${whatwgUrl.password}`;
+		}
+	}
+
+	return legacyUrl;
+}
+
 async function useGateway(method, job, groupings) {
 	// `URL` first added in v6.13.0
-	// eslint-disable-next-line n/no-deprecated-api
-	const gatewayUrlParsed = url.parse(this.gatewayUrl);
+	const gatewayUrlParsed = new url.URL(this.gatewayUrl);
 	const gatewayUrlPath =
 		gatewayUrlParsed.pathname && gatewayUrlParsed.pathname !== '/'
 			? gatewayUrlParsed.pathname
@@ -58,14 +94,14 @@ async function useGateway(method, job, groupings) {
 		: '';
 	const path = `${gatewayUrlPath}/metrics${jobPath}`;
 
-	// eslint-disable-next-line n/no-deprecated-api
-	const target = url.resolve(this.gatewayUrl, path);
-	// eslint-disable-next-line n/no-deprecated-api
-	const requestParams = url.parse(target);
+	const target = legacyUrlResolve(this.gatewayUrl, path);
+	const requestParams = new url.URL(target);
 	const httpModule = isHttps(requestParams.href) ? https : http;
-	const options = Object.assign(requestParams, this.requestOptions, {
-		method,
-	});
+	const options = Object.assign(
+		legacyUrlFromWhatwgUrl(requestParams),
+		this.requestOptions,
+		{ method },
+	);
 
 	return new Promise((resolve, reject) => {
 		if (method === 'DELETE' && options.headers) {

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const url = require('url');
 const http = require('http');
 const https = require('https');
 const { gzipSync } = require('zlib');
@@ -46,35 +45,9 @@ class Pushgateway {
 	}
 }
 
-function legacyUrlFromWhatwgUrl(whatwgUrl) {
-	const legacyUrl = {
-		hash: whatwgUrl.hash,
-		host: whatwgUrl.host,
-		href: whatwgUrl.href,
-		pathname: whatwgUrl.pathname,
-		port: whatwgUrl.port,
-		protocol: whatwgUrl.protocol,
-		search: whatwgUrl.search,
-
-		// replaced
-		hostname: whatwgUrl.hostname.replace(/^\[|]$/, ''),
-		path: `${whatwgUrl.pathname}${whatwgUrl.search}`,
-	};
-
-	if (whatwgUrl.username) {
-		legacyUrl.auth = whatwgUrl.username;
-
-		if (whatwgUrl.password) {
-			legacyUrl.auth += `:${whatwgUrl.password}`;
-		}
-	}
-
-	return legacyUrl;
-}
-
 async function useGateway(method, job, groupings) {
-	// `URL` first added in v6.13.0
-	const requestParams = new url.URL(this.gatewayUrl);
+	// `URL` is a global since Node.js v10 - no `require('url')` needed.
+	const requestParams = new URL(this.gatewayUrl);
 	const gatewayUrlPath =
 		requestParams.pathname && requestParams.pathname !== '/'
 			? requestParams.pathname
@@ -84,18 +57,14 @@ async function useGateway(method, job, groupings) {
 		: '';
 	requestParams.pathname = `${gatewayUrlPath}/metrics${jobPath}`;
 
-	const httpModule = isHttps(requestParams.href) ? https : http;
-	const options = Object.assign(
-		legacyUrlFromWhatwgUrl(requestParams),
-		this.requestOptions,
-		{ method },
-	);
+	const httpModule = requestParams.protocol === 'https:' ? https : http;
+	const options = { ...this.requestOptions, method };
 
 	return new Promise((resolve, reject) => {
 		if (method === 'DELETE' && options.headers) {
 			delete options.headers['Content-Encoding'];
 		}
-		const req = httpModule.request(options, resp => {
+		const req = httpModule.request(requestParams, options, resp => {
 			let body = '';
 			resp.setEncoding('utf8');
 			resp.on('data', chunk => {
@@ -151,10 +120,6 @@ function generateGroupings(groupings) {
 				`/${encodeURIComponent(key)}/${encodeURIComponent(groupings[key])}`,
 		)
 		.join('');
-}
-
-function isHttps(href) {
-	return href.search(/^https/) !== -1;
 }
 
 module.exports = Pushgateway;

--- a/test/__snapshots__/pushgatewayWithPathTest.js.snap
+++ b/test/__snapshots__/pushgatewayWithPathTest.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`pushgateway with path and OpenMetrics registry global registry pins the http.request(url, options) call shape (no legacy options translation) 1`] = `
+{
+  "options": {
+    "method": "PUT",
+  },
+  "url": "http://192.168.99.100:9091/path/metrics/job/testJob",
+}
+`;
+
+exports[`pushgateway with path and OpenMetrics registry registry instance pins the http.request(url, options) call shape (no legacy options translation) 1`] = `
+{
+  "options": {
+    "method": "PUT",
+  },
+  "url": "http://192.168.99.100:9091/path/metrics/job/testJob",
+}
+`;
+
+exports[`pushgateway with path and Prometheus registry global registry pins the http.request(url, options) call shape (no legacy options translation) 1`] = `
+{
+  "options": {
+    "method": "PUT",
+  },
+  "url": "http://192.168.99.100:9091/path/metrics/job/testJob",
+}
+`;
+
+exports[`pushgateway with path and Prometheus registry registry instance pins the http.request(url, options) call shape (no legacy options translation) 1`] = `
+{
+  "options": {
+    "method": "PUT",
+  },
+  "url": "http://192.168.99.100:9091/path/metrics/job/testJob",
+}
+`;

--- a/test/pushgatewayWithPathTest.js
+++ b/test/pushgatewayWithPathTest.js
@@ -37,27 +37,29 @@ describe.each([
 				instance.pushAdd({ jobName: 'testJob' });
 
 				expect(mockHttp).toHaveBeenCalledTimes(1);
-				const invocation = mockHttp.mock.calls[0][0];
-				expect(invocation.method).toEqual('POST');
-				expect(invocation.path).toEqual('/path/metrics/job/testJob');
+				const [requestUrl, requestOptions] = mockHttp.mock.calls[0];
+				expect(requestOptions.method).toEqual('POST');
+				expect(requestUrl.pathname).toEqual('/path/metrics/job/testJob');
 			});
 
 			it('should use groupings', () => {
 				instance.pushAdd({ jobName: 'testJob', groupings: { key: 'value' } });
 
 				expect(mockHttp).toHaveBeenCalledTimes(1);
-				const invocation = mockHttp.mock.calls[0][0];
-				expect(invocation.method).toEqual('POST');
-				expect(invocation.path).toEqual('/path/metrics/job/testJob/key/value');
+				const [requestUrl, requestOptions] = mockHttp.mock.calls[0];
+				expect(requestOptions.method).toEqual('POST');
+				expect(requestUrl.pathname).toEqual(
+					'/path/metrics/job/testJob/key/value',
+				);
 			});
 
 			it('should escape groupings', () => {
 				instance.pushAdd({ jobName: 'testJob', groupings: { key: 'va&lue' } });
 
 				expect(mockHttp).toHaveBeenCalledTimes(1);
-				const invocation = mockHttp.mock.calls[0][0];
-				expect(invocation.method).toEqual('POST');
-				expect(invocation.path).toEqual(
+				const [requestUrl, requestOptions] = mockHttp.mock.calls[0];
+				expect(requestOptions.method).toEqual('POST');
+				expect(requestUrl.pathname).toEqual(
 					'/path/metrics/job/testJob/key/va%26lue',
 				);
 			});
@@ -68,18 +70,18 @@ describe.each([
 				instance.push({ jobName: 'testJob' });
 
 				expect(mockHttp).toHaveBeenCalledTimes(1);
-				const invocation = mockHttp.mock.calls[0][0];
-				expect(invocation.method).toEqual('PUT');
-				expect(invocation.path).toEqual('/path/metrics/job/testJob');
+				const [requestUrl, requestOptions] = mockHttp.mock.calls[0];
+				expect(requestOptions.method).toEqual('PUT');
+				expect(requestUrl.pathname).toEqual('/path/metrics/job/testJob');
 			});
 
 			it('should uri encode url', () => {
 				instance.push({ jobName: 'test&Job' });
 
 				expect(mockHttp).toHaveBeenCalledTimes(1);
-				const invocation = mockHttp.mock.calls[0][0];
-				expect(invocation.method).toEqual('PUT');
-				expect(invocation.path).toEqual('/path/metrics/job/test%26Job');
+				const [requestUrl, requestOptions] = mockHttp.mock.calls[0];
+				expect(requestOptions.method).toEqual('PUT');
+				expect(requestUrl.pathname).toEqual('/path/metrics/job/test%26Job');
 			});
 		});
 
@@ -88,9 +90,9 @@ describe.each([
 				instance.delete({ jobName: 'testJob' });
 
 				expect(mockHttp).toHaveBeenCalledTimes(1);
-				const invocation = mockHttp.mock.calls[0][0];
-				expect(invocation.method).toEqual('DELETE');
-				expect(invocation.path).toEqual('/path/metrics/job/testJob');
+				const [requestUrl, requestOptions] = mockHttp.mock.calls[0];
+				expect(requestOptions.method).toEqual('DELETE');
+				expect(requestUrl.pathname).toEqual('/path/metrics/job/testJob');
 			});
 		});
 
@@ -111,27 +113,30 @@ describe.each([
 				instance.pushAdd({ jobName: 'testJob' });
 
 				expect(mockHttp).toHaveBeenCalledTimes(1);
-				const invocation = mockHttp.mock.calls[0][0];
-				expect(invocation.method).toEqual('POST');
-				expect(invocation.auth).toEqual(auth);
+				const [requestUrl, requestOptions] = mockHttp.mock.calls[0];
+				expect(requestOptions.method).toEqual('POST');
+				expect(requestUrl.username).toEqual(USERNAME);
+				expect(requestUrl.password).toEqual(PASSWORD);
 			});
 
 			it('push should send PUT request with basic auth data', () => {
 				instance.push({ jobName: 'testJob' });
 
 				expect(mockHttp).toHaveBeenCalledTimes(1);
-				const invocation = mockHttp.mock.calls[0][0];
-				expect(invocation.method).toEqual('PUT');
-				expect(invocation.auth).toEqual(auth);
+				const [requestUrl, requestOptions] = mockHttp.mock.calls[0];
+				expect(requestOptions.method).toEqual('PUT');
+				expect(requestUrl.username).toEqual(USERNAME);
+				expect(requestUrl.password).toEqual(PASSWORD);
 			});
 
 			it('delete should send DELETE request with basic auth data', () => {
 				instance.delete({ jobName: 'testJob' });
 
 				expect(mockHttp).toHaveBeenCalledTimes(1);
-				const invocation = mockHttp.mock.calls[0][0];
-				expect(invocation.method).toEqual('DELETE');
-				expect(invocation.auth).toEqual(auth);
+				const [requestUrl, requestOptions] = mockHttp.mock.calls[0];
+				expect(requestOptions.method).toEqual('DELETE');
+				expect(requestUrl.username).toEqual(USERNAME);
+				expect(requestUrl.password).toEqual(PASSWORD);
 			});
 		});
 
@@ -149,8 +154,22 @@ describe.each([
 			instance.push({ jobName: 'testJob' });
 
 			expect(mockHttp).toHaveBeenCalledTimes(1);
-			const invocation = mockHttp.mock.calls[0][0];
-			expect(invocation.headers).toEqual({ 'unit-test': '1' });
+			const [, requestOptions] = mockHttp.mock.calls[0];
+			expect(requestOptions.headers).toEqual({ 'unit-test': '1' });
+		});
+
+		it('pins the http.request(url, options) call shape (no legacy options translation)', () => {
+			instance.push({ jobName: 'testJob' });
+
+			expect(mockHttp).toHaveBeenCalledTimes(1);
+			const [requestUrl, requestOptions] = mockHttp.mock.calls[0];
+
+			expect(requestUrl).toBeInstanceOf(URL);
+
+			expect({
+				url: requestUrl.toString(),
+				options: requestOptions,
+			}).toMatchSnapshot();
 		});
 	};
 	describe('global registry', () => {


### PR DESCRIPTION
Related to https://github.com/siimon/prom-client/issues/743

Replaces usage of `url.urlParse` and `url.resolve` from `node:url` by `new url.Url` from same package as these functions have been deprecated and trigger a warning on usage.

Changes based on code and documentation available at https://nodejs.org/api/url.html#urlresolvefrom-to and https://github.com/nodejs/userland-migrations/tree/main/recipes/node-url-to-whatwg-url