### PR TITLE
Add Zach to maintainers list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+This release marks our first release under the Prometheus umbrella.
+
 ### Breaking
 
 - Drop support for Node.js versions 16, 18, 20, 21 and 23

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,7 +1,8 @@
 # Maintainers
 
-- Jason Marshall (@jdmarshall)
+- Jason Marshall @jdmarshall
+- Zach Bjornson <zbbjornson@gmail.com> @zbjornson
 
 # Emeritus
 
-- Simon Nyberg (@siimon)
+- Simon Nyberg @siimon


### PR DESCRIPTION
Zach was a maintainer on prom-client and currently has publish rights under the old npmjs account.

He's agreed to stay on to rubber stamp hot fixes and occasionally participate in PR reviews.