### PR TITLE
chore: Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,26 @@
+###
+# Avoid syncing from prometheus/prometheus: no_prometheus_repo_sync
+###
 version: 2
 updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    groups:
+      promci:
+        patterns:
+          - 'prometheus/promci*'
+      codeql:
+        patterns:
+          - 'github/codeql-action*'
+    # Exclude configs synced from upstream prometheus/prometheus.
+    exclude-paths:
+      - .github/workflows/container_description.yml
+      - .github/workflows/golangci-lint.yml
+      - .github/workflows/govulncheck.yml
+      - .github/workflows/scorecards.yml
+      - .github/workflows/stale.yml
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:


### PR DESCRIPTION
* Opt-out of sync from upstream Prometheus.
* Add updates for Github Actions.