### PR TITLE
drop node 20 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking
 
-- Drop support for Node.js versions 16, 18, 21 and 23
+- Drop support for Node.js versions 16, 18, 20, 21 and 23
 - Metric internal storage ('hashMap') changed to a separate object, LabelMap. If you have
   subclassed the built-in metric types you may need to adjust your code.
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"index.d.ts"
 	],
 	"engines": {
-		"node": "^20 || ^22 || >=24"
+		"node": "^22 || >=24"
 	},
 	"scripts": {
 		"benchmarks": "node --max-heap-size=5000 --allow-natives-syntax ./benchmarks/index.js",


### PR DESCRIPTION
Node 20.x went End-of-Life on 2026-04-30.

The package rename seems like a good time for such a change.