### PR TITLE
chore: rename module to @prometheus/client_js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,14 +54,14 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Enable `bun.js` by catching `NotImplemented` error (Fixes [#570](https://github.com/siimon/prom-client/issues/570))
+- Enable `bun.js` by catching `NotImplemented` error (Fixes [#570](https://github.com/prometheus/client_js/issues/570))
 
 ## [15.1.1] - 2024-03-26
 
 ### Changed
 
 - Improve the memory usage of histograms when the `enableExemplars` option is disabled
-- fix: Avoid updating exemplar values during subsequent metric changes (Fixes [#616](https://github.com/siimon/prom-client/issues/616))
+- fix: Avoid updating exemplar values during subsequent metric changes (Fixes [#616](https://github.com/prometheus/client_js/issues/616))
 
 ## [15.1.0] - 2023-12-15
 
@@ -76,7 +76,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Allow Pushgateway to now require job names for compatibility with Gravel Gateway.
 - Allow `histogram.startTime()` to be used with exemplars.
 
-[15.1.0]: https://github.com/siimon/prom-client/compare/v15.0.0...v15.1.0
+[15.1.0]: https://github.com/prometheus/client_js/compare/v15.0.0...v15.1.0
 
 ## [15.0.0] - 2023-10-09
 
@@ -102,7 +102,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Support for OpenMetrics and Exemplars
 
-[15.0.0]: https://github.com/siimon/prom-client/compare/v14.2.0...v15.0.0
+[15.0.0]: https://github.com/prometheus/client_js/compare/v14.2.0...v15.0.0
 
 ## [14.2.0] - 2023-03-06
 
@@ -120,7 +120,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add `get` method to type definitions of metric classes
 
-[14.2.0]: https://github.com/siimon/prom-client/compare/v14.1.1...v14.2.0
+[14.2.0]: https://github.com/prometheus/client_js/compare/v14.1.1...v14.2.0
 
 ## [14.1.1] - 2022-12-31
 
@@ -128,7 +128,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Increase compatibility with external build system such as `rollup` by making perf_hooks optional in gc.js
 
-[14.1.1]: https://github.com/siimon/prom-client/compare/v14.1.0...v14.1.1
+[14.1.1]: https://github.com/prometheus/client_js/compare/v14.1.0...v14.1.1
 
 ## [14.1.0] - 2022-08-23
 
@@ -157,7 +157,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Support gzipped pushgateway requests
 
-[14.1.0]: https://github.com/siimon/prom-client/compare/v14.0.1...v14.1.0
+[14.1.0]: https://github.com/prometheus/client_js/compare/v14.0.1...v14.1.0
 
 ## [14.0.1] - 2021-11-02
 
@@ -165,7 +165,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - changed: typedef for pushgateway to reflect js implementation.
 
-[14.0.1]: https://github.com/siimon/prom-client/compare/v14.0.0...v14.0.1
+[14.0.1]: https://github.com/prometheus/client_js/compare/v14.0.0...v14.0.1
 
 ## [14.0.0] - 2021-09-18
 
@@ -174,7 +174,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - changed: `linearBuckets` does not propagate rounding errors anymore.
 
   Fewer bucket bounds will be affected by rounding errors. Histogram bucket
-  labels may change. [`6f1f3b2`](https://github.com/siimon/prom-client/commit/6f1f3b24c9c21311ff33e7d4b987b40c6b304e04)
+  labels may change. [`6f1f3b2`](https://github.com/prometheus/client_js/commit/6f1f3b24c9c21311ff33e7d4b987b40c6b304e04)
 
 - changed: The push gateway methods `pushAdd()`, `push()` and `delete()` now
   return Promises instead of accepting a callback:
@@ -191,20 +191,20 @@ project adheres to [Semantic Versioning](http://semver.org/).
   const { resp, body } = await gateway.pushAdd({ jobName: 'test' });
   ```
 
-  [`f177b1f`](https://github.com/siimon/prom-client/commit/f177b1fd3d4db5fc48fcb1ec02d94069fffcf144)
+  [`f177b1f`](https://github.com/prometheus/client_js/commit/f177b1fd3d4db5fc48fcb1ec02d94069fffcf144)
 
 - changed: The default `nodejs_eventloop_lag_*` metrics are now reset every time
   they are observed. This prevents these metrics from "stabilizing" over a long
   period of time and becoming insensitive to small changes. For more info, see
-  [#370](https://github.com/siimon/prom-client/issues/370). [`0f444cd`](https://github.com/siimon/prom-client/commit/0f444cd38e4c7074991270106c270f731bafddb8)
+  [#370](https://github.com/prometheus/client_js/issues/370). [`0f444cd`](https://github.com/prometheus/client_js/commit/0f444cd38e4c7074991270106c270f731bafddb8)
 
 ### Changed
 
-- Add missing `await`/`then`s to examples. [`074f339`](https://github.com/siimon/prom-client/commit/074f339914e5d71b5829cd4a949affae23dbc409)
-- Add missing type declaration for `client.contentType`. [`3b66641`](https://github.com/siimon/prom-client/commit/3b6664160bdd1555045b03d8f4c421022f30e1db)
-- Modernize some label processing code. [`c9bf1d8`](https://github.com/siimon/prom-client/commit/c9bf1d8e3db3b5fb97faf2df9ca9b9af670288f3)
+- Add missing `await`/`then`s to examples. [`074f339`](https://github.com/prometheus/client_js/commit/074f339914e5d71b5829cd4a949affae23dbc409)
+- Add missing type declaration for `client.contentType`. [`3b66641`](https://github.com/prometheus/client_js/commit/3b6664160bdd1555045b03d8f4c421022f30e1db)
+- Modernize some label processing code. [`c9bf1d8`](https://github.com/prometheus/client_js/commit/c9bf1d8e3db3b5fb97faf2df9ca9b9af670288f3)
 
-[14.0.0]: https://github.com/siimon/prom-client/compare/v13.2.0...v14.0.0
+[14.0.0]: https://github.com/prometheus/client_js/compare/v13.2.0...v14.0.0
 
 ## [13.2.0] - 2021-08-08
 
@@ -213,7 +213,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Don't add event listener to `process` if cluster module is not used.
 - fix: set labels for default memory metrics on linux.
 - fix: fix DEP0152 deprecation warning in Node.js v16+.
-- fix: Set aggregation mode for newer event loop metrics. (Fixes [#418](https://github.com/siimon/prom-client/issues/418))
+- fix: Set aggregation mode for newer event loop metrics. (Fixes [#418](https://github.com/prometheus/client_js/issues/418))
 - Improve performance of/reduce memory allocations in Gauge.
 
 ### Added
@@ -221,22 +221,22 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - feat: added `zero()` to `Histogram` for setting the metrics for a given label combination to zero
 - fix: allow `Gauge.inc/dec(0)` without defaulting to 1
 
-[13.2.0]: https://github.com/siimon/prom-client/compare/v13.1.0...v13.2.0
+[13.2.0]: https://github.com/prometheus/client_js/compare/v13.1.0...v13.2.0
 
 ## [13.1.0] - 2021-01-24
 
 ### Changed
 
-- fix: push client attempting to write Promise (fixes [#390](https://github.com/siimon/prom-client/issues/390))
+- fix: push client attempting to write Promise (fixes [#390](https://github.com/prometheus/client_js/issues/390))
 - types: improve type checking of labels
-- fix: Summary#observe should throw when adding additional labels to labelset (fixes [#262](https://github.com/siimon/prom-client/issues/262))
+- fix: Summary#observe should throw when adding additional labels to labelset (fixes [#262](https://github.com/prometheus/client_js/issues/262))
 
 ### Added
 
 - feat: added the ability to pass labels as an object to `labels()` and `remove()`
 - Added: More examples with commented output
 
-[13.1.0]: https://github.com/siimon/prom-client/compare/v13.0.0...v13.1.0
+[13.1.0]: https://github.com/prometheus/client_js/compare/v13.0.0...v13.1.0
 
 ## [13.0.0] - 2020-12-16
 
@@ -285,7 +285,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - feat: added support for adding labels to default metrics (#374)
 - Added CHANGELOG reminder
 
-[13.0.0]: https://github.com/siimon/prom-client/compare/v12.0.0...v13.0.0
+[13.0.0]: https://github.com/prometheus/client_js/compare/v12.0.0...v13.0.0
 
 ## [12.0.0] - 2020-02-20
 
@@ -317,7 +317,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - feat: implement GC metrics collection without native(C++) modules.
 - feat: implement advanced event loop monitoring
 
-[12.0.0]: https://github.com/siimon/prom-client/compare/v11.5.3...v12.0.0
+[12.0.0]: https://github.com/prometheus/client_js/compare/v11.5.3...v12.0.0
 
 ## [11.5.3] - 2019-06-27
 
@@ -326,7 +326,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Parameter `compressCount` in Summaries to control compression of data in t-digest.
 - Compress t-digest in Summaries
 
-[11.5.3]: https://github.com/siimon/prom-client/compare/v11.5.2...v11.5.3
+[11.5.3]: https://github.com/prometheus/client_js/compare/v11.5.2...v11.5.3
 
 ## [11.5.2] - 2019-06-20
 
@@ -334,7 +334,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - fix: avoid mutation bug in registry
 
-[11.5.2]: https://github.com/siimon/prom-client/compare/v11.5.1...v11.5.2
+[11.5.2]: https://github.com/prometheus/client_js/compare/v11.5.1...v11.5.2
 
 ## [11.5.1] - 2019-06-13
 
@@ -342,7 +342,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - fix: guard against missing constructor
 
-[11.5.1]: https://github.com/siimon/prom-client/compare/v11.5.0...v11.5.1
+[11.5.1]: https://github.com/prometheus/client_js/compare/v11.5.0...v11.5.1
 
 ## [11.5.0] - 2019-06-04
 
@@ -351,7 +351,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Added `timestamps` toggle to `collectDefaultMetrics` options
 - Export `validateMetricName`
 
-[11.5.0]: https://github.com/siimon/prom-client/compare/v11.4.0...v11.5.0
+[11.5.0]: https://github.com/prometheus/client_js/compare/v11.4.0...v11.5.0
 
 ## [11.4.0] - 2019-06-04
 
@@ -360,7 +360,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - `nodejs_active_handles` metric to the `collectDefaultMetrics()`. Unlike `nodejs_active_handles_total` it split count of active handles by type.
 - `nodejs_active_requests` metric to the `collectDefaultMetrics()`. Unlike `nodejs_active_requests_total` it split count of active requests by type.
 
-[11.4.0]: https://github.com/siimon/prom-client/compare/v11.3.0...v11.4.0
+[11.4.0]: https://github.com/prometheus/client_js/compare/v11.3.0...v11.4.0
 
 ## [11.3.0] - 2019-04-02
 
@@ -373,7 +373,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added a `remove()` method on each metric type, based on [Prometheus "Writing Client Libraries" section on labels](https://prometheus.io/docs/instrumenting/writing_clientlibs/#labels)
 
-[11.3.0]: https://github.com/siimon/prom-client/compare/v11.2.1...v11.3.0
+[11.3.0]: https://github.com/prometheus/client_js/compare/v11.2.1...v11.3.0
 
 ## [11.2.1]
 
@@ -385,7 +385,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Updated types for Summary in typescript definition file
 
-[11.2.1]: https://github.com/siimon/prom-client/compare/v11.2.0...v11.2.1
+[11.2.1]: https://github.com/prometheus/client_js/compare/v11.2.0...v11.2.1
 
 ## [11.2.0]
 
@@ -398,7 +398,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Added an initial `benchmark` suite which can be run with `npm run benchmarks`.
 - Add support for sliding windows in Summaries
 
-[11.2.0]: https://github.com/siimon/prom-client/compare/v11.1.3...v11.2.0
+[11.2.0]: https://github.com/prometheus/client_js/compare/v11.1.3...v11.2.0
 
 ## [11.1.3] - 2018-09-22
 
@@ -407,7 +407,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed performance by avoiding `Object.assign` on hot paths, as well as
   mutating objects when appropriate.
 
-[11.1.3]: https://github.com/siimon/prom-client/compare/v11.1.2...v11.1.3
+[11.1.3]: https://github.com/prometheus/client_js/compare/v11.1.2...v11.1.3
 
 ## [11.1.2] - 2018-09-19
 
@@ -416,7 +416,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Allow setting Gauge values to NaN, +Inf, and -Inf
 - Fixed `histogram` scrape performance by using `acc.push` instead of `acc.concat`. Fixes #216 with #219
 
-[11.1.2]: https://github.com/siimon/prom-client/compare/v11.1.1...v11.1.2
+[11.1.2]: https://github.com/prometheus/client_js/compare/v11.1.1...v11.1.2
 
 ## [11.1.1] - 2018-06-29
 
@@ -424,7 +424,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed `processOpenFileDescriptors` metric when no custom config was set
 
-[11.1.1]: https://github.com/siimon/prom-client/compare/v11.1.0...v11.1.1
+[11.1.1]: https://github.com/prometheus/client_js/compare/v11.1.0...v11.1.1
 
 ## [11.1.0] - 2018-06-29
 
@@ -437,7 +437,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
   labelset
 - Fixed `AggregatorFactory` losing the aggregator method of metrics
 
-[11.1.0]: https://github.com/siimon/prom-client/compare/v11.0.0...v11.1.0
+[11.1.0]: https://github.com/prometheus/client_js/compare/v11.0.0...v11.1.0
 
 ## [11.0.0] - 2018-03-10
 
@@ -448,7 +448,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
     [best practices](https://prometheus.io/docs/practices/naming/#base-units)
 - Dropped support for node 4
 
-[11.0.0]: https://github.com/siimon/prom-client/compare/v10.2.3...v11.0.0
+[11.0.0]: https://github.com/prometheus/client_js/compare/v10.2.3...v11.0.0
 
 ## [10.2.3] - 2018-02-28
 
@@ -460,7 +460,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-[10.2.3]: https://github.com/siimon/prom-client/compare/v10.2.2...v10.2.3
+[10.2.3]: https://github.com/prometheus/client_js/compare/v10.2.2...v10.2.3
 
 ## [10.2.2] - 2017-11-02
 
@@ -585,16 +585,16 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Creating metrics with one argument per parameter - use object literals
   instead.
 
-[10.2.2]: https://github.com/siimon/prom-client/compare/v10.2.1...v10.2.2
-[10.2.1]: https://github.com/siimon/prom-client/compare/v10.2.0...v10.2.1
-[10.2.0]: https://github.com/siimon/prom-client/compare/v10.1.1...v10.2.0
-[10.1.1]: https://github.com/siimon/prom-client/compare/v10.1.0...v10.1.1
-[10.1.0]: https://github.com/siimon/prom-client/compare/v10.0.4...v10.1.0
-[10.0.4]: https://github.com/siimon/prom-client/compare/v10.0.3...v10.0.4
-[10.0.3]: https://github.com/siimon/prom-client/compare/v10.0.2...v10.0.3
-[10.0.2]: https://github.com/siimon/prom-client/compare/v10.0.1...v10.0.2
-[10.0.1]: https://github.com/siimon/prom-client/compare/v10.0.0...v10.0.1
-[10.0.0]: https://github.com/siimon/prom-client/compare/v9.1.1...v10.0.0
-[9.1.1]: https://github.com/siimon/prom-client/compare/v9.1.0...v9.1.1
-[9.1.0]: https://github.com/siimon/prom-client/compare/v9.0.0...v9.1.0
-[9.0.0]: https://github.com/siimon/prom-client/commit/1ef835f908e1a5032f228bbc754479fe7ccf5201
+[10.2.2]: https://github.com/prometheus/client_js/compare/v10.2.1...v10.2.2
+[10.2.1]: https://github.com/prometheus/client_js/compare/v10.2.0...v10.2.1
+[10.2.0]: https://github.com/prometheus/client_js/compare/v10.1.1...v10.2.0
+[10.1.1]: https://github.com/prometheus/client_js/compare/v10.1.0...v10.1.1
+[10.1.0]: https://github.com/prometheus/client_js/compare/v10.0.4...v10.1.0
+[10.0.4]: https://github.com/prometheus/client_js/compare/v10.0.3...v10.0.4
+[10.0.3]: https://github.com/prometheus/client_js/compare/v10.0.2...v10.0.3
+[10.0.2]: https://github.com/prometheus/client_js/compare/v10.0.1...v10.0.2
+[10.0.1]: https://github.com/prometheus/client_js/compare/v10.0.0...v10.0.1
+[10.0.0]: https://github.com/prometheus/client_js/compare/v9.1.1...v10.0.0
+[9.1.1]: https://github.com/prometheus/client_js/compare/v9.1.0...v9.1.1
+[9.1.0]: https://github.com/prometheus/client_js/compare/v9.0.0...v9.1.0
+[9.0.0]: https://github.com/prometheus/client_js/commit/1ef835f908e1a5032f228bbc754479fe7ccf5201

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Prometheus client for node.js [![Actions Status](https://github.com/siimon/prom-client/workflows/Node.js%20CI/badge.svg?branch=master)](https://github.com/siimon/prom-client/actions)
+# Prometheus client for node.js [![Actions Status](https://github.com/prometheus/client_js/workflows/Node.js%20CI/badge.svg?branch=master)](https://github.com/prometheus/client_js/actions)
 
 A prometheus client for Node.js that supports histogram, summaries, gauges and
 counters.
@@ -58,7 +58,7 @@ available on Linux.
 To register metrics to another registry, pass it in as `register`:
 
 ```js
-const client = require('prom-client');
+const client = require('@prometheus/client_js');
 const collectDefaultMetrics = client.collectDefaultMetrics;
 const Registry = client.Registry;
 const register = new Registry();
@@ -68,7 +68,7 @@ collectDefaultMetrics({ register });
 To use custom buckets for GC duration histogram, pass it in as `gcDurationBuckets`:
 
 ```js
-const client = require('prom-client');
+const client = require('@prometheus/client_js');
 const collectDefaultMetrics = client.collectDefaultMetrics;
 collectDefaultMetrics({ gcDurationBuckets: [0.1, 0.2, 0.3] });
 ```
@@ -76,7 +76,7 @@ collectDefaultMetrics({ gcDurationBuckets: [0.1, 0.2, 0.3] });
 To prefix metric names with your own arbitrary string, pass in a `prefix`:
 
 ```js
-const client = require('prom-client');
+const client = require('@prometheus/client_js');
 const collectDefaultMetrics = client.collectDefaultMetrics;
 const prefix = 'my_application_';
 collectDefaultMetrics({ prefix });
@@ -85,7 +85,7 @@ collectDefaultMetrics({ prefix });
 To apply generic labels to all default metrics, pass an object to the `labels` property (useful if you're working in a clustered environment):
 
 ```js
-const client = require('prom-client');
+const client = require('@prometheus/client_js');
 const collectDefaultMetrics = client.collectDefaultMetrics;
 collectDefaultMetrics({
   labels: { NODE_APP_INSTANCE: process.env.NODE_APP_INSTANCE },
@@ -99,7 +99,7 @@ Default metrics are collected on scrape of metrics endpoint,
 not on an interval.
 
 ```js
-const client = require('prom-client');
+const client = require('@prometheus/client_js');
 
 const collectDefaultMetrics = client.collectDefaultMetrics;
 
@@ -127,7 +127,7 @@ metric types.
 Counters go up, and reset when the process restarts.
 
 ```js
-const client = require('prom-client');
+const client = require('@prometheus/client_js');
 const counter = new client.Counter({
   name: 'metric_name',
   help: 'metric_help',
@@ -141,7 +141,7 @@ counter.inc(10); // Increment by 10
 Gauges are similar to Counters but a Gauge's value can be decreased.
 
 ```js
-const client = require('prom-client');
+const client = require('@prometheus/client_js');
 const gauge = new client.Gauge({ name: 'metric_name', help: 'metric_help' });
 gauge.set(10); // Set to 10
 gauge.inc(); // Increment 1
@@ -156,7 +156,7 @@ If the gauge is used for a point-in-time observation, you should provide a
 `collect` function:
 
 ```js
-const client = require('prom-client');
+const client = require('@prometheus/client_js');
 new client.Gauge({
   name: 'metric_name',
   help: 'metric_help',
@@ -170,7 +170,7 @@ new client.Gauge({
 
 ```js
 // Async version:
-const client = require('prom-client');
+const client = require('@prometheus/client_js');
 new client.Gauge({
   name: 'metric_name',
   help: 'metric_help',
@@ -208,7 +208,7 @@ The defaults buckets are intended to cover usual web/RPC requests, but they can
 be overridden. (See also [**Bucket Generators**](#bucket-generators).)
 
 ```js
-const client = require('prom-client');
+const client = require('@prometheus/client_js');
 new client.Histogram({
   name: 'metric_name',
   help: 'metric_help',
@@ -219,7 +219,7 @@ new client.Histogram({
 ##### Examples
 
 ```js
-const client = require('prom-client');
+const client = require('@prometheus/client_js');
 const histogram = new client.Histogram({
   name: 'metric_name',
   help: 'metric_help',
@@ -247,7 +247,7 @@ can be overridden by specifying a `percentiles` array. (See also
 [**Bucket Generators**](#bucket-generators).)
 
 ```js
-const client = require('prom-client');
+const client = require('@prometheus/client_js');
 new client.Summary({
   name: 'metric_name',
   help: 'metric_help',
@@ -259,7 +259,7 @@ To enable the sliding window functionality for summaries you need to add
 `maxAgeSeconds` and `ageBuckets` to the config like this:
 
 ```js
-const client = require('prom-client');
+const client = require('@prometheus/client_js');
 new client.Summary({
   name: 'metric_name',
   help: 'metric_help',
@@ -278,7 +278,7 @@ always be present, even when empty (its percentile values will be `0`). Set
 ##### Examples
 
 ```js
-const client = require('prom-client');
+const client = require('@prometheus/client_js');
 const summary = new client.Summary({
   name: 'metric_name',
   help: 'metric_help',
@@ -302,7 +302,7 @@ label names that the metric support needs to be declared here. There are two
 ways to add values to the labels:
 
 ```js
-const client = require('prom-client');
+const client = require('@prometheus/client_js');
 const gauge = new client.Gauge({
   name: 'metric_name',
   help: 'metric_help',
@@ -354,7 +354,7 @@ histogram.zero({ method: 'POST' });
 Typescript can also enforce label names using `as const`
 
 ```typescript
-import * as client from 'prom-client';
+import * as client from '@prometheus/client_js';
 
 const counter = new client.Counter({
   name: 'metric_name',
@@ -376,7 +376,7 @@ counter.inc({ methods: 1 });
 Static labels may be applied to every metric emitted by a registry:
 
 ```js
-const client = require('prom-client');
+const client = require('@prometheus/client_js');
 const defaultLabels = { serviceName: 'api-v1' };
 client.register.setDefaultLabels(defaultLabels);
 ```
@@ -413,7 +413,7 @@ The library supports both the old Prometheus format and the OpenMetrics format.
 The format can be set per registry. For default metrics:
 
 ```js
-const Prometheus = require('prom-client');
+const Prometheus = require('@prometheus/client_js');
 Prometheus.register.setContentType(
   Prometheus.Registry.OPENMETRICS_CONTENT_TYPE,
 );
@@ -437,7 +437,7 @@ type when creating a new registry, currently defaults to Prometheus type.
 ### Multiple registries
 
 By default, metrics are automatically registered to the global registry (located
-at `require('prom-client').register`). You can prevent this by specifying
+at `require('@prometheus/client_js').register`). You can prevent this by specifying
 `registers: []` in the metric constructor configuration.
 
 Using non-global registries requires creating a Registry instance and passing it
@@ -452,7 +452,7 @@ Merging registries of different types is undefined. The user needs to make sure
 all used registries have the same type (Prometheus or OpenMetrics versions).
 
 ```js
-const client = require('prom-client');
+const client = require('@prometheus/client_js');
 const registry = new client.Registry();
 const counter = new client.Counter({
   name: 'metric_name',
@@ -534,7 +534,7 @@ It is possible to push metrics via a
 [Pushgateway](https://github.com/prometheus/pushgateway).
 
 ```js
-const client = require('prom-client');
+const client = require('@prometheus/client_js');
 let gateway = new client.Pushgateway('http://127.0.0.1:9091');
 
 gateway.pushAdd({ jobName: 'test' })
@@ -597,7 +597,7 @@ For convenience, there are two bucket generator functions - linear and
 exponential.
 
 ```js
-const client = require('prom-client');
+const client = require('@prometheus/client_js');
 new client.Histogram({
   name: 'metric_name',
   help: 'metric_help',

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ available on Linux.
 To register metrics to another registry, pass it in as `register`:
 
 ```js
-const client = require('@prometheus-io/client');
+const client = require('@prometheus/client');
 const collectDefaultMetrics = client.collectDefaultMetrics;
 const Registry = client.Registry;
 const register = new Registry();
@@ -68,7 +68,7 @@ collectDefaultMetrics({ register });
 To use custom buckets for GC duration histogram, pass it in as `gcDurationBuckets`:
 
 ```js
-const client = require('@prometheus-io/client');
+const client = require('@prometheus/client');
 const collectDefaultMetrics = client.collectDefaultMetrics;
 collectDefaultMetrics({ gcDurationBuckets: [0.1, 0.2, 0.3] });
 ```
@@ -76,7 +76,7 @@ collectDefaultMetrics({ gcDurationBuckets: [0.1, 0.2, 0.3] });
 To prefix metric names with your own arbitrary string, pass in a `prefix`:
 
 ```js
-const client = require('@prometheus-io/client');
+const client = require('@prometheus/client');
 const collectDefaultMetrics = client.collectDefaultMetrics;
 const prefix = 'my_application_';
 collectDefaultMetrics({ prefix });
@@ -85,7 +85,7 @@ collectDefaultMetrics({ prefix });
 To apply generic labels to all default metrics, pass an object to the `labels` property (useful if you're working in a clustered environment):
 
 ```js
-const client = require('@prometheus-io/client');
+const client = require('@prometheus/client');
 const collectDefaultMetrics = client.collectDefaultMetrics;
 collectDefaultMetrics({
   labels: { NODE_APP_INSTANCE: process.env.NODE_APP_INSTANCE },
@@ -99,7 +99,7 @@ Default metrics are collected on scrape of metrics endpoint,
 not on an interval.
 
 ```js
-const client = require('@prometheus-io/client');
+const client = require('@prometheus/client');
 
 const collectDefaultMetrics = client.collectDefaultMetrics;
 
@@ -127,7 +127,7 @@ metric types.
 Counters go up, and reset when the process restarts.
 
 ```js
-const client = require('@prometheus-io/client');
+const client = require('@prometheus/client');
 const counter = new client.Counter({
   name: 'metric_name',
   help: 'metric_help',
@@ -141,7 +141,7 @@ counter.inc(10); // Increment by 10
 Gauges are similar to Counters but a Gauge's value can be decreased.
 
 ```js
-const client = require('@prometheus-io/client');
+const client = require('@prometheus/client');
 const gauge = new client.Gauge({ name: 'metric_name', help: 'metric_help' });
 gauge.set(10); // Set to 10
 gauge.inc(); // Increment 1
@@ -156,7 +156,7 @@ If the gauge is used for a point-in-time observation, you should provide a
 `collect` function:
 
 ```js
-const client = require('@prometheus-io/client');
+const client = require('@prometheus/client');
 new client.Gauge({
   name: 'metric_name',
   help: 'metric_help',
@@ -170,7 +170,7 @@ new client.Gauge({
 
 ```js
 // Async version:
-const client = require('@prometheus-io/client');
+const client = require('@prometheus/client');
 new client.Gauge({
   name: 'metric_name',
   help: 'metric_help',
@@ -208,7 +208,7 @@ The defaults buckets are intended to cover usual web/RPC requests, but they can
 be overridden. (See also [**Bucket Generators**](#bucket-generators).)
 
 ```js
-const client = require('@prometheus-io/client');
+const client = require('@prometheus/client');
 new client.Histogram({
   name: 'metric_name',
   help: 'metric_help',
@@ -219,7 +219,7 @@ new client.Histogram({
 ##### Examples
 
 ```js
-const client = require('@prometheus-io/client');
+const client = require('@prometheus/client');
 const histogram = new client.Histogram({
   name: 'metric_name',
   help: 'metric_help',
@@ -247,7 +247,7 @@ can be overridden by specifying a `percentiles` array. (See also
 [**Bucket Generators**](#bucket-generators).)
 
 ```js
-const client = require('@prometheus-io/client');
+const client = require('@prometheus/client');
 new client.Summary({
   name: 'metric_name',
   help: 'metric_help',
@@ -259,7 +259,7 @@ To enable the sliding window functionality for summaries you need to add
 `maxAgeSeconds` and `ageBuckets` to the config like this:
 
 ```js
-const client = require('@prometheus-io/client');
+const client = require('@prometheus/client');
 new client.Summary({
   name: 'metric_name',
   help: 'metric_help',
@@ -278,7 +278,7 @@ always be present, even when empty (its percentile values will be `0`). Set
 ##### Examples
 
 ```js
-const client = require('@prometheus-io/client');
+const client = require('@prometheus/client');
 const summary = new client.Summary({
   name: 'metric_name',
   help: 'metric_help',
@@ -302,7 +302,7 @@ label names that the metric support needs to be declared here. There are two
 ways to add values to the labels:
 
 ```js
-const client = require('@prometheus-io/client');
+const client = require('@prometheus/client');
 const gauge = new client.Gauge({
   name: 'metric_name',
   help: 'metric_help',
@@ -354,7 +354,7 @@ histogram.zero({ method: 'POST' });
 Typescript can also enforce label names using `as const`
 
 ```typescript
-import * as client from '@prometheus-io/client';
+import * as client from '@prometheus/client';
 
 const counter = new client.Counter({
   name: 'metric_name',
@@ -376,7 +376,7 @@ counter.inc({ methods: 1 });
 Static labels may be applied to every metric emitted by a registry:
 
 ```js
-const client = require('@prometheus-io/client');
+const client = require('@prometheus/client');
 const defaultLabels = { serviceName: 'api-v1' };
 client.register.setDefaultLabels(defaultLabels);
 ```
@@ -413,7 +413,7 @@ The library supports both the old Prometheus format and the OpenMetrics format.
 The format can be set per registry. For default metrics:
 
 ```js
-const Prometheus = require('@prometheus-io/client');
+const Prometheus = require('@prometheus/client');
 Prometheus.register.setContentType(
   Prometheus.Registry.OPENMETRICS_CONTENT_TYPE,
 );
@@ -437,7 +437,7 @@ type when creating a new registry, currently defaults to Prometheus type.
 ### Multiple registries
 
 By default, metrics are automatically registered to the global registry (located
-at `require('@prometheus-io/client').register`). You can prevent this by specifying
+at `require('@prometheus/client').register`). You can prevent this by specifying
 `registers: []` in the metric constructor configuration.
 
 Using non-global registries requires creating a Registry instance and passing it
@@ -452,7 +452,7 @@ Merging registries of different types is undefined. The user needs to make sure
 all used registries have the same type (Prometheus or OpenMetrics versions).
 
 ```js
-const client = require('@prometheus-io/client');
+const client = require('@prometheus/client');
 const registry = new client.Registry();
 const counter = new client.Counter({
   name: 'metric_name',
@@ -534,7 +534,7 @@ It is possible to push metrics via a
 [Pushgateway](https://github.com/prometheus/pushgateway).
 
 ```js
-const client = require('@prometheus-io/client');
+const client = require('@prometheus/client');
 let gateway = new client.Pushgateway('http://127.0.0.1:9091');
 
 gateway.pushAdd({ jobName: 'test' })
@@ -597,7 +597,7 @@ For convenience, there are two bucket generator functions - linear and
 exponential.
 
 ```js
-const client = require('@prometheus-io/client');
+const client = require('@prometheus/client');
 new client.Histogram({
   name: 'metric_name',
   help: 'metric_help',

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ available on Linux.
 To register metrics to another registry, pass it in as `register`:
 
 ```js
-const client = require('@prometheus/client_js');
+const client = require('@prometheus-io/client');
 const collectDefaultMetrics = client.collectDefaultMetrics;
 const Registry = client.Registry;
 const register = new Registry();
@@ -68,7 +68,7 @@ collectDefaultMetrics({ register });
 To use custom buckets for GC duration histogram, pass it in as `gcDurationBuckets`:
 
 ```js
-const client = require('@prometheus/client_js');
+const client = require('@prometheus-io/client');
 const collectDefaultMetrics = client.collectDefaultMetrics;
 collectDefaultMetrics({ gcDurationBuckets: [0.1, 0.2, 0.3] });
 ```
@@ -76,7 +76,7 @@ collectDefaultMetrics({ gcDurationBuckets: [0.1, 0.2, 0.3] });
 To prefix metric names with your own arbitrary string, pass in a `prefix`:
 
 ```js
-const client = require('@prometheus/client_js');
+const client = require('@prometheus-io/client');
 const collectDefaultMetrics = client.collectDefaultMetrics;
 const prefix = 'my_application_';
 collectDefaultMetrics({ prefix });
@@ -85,7 +85,7 @@ collectDefaultMetrics({ prefix });
 To apply generic labels to all default metrics, pass an object to the `labels` property (useful if you're working in a clustered environment):
 
 ```js
-const client = require('@prometheus/client_js');
+const client = require('@prometheus-io/client');
 const collectDefaultMetrics = client.collectDefaultMetrics;
 collectDefaultMetrics({
   labels: { NODE_APP_INSTANCE: process.env.NODE_APP_INSTANCE },
@@ -99,7 +99,7 @@ Default metrics are collected on scrape of metrics endpoint,
 not on an interval.
 
 ```js
-const client = require('@prometheus/client_js');
+const client = require('@prometheus-io/client');
 
 const collectDefaultMetrics = client.collectDefaultMetrics;
 
@@ -127,7 +127,7 @@ metric types.
 Counters go up, and reset when the process restarts.
 
 ```js
-const client = require('@prometheus/client_js');
+const client = require('@prometheus-io/client');
 const counter = new client.Counter({
   name: 'metric_name',
   help: 'metric_help',
@@ -141,7 +141,7 @@ counter.inc(10); // Increment by 10
 Gauges are similar to Counters but a Gauge's value can be decreased.
 
 ```js
-const client = require('@prometheus/client_js');
+const client = require('@prometheus-io/client');
 const gauge = new client.Gauge({ name: 'metric_name', help: 'metric_help' });
 gauge.set(10); // Set to 10
 gauge.inc(); // Increment 1
@@ -156,7 +156,7 @@ If the gauge is used for a point-in-time observation, you should provide a
 `collect` function:
 
 ```js
-const client = require('@prometheus/client_js');
+const client = require('@prometheus-io/client');
 new client.Gauge({
   name: 'metric_name',
   help: 'metric_help',
@@ -170,7 +170,7 @@ new client.Gauge({
 
 ```js
 // Async version:
-const client = require('@prometheus/client_js');
+const client = require('@prometheus-io/client');
 new client.Gauge({
   name: 'metric_name',
   help: 'metric_help',
@@ -208,7 +208,7 @@ The defaults buckets are intended to cover usual web/RPC requests, but they can
 be overridden. (See also [**Bucket Generators**](#bucket-generators).)
 
 ```js
-const client = require('@prometheus/client_js');
+const client = require('@prometheus-io/client');
 new client.Histogram({
   name: 'metric_name',
   help: 'metric_help',
@@ -219,7 +219,7 @@ new client.Histogram({
 ##### Examples
 
 ```js
-const client = require('@prometheus/client_js');
+const client = require('@prometheus-io/client');
 const histogram = new client.Histogram({
   name: 'metric_name',
   help: 'metric_help',
@@ -247,7 +247,7 @@ can be overridden by specifying a `percentiles` array. (See also
 [**Bucket Generators**](#bucket-generators).)
 
 ```js
-const client = require('@prometheus/client_js');
+const client = require('@prometheus-io/client');
 new client.Summary({
   name: 'metric_name',
   help: 'metric_help',
@@ -259,7 +259,7 @@ To enable the sliding window functionality for summaries you need to add
 `maxAgeSeconds` and `ageBuckets` to the config like this:
 
 ```js
-const client = require('@prometheus/client_js');
+const client = require('@prometheus-io/client');
 new client.Summary({
   name: 'metric_name',
   help: 'metric_help',
@@ -278,7 +278,7 @@ always be present, even when empty (its percentile values will be `0`). Set
 ##### Examples
 
 ```js
-const client = require('@prometheus/client_js');
+const client = require('@prometheus-io/client');
 const summary = new client.Summary({
   name: 'metric_name',
   help: 'metric_help',
@@ -302,7 +302,7 @@ label names that the metric support needs to be declared here. There are two
 ways to add values to the labels:
 
 ```js
-const client = require('@prometheus/client_js');
+const client = require('@prometheus-io/client');
 const gauge = new client.Gauge({
   name: 'metric_name',
   help: 'metric_help',
@@ -354,7 +354,7 @@ histogram.zero({ method: 'POST' });
 Typescript can also enforce label names using `as const`
 
 ```typescript
-import * as client from '@prometheus/client_js';
+import * as client from '@prometheus-io/client';
 
 const counter = new client.Counter({
   name: 'metric_name',
@@ -376,7 +376,7 @@ counter.inc({ methods: 1 });
 Static labels may be applied to every metric emitted by a registry:
 
 ```js
-const client = require('@prometheus/client_js');
+const client = require('@prometheus-io/client');
 const defaultLabels = { serviceName: 'api-v1' };
 client.register.setDefaultLabels(defaultLabels);
 ```
@@ -413,7 +413,7 @@ The library supports both the old Prometheus format and the OpenMetrics format.
 The format can be set per registry. For default metrics:
 
 ```js
-const Prometheus = require('@prometheus/client_js');
+const Prometheus = require('@prometheus-io/client');
 Prometheus.register.setContentType(
   Prometheus.Registry.OPENMETRICS_CONTENT_TYPE,
 );
@@ -437,7 +437,7 @@ type when creating a new registry, currently defaults to Prometheus type.
 ### Multiple registries
 
 By default, metrics are automatically registered to the global registry (located
-at `require('@prometheus/client_js').register`). You can prevent this by specifying
+at `require('@prometheus-io/client').register`). You can prevent this by specifying
 `registers: []` in the metric constructor configuration.
 
 Using non-global registries requires creating a Registry instance and passing it
@@ -452,7 +452,7 @@ Merging registries of different types is undefined. The user needs to make sure
 all used registries have the same type (Prometheus or OpenMetrics versions).
 
 ```js
-const client = require('@prometheus/client_js');
+const client = require('@prometheus-io/client');
 const registry = new client.Registry();
 const counter = new client.Counter({
   name: 'metric_name',
@@ -534,7 +534,7 @@ It is possible to push metrics via a
 [Pushgateway](https://github.com/prometheus/pushgateway).
 
 ```js
-const client = require('@prometheus/client_js');
+const client = require('@prometheus-io/client');
 let gateway = new client.Pushgateway('http://127.0.0.1:9091');
 
 gateway.pushAdd({ jobName: 'test' })
@@ -597,7 +597,7 @@ For convenience, there are two bucket generator functions - linear and
 exponential.
 
 ```js
-const client = require('@prometheus/client_js');
+const client = require('@prometheus-io/client');
 new client.Histogram({
   name: 'metric_name',
   help: 'metric_help',

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -13,9 +13,9 @@ const debug = require('debug')('benchmark');
  */
 
 const benchmarks = new Benchmark({
-	'@prometheus-io/client@latest': '@prometheus-io/client@latest',
-	'@prometheus-io/client@trunk': 'git@github.com:prometheus/client_js',
-	'@prometheus-io/client@current': { location: process.cwd() },
+	'@prometheus/client@latest': '@prometheus/client@latest',
+	'@prometheus/client@trunk': 'git@github.com:prometheus/client_js',
+	'@prometheus/client@current': { location: process.cwd() },
 });
 
 benchmarks.suite('counter', require('./counter'));

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -13,9 +13,9 @@ const debug = require('debug')('benchmark');
  */
 
 const benchmarks = new Benchmark({
-	'prom-client@latest': 'prom-client@latest',
-	'prom-client@trunk': 'git@github.com:siimon/prom-client',
-	'prom-client@current': { location: process.cwd() },
+	'@prometheus/client_js@latest': '@prometheus/client_js@latest',
+	'@prometheus/client_js@trunk': 'git@github.com:prometheus/client_js',
+	'@prometheus/client_js@current': { location: process.cwd() },
 });
 
 benchmarks.suite('counter', require('./counter'));

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -13,9 +13,9 @@ const debug = require('debug')('benchmark');
  */
 
 const benchmarks = new Benchmark({
-	'@prometheus/client_js@latest': '@prometheus/client_js@latest',
-	'@prometheus/client_js@trunk': 'git@github.com:prometheus/client_js',
-	'@prometheus/client_js@current': { location: process.cwd() },
+	'@prometheus-io/client@latest': '@prometheus-io/client@latest',
+	'@prometheus-io/client@trunk': 'git@github.com:prometheus/client_js',
+	'@prometheus-io/client@current': { location: process.cwd() },
 });
 
 benchmarks.suite('counter', require('./counter'));

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -13,7 +13,8 @@ const debug = require('debug')('benchmark');
  */
 
 const benchmarks = new Benchmark({
-	'@prometheus/client@latest': '@prometheus/client@latest',
+	// TODO: Update this once the module is published to as @prometheus/client.
+	'@prometheus/client@latest': 'prom-client@latest',
 	'@prometheus/client@trunk': 'git@github.com:prometheus/client_js',
 	'@prometheus/client@current': { location: process.cwd() },
 });

--- a/benchmarks/util.js
+++ b/benchmarks/util.js
@@ -5,7 +5,7 @@ const Path = require('path');
 module.exports = setupUtilSuite;
 
 function setupUtilSuite(suite) {
-	const skip = ['@prometheus-io/client@latest'];
+	const skip = ['@prometheus/client@latest'];
 
 	suite.add(
 		'hashObject',

--- a/benchmarks/util.js
+++ b/benchmarks/util.js
@@ -5,7 +5,7 @@ const Path = require('path');
 module.exports = setupUtilSuite;
 
 function setupUtilSuite(suite) {
-	const skip = ['prom-client@latest'];
+	const skip = ['@prometheus/client_js@latest'];
 
 	suite.add(
 		'hashObject',

--- a/benchmarks/util.js
+++ b/benchmarks/util.js
@@ -5,7 +5,7 @@ const Path = require('path');
 module.exports = setupUtilSuite;
 
 function setupUtilSuite(suite) {
-	const skip = ['@prometheus/client_js@latest'];
+	const skip = ['@prometheus-io/client@latest'];
 
 	suite.add(
 		'hashObject',

--- a/benchmarks/util.js
+++ b/benchmarks/util.js
@@ -77,7 +77,7 @@ function setupUtilSuite(suite) {
 
 				return new Util.LabelGrouper();
 			},
-			skip: ['prom-client@latest', 'prom-client@trunk'],
+			skip: ['@prometheus/client@latest', '@prometheus/client@trunk'],
 		},
 	);
 }

--- a/example/worker.js
+++ b/example/worker.js
@@ -5,7 +5,7 @@ const { Worker, isMainThread, workerData } = require('node:worker_threads');
 const express = require('express');
 const WorkerRegistry = require('../').WorkerRegistry;
 
-const collector = workerData?.['@prometheus/client_js']?.collector === true;
+const collector = workerData?.['@prometheus-io/client']?.collector === true;
 const metricsServer = express();
 const workerRegistry = new WorkerRegistry(
 	WorkerRegistry.PROMETHEUS_CONTENT_TYPE,
@@ -17,7 +17,7 @@ if (isMainThread) {
 	new Worker(Path.join(__filename), {
 		env: { ...process.env, PORT: 3333 },
 		workerData: {
-			'@prometheus/client_js': { collector: true },
+			'@prometheus-io/client': { collector: true },
 		},
 	});
 

--- a/example/worker.js
+++ b/example/worker.js
@@ -5,7 +5,7 @@ const { Worker, isMainThread, workerData } = require('node:worker_threads');
 const express = require('express');
 const WorkerRegistry = require('../').WorkerRegistry;
 
-const collector = workerData?.['prom-client']?.collector === true;
+const collector = workerData?.['@prometheus/client_js']?.collector === true;
 const metricsServer = express();
 const workerRegistry = new WorkerRegistry(
 	WorkerRegistry.PROMETHEUS_CONTENT_TYPE,
@@ -17,7 +17,7 @@ if (isMainThread) {
 	new Worker(Path.join(__filename), {
 		env: { ...process.env, PORT: 3333 },
 		workerData: {
-			'prom-client': { collector: true },
+			'@prometheus/client_js': { collector: true },
 		},
 	});
 

--- a/example/worker.js
+++ b/example/worker.js
@@ -5,7 +5,7 @@ const { Worker, isMainThread, workerData } = require('node:worker_threads');
 const express = require('express');
 const WorkerRegistry = require('../').WorkerRegistry;
 
-const collector = workerData?.['@prometheus-io/client']?.collector === true;
+const collector = workerData?.['@prometheus/client']?.collector === true;
 const metricsServer = express();
 const workerRegistry = new WorkerRegistry(
 	WorkerRegistry.PROMETHEUS_CONTENT_TYPE,
@@ -17,7 +17,7 @@ if (isMainThread) {
 	new Worker(Path.join(__filename), {
 		env: { ...process.env, PORT: 3333 },
 		workerData: {
-			'@prometheus-io/client': { collector: true },
+			'@prometheus/client': { collector: true },
 		},
 	});
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @prometheus-io/client
+// Type definitions for @prometheus/client
 // Definitions by: Simon Nyberg http://twitter.com/siimon_nyberg
 
 export type Charset = 'utf-8';

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for client_js
+// Type definitions for @prometheus-io/client
 // Definitions by: Simon Nyberg http://twitter.com/siimon_nyberg
 
 export type Charset = 'utf-8';

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for prom-client
+// Type definitions for client_js
 // Definitions by: Simon Nyberg http://twitter.com/siimon_nyberg
 
 export type Charset = 'utf-8';

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -17,8 +17,8 @@ let cluster = () => {
 	return data;
 };
 
-const GET_METRICS_REQ = '@prometheus/client_js:getMetricsReq';
-const GET_METRICS_RES = '@prometheus/client_js:getMetricsRes';
+const GET_METRICS_REQ = '@prometheus-io/client:getMetricsReq';
+const GET_METRICS_RES = '@prometheus-io/client:getMetricsRes';
 
 let registries = [Registry.globalRegistry];
 let requestCtr = 0; // Concurrency control

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -17,8 +17,8 @@ let cluster = () => {
 	return data;
 };
 
-const GET_METRICS_REQ = '@prometheus-io/client:getMetricsReq';
-const GET_METRICS_RES = '@prometheus-io/client:getMetricsRes';
+const GET_METRICS_REQ = '@prometheus/client:getMetricsReq';
+const GET_METRICS_RES = '@prometheus/client:getMetricsRes';
 
 let registries = [Registry.globalRegistry];
 let requestCtr = 0; // Concurrency control

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -17,8 +17,8 @@ let cluster = () => {
 	return data;
 };
 
-const GET_METRICS_REQ = 'prom-client:getMetricsReq';
-const GET_METRICS_RES = 'prom-client:getMetricsRes';
+const GET_METRICS_REQ = '@prometheus/client_js:getMetricsReq';
+const GET_METRICS_RES = '@prometheus/client_js:getMetricsRes';
 
 let registries = [Registry.globalRegistry];
 let requestCtr = 0; // Concurrency control

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -12,11 +12,11 @@ const Registry = require('./registry');
 const worker = require('node:worker_threads');
 const { isMainThread, threadId, BroadcastChannel } = worker;
 
-const ANNOUNCEMENT = '@prometheus/client_js:announcement';
-const GET_METRICS_REQ = '@prometheus/client_js:getMetricsReq';
-const GET_METRICS_RES = '@prometheus/client_js:getMetricsRes';
+const ANNOUNCEMENT = '@prometheus-io/client:announcement';
+const GET_METRICS_REQ = '@prometheus-io/client:getMetricsReq';
+const GET_METRICS_RES = '@prometheus-io/client:getMetricsRes';
 const ANNOUNCEMENT_CHANNEL = new BroadcastChannel(
-	'@prometheus/client_js:announce',
+	'@prometheus-io/client:announce',
 );
 
 ANNOUNCEMENT_CHANNEL.unref();
@@ -198,7 +198,7 @@ function addListeners(registry) {
 
 	listenersAdded = true;
 
-	const name = `@prometheus/client_js:worker:${threadId}`;
+	const name = `@prometheus-io/client:worker:${threadId}`;
 	const channel = new BroadcastChannel(name);
 
 	channel.unref();

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -12,11 +12,11 @@ const Registry = require('./registry');
 const worker = require('node:worker_threads');
 const { isMainThread, threadId, BroadcastChannel } = worker;
 
-const ANNOUNCEMENT = '@prometheus-io/client:announcement';
-const GET_METRICS_REQ = '@prometheus-io/client:getMetricsReq';
-const GET_METRICS_RES = '@prometheus-io/client:getMetricsRes';
+const ANNOUNCEMENT = '@prometheus/client:announcement';
+const GET_METRICS_REQ = '@prometheus/client:getMetricsReq';
+const GET_METRICS_RES = '@prometheus/client:getMetricsRes';
 const ANNOUNCEMENT_CHANNEL = new BroadcastChannel(
-	'@prometheus-io/client:announce',
+	'@prometheus/client:announce',
 );
 
 ANNOUNCEMENT_CHANNEL.unref();
@@ -198,7 +198,7 @@ function addListeners(registry) {
 
 	listenersAdded = true;
 
-	const name = `@prometheus-io/client:worker:${threadId}`;
+	const name = `@prometheus/client:worker:${threadId}`;
 	const channel = new BroadcastChannel(name);
 
 	channel.unref();

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -12,10 +12,12 @@ const Registry = require('./registry');
 const worker = require('node:worker_threads');
 const { isMainThread, threadId, BroadcastChannel } = worker;
 
-const ANNOUNCEMENT = 'prom-client:announcement';
-const GET_METRICS_REQ = 'prom-client:getMetricsReq';
-const GET_METRICS_RES = 'prom-client:getMetricsRes';
-const ANNOUNCEMENT_CHANNEL = new BroadcastChannel('prom-client:announce');
+const ANNOUNCEMENT = '@prometheus/client_js:announcement';
+const GET_METRICS_REQ = '@prometheus/client_js:getMetricsReq';
+const GET_METRICS_RES = '@prometheus/client_js:getMetricsRes';
+const ANNOUNCEMENT_CHANNEL = new BroadcastChannel(
+	'@prometheus/client_js:announce',
+);
 
 ANNOUNCEMENT_CHANNEL.unref();
 
@@ -196,7 +198,7 @@ function addListeners(registry) {
 
 	listenersAdded = true;
 
-	const name = `prom-client:worker:${threadId}`;
+	const name = `@prometheus/client_js:worker:${threadId}`;
 	const channel = new BroadcastChannel(name);
 
 	channel.unref();

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@prometheus-io/client",
+	"name": "@prometheus/client",
 	"version": "15.1.3",
 	"description": "Client for prometheus",
 	"main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@prometheus/client_js",
+	"name": "@prometheus-io/client",
 	"version": "15.1.3",
 	"description": "Client for prometheus",
 	"main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "prom-client",
+	"name": "@prometheus/client_js",
 	"version": "15.1.3",
 	"description": "Client for prometheus",
 	"main": "index.js",
@@ -23,7 +23,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git@github.com:siimon/prom-client.git"
+		"url": "git@github.com:prometheus/client_js.git"
 	},
 	"keywords": [
 		"Prometheus",
@@ -32,7 +32,7 @@
 	],
 	"author": "Simon Nyberg",
 	"license": "Apache-2.0",
-	"homepage": "https://github.com/siimon/prom-client",
+	"homepage": "https://github.com/prometheus/client_js",
 	"devDependencies": {
 		"@eslint/js": "^9.29.0",
 		"debug": "^4.4.1",

--- a/test/clusterTest.js
+++ b/test/clusterTest.js
@@ -57,7 +57,7 @@ describe.each([
 
 			//Emulate a response that has been deleted from requests
 			const unexpected = {
-				type: 'prom-client:getMetricsRes',
+				type: '@prometheus/client_js:getMetricsRes',
 				metrics: ['{}'],
 				requestId: -3,
 			};

--- a/test/clusterTest.js
+++ b/test/clusterTest.js
@@ -57,7 +57,7 @@ describe.each([
 
 			//Emulate a response that has been deleted from requests
 			const unexpected = {
-				type: '@prometheus/client_js:getMetricsRes',
+				type: '@prometheus-io/client:getMetricsRes',
 				metrics: ['{}'],
 				requestId: -3,
 			};

--- a/test/clusterTest.js
+++ b/test/clusterTest.js
@@ -57,7 +57,7 @@ describe.each([
 
 			//Emulate a response that has been deleted from requests
 			const unexpected = {
-				type: '@prometheus-io/client:getMetricsRes',
+				type: '@prometheus/client:getMetricsRes',
 				metrics: ['{}'],
 				requestId: -3,
 			};

--- a/test/workerTest.js
+++ b/test/workerTest.js
@@ -33,7 +33,7 @@ describe.each([
 
 			//Emulate a response that has been deleted from requests
 			const unexpected = {
-				type: '@prometheus-io/client:getMetricsRes',
+				type: '@prometheus/client:getMetricsRes',
 				metrics: ['{}'],
 				requestId: -3,
 			};

--- a/test/workerTest.js
+++ b/test/workerTest.js
@@ -33,7 +33,7 @@ describe.each([
 
 			//Emulate a response that has been deleted from requests
 			const unexpected = {
-				type: '@prometheus/client_js:getMetricsRes',
+				type: '@prometheus-io/client:getMetricsRes',
 				metrics: ['{}'],
 				requestId: -3,
 			};

--- a/test/workerTest.js
+++ b/test/workerTest.js
@@ -33,7 +33,7 @@ describe.each([
 
 			//Emulate a response that has been deleted from requests
 			const unexpected = {
-				type: 'prom-client:getMetricsRes',
+				type: '@prometheus/client_js:getMetricsRes',
 				metrics: ['{}'],
 				requestId: -3,
 			};


### PR DESCRIPTION
This commit updates the project name from prom-client to @prometheus/client_js to reflect the recent move.

This is my first time contributing to this project under any package name, so please let me know if anything here is incorrect.