### PR TITLE
Return the mutated entry from LabelMap.set and LabelMap.setDelta

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -172,38 +172,40 @@ class LabelMap {
 	 * @function setValue
 	 * @param {object} labels
 	 * @param {*} value
-	 * @returns {LabelMap}
+	 * @returns {StatsEntry} the entry that was created or updated
 	 */
 	set(labels, value = 0) {
 		const key = this.keyFrom(labels);
-		const entry = this.#map.get(key);
+		let entry = this.#map.get(key);
 
 		if (entry !== undefined) {
 			entry.value = value;
 		} else {
-			this.#map.set(key, { value, labels });
+			entry = { value, labels };
+			this.#map.set(key, entry);
 		}
 
-		return this;
+		return entry;
 	}
 
 	/**
 	 * @function setDelta
 	 * @param {object} labels
 	 * @param {*} value
-	 * @returns {LabelMap}
+	 * @returns {StatsEntry} the entry that was created or updated
 	 */
 	setDelta(labels, value = 0) {
 		const key = this.keyFrom(labels);
-		const entry = this.#map.get(key);
+		let entry = this.#map.get(key);
 
 		if (entry !== undefined) {
 			entry.value += value;
 		} else {
-			this.#map.set(key, { value, labels });
+			entry = { value, labels };
+			this.#map.set(key, entry);
 		}
 
-		return this;
+		return entry;
 	}
 
 	/**

--- a/test/utilTest.js
+++ b/test/utilTest.js
@@ -88,8 +88,8 @@ describe('utils', () => {
 			it('can update existing values', () => {
 				const map = new LabelMap(['b', 'c', 'a']);
 
-				// And supports chaining
-				map.set({ a: 2 }, 3).set({ a: 2 }, 4);
+				map.set({ a: 2 }, 3);
+				map.set({ a: 2 }, 4);
 
 				expect(map.size).toEqual(1);
 				expect(Array.from(map.values())).toStrictEqual([
@@ -100,7 +100,8 @@ describe('utils', () => {
 			it('creates separate records for each label combination', () => {
 				const map = new LabelMap(['b', 'c', 'a']);
 
-				map.set({ a: 2 }, 22).set({ a: 3 }, 3);
+				map.set({ a: 2 }, 22);
+				map.set({ a: 3 }, 3);
 
 				expect(map.size).toEqual(2);
 				expect(Array.from(map.values())).toStrictEqual([
@@ -113,6 +114,17 @@ describe('utils', () => {
 						labels: { a: 3 },
 					},
 				]);
+			});
+
+			it('returns the entry it created or updated', () => {
+				const map = new LabelMap(['b', 'c', 'a']);
+
+				const created = map.set({ a: 2 }, 3);
+				expect(created).toEqual({ value: 3, labels: { a: 2 } });
+
+				const updated = map.set({ a: 2 }, 4);
+				expect(updated).toBe(created);
+				expect(updated.value).toEqual(4);
 			});
 		});
 
@@ -131,7 +143,8 @@ describe('utils', () => {
 			it('can update existing values', () => {
 				const map = new LabelMap(['b', 'c', 'a']);
 
-				map.setDelta({ a: 2 }, 3).setDelta({ a: 2 }, 4);
+				map.setDelta({ a: 2 }, 3);
+				map.setDelta({ a: 2 }, 4);
 
 				expect(map.size).toEqual(1);
 				expect(Array.from(map.values())).toStrictEqual([
@@ -150,6 +163,17 @@ describe('utils', () => {
 					{ value: 3, labels: { a: 2 } },
 					{ value: 3, labels: { a: 3 } },
 				]);
+			});
+
+			it('returns the entry it created or updated', () => {
+				const map = new LabelMap(['b', 'c', 'a']);
+
+				const created = map.setDelta({ a: 2 }, 3);
+				expect(created).toEqual({ value: 3, labels: { a: 2 } });
+
+				const updated = map.setDelta({ a: 2 }, 4);
+				expect(updated).toBe(created);
+				expect(updated.value).toEqual(7);
 			});
 		});
 
@@ -260,7 +284,8 @@ describe('utils', () => {
 			it('resets the collection', () => {
 				const map = new LabelMap(['b', 'c', 'a']);
 
-				map.set({ a: 2 }, 3).set({ a: 3 }, 4);
+				map.set({ a: 2 }, 3);
+				map.set({ a: 3 }, 4);
 				map.clear();
 
 				expect(map.size).toEqual(0);


### PR DESCRIPTION
I'd like to contribute start timestamp (formerly known as created timestamp) support . For this I need to store the start time in the metric entry, but don't want to look the entry up again after adding to the LabelMap. Would be simpler to have set / setDelta return the entry so I can set the start timestamp. Would be used for counters and histograms. Eventually the start timestamp could be exposed on OpenMetrics 1.0 / 2.0.

## Summary

- `LabelMap.set` and `LabelMap.setDelta` now return the entry they created or updated, instead of `this` (the `LabelMap`).
- Within this repo, no caller relied on the old `this` return (the only chained usages were in `test/utilTest.js`, now de-chained).
- Added one return-value assertion per method.

## API-surface note

`LabelMap` is an internal helper: it's not exported from `index.js`, not documented in the README, and `entry()`'s JSDoc explicitly says *"Used internally by some Metrics. You should probably not call this directly."* That said, `lib/util.js` ships in the published package, so a deep-import consumer could in principle have relied on the chaining return. I judge that risk low and reversible, but flagging it explicitly so you can decide.

