### PR TITLE
Add getMetricsAsString to TypeScript definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Add `Registry#getMetricsAsString()` to the TypeScript definitions
 - Improve types for no labels
 - perf: Faster stats gathering with lower memory overhead
 - Simplified number format logic

--- a/index.d.ts
+++ b/index.d.ts
@@ -56,6 +56,12 @@ export class Registry<
 	getMetricsAsJSON(): Promise<MetricObjectWithValues<MetricValue<string>>[]>;
 
 	/**
+	 * Get string representation for a metric
+	 * @param metric Metric to convert to a string
+	 */
+	getMetricsAsString<T extends string>(metric: Metric<T>): Promise<string>;
+
+	/**
 	 * Get all metrics as objects
 	 */
 	getMetricsAsArray(): MetricObject[];

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -1,0 +1,12 @@
+import { Counter, Registry } from '../index';
+
+const registry = new Registry();
+const counter = new Counter({
+	name: 'typescript_test_counter',
+	help: 'TypeScript test counter',
+	registers: [registry],
+});
+
+const metricsText: Promise<string> = registry.getMetricsAsString(counter);
+
+void metricsText;


### PR DESCRIPTION
## Purpose

`Registry#getMetricsAsString(metric)` exists at runtime, but it is missing from the TypeScript declarations. This makes the method unavailable to TypeScript users even though it is already implemented.

Fixes #678.

## Changes

- Add `Registry#getMetricsAsString<T>(metric: Metric<T>): Promise<string>` to `index.d.ts`
- Add a small TypeScript compile check that calls `registry.getMetricsAsString(counter)`
- Update the unreleased changelog

## Testing

- `npm test -- --runInBand --forceExit`