### PR TITLE
Support registry as Pushgateway second argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This release marks our first release under the Prometheus umbrella.
 
 ### Changed
 
+- Allow `Pushgateway` to accept a custom registry as the second constructor argument
 - Add `Registry#getMetricsAsString()` to the TypeScript definitions
 - Improve types for no labels
 - perf: Faster stats gathering with lower memory overhead

--- a/index.d.ts
+++ b/index.d.ts
@@ -773,7 +773,12 @@ export class Pushgateway<T extends RegistryContentType> {
 	 * @param options Options
 	 * @param registry Registry
 	 */
-	constructor(url: string, options?: any, registry?: Registry<T>);
+	constructor(url: string, registry: Registry<T>);
+	constructor(
+		url: string,
+		options?: Pushgateway.Options | null,
+		registry?: Registry<T>,
+	);
 
 	/**
 	 * Add metric and overwrite old ones
@@ -801,6 +806,11 @@ export class Pushgateway<T extends RegistryContentType> {
 }
 
 export namespace Pushgateway {
+	interface Options {
+		requireJobName?: boolean;
+		[key: string]: unknown;
+	}
+
 	interface Parameters {
 		/**
 		 * Jobname that is pushing the metric

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -7,13 +7,10 @@ const Registry = require('./registry');
 const { globalRegistry } = Registry;
 
 class Pushgateway {
-	constructor(gatewayUrl, options, registry) {
+	constructor(gatewayUrl, options, registry = globalRegistry) {
 		if (options instanceof Registry) {
 			registry = options;
-			options = undefined;
-		}
-		if (!registry) {
-			registry = globalRegistry;
+			options = {};
 		}
 		this.registry = registry;
 		this.gatewayUrl = gatewayUrl;

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -3,10 +3,15 @@
 const http = require('http');
 const https = require('https');
 const { gzipSync } = require('zlib');
-const { globalRegistry } = require('./registry');
+const Registry = require('./registry');
+const { globalRegistry } = Registry;
 
 class Pushgateway {
 	constructor(gatewayUrl, options, registry) {
+		if (options instanceof Registry) {
+			registry = options;
+			options = undefined;
+		}
 		if (!registry) {
 			registry = globalRegistry;
 		}

--- a/test/pushgatewayTest.js
+++ b/test/pushgatewayTest.js
@@ -326,6 +326,22 @@ describe.each([
 			cnt.inc(100);
 		});
 
+		it('should use a registry passed as the second constructor argument', () => {
+			const body =
+				regType === Registry.OPENMETRICS_CONTENT_TYPE
+					? '# HELP test test\n# TYPE test counter\ntest_total 100\n# EOF\n'
+					: '# HELP test test\n# TYPE test counter\ntest 100\n';
+			const mockHttp = nock('http://192.168.99.100:9091')
+				.put('/metrics/job/testJob', body)
+				.reply(200);
+
+			instance = new Pushgateway('http://192.168.99.100:9091', registry);
+
+			return instance.push({ jobName: 'testJob' }).then(() => {
+				expect(mockHttp.isDone());
+			});
+		});
+
 		tests();
 	});
 });

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -1,4 +1,4 @@
-import { Counter, Registry } from '../index';
+import { Counter, Pushgateway, Registry } from '../index';
 
 const registry = new Registry();
 const counter = new Counter({
@@ -8,5 +8,19 @@ const counter = new Counter({
 });
 
 const metricsText: Promise<string> = registry.getMetricsAsString(counter);
+const gatewayWithRegistry = new Pushgateway('http://127.0.0.1:9091', registry);
+const gatewayWithOptionsAndRegistry = new Pushgateway(
+	'http://127.0.0.1:9091',
+	{ timeout: 10, requireJobName: false },
+	registry,
+);
+const gatewayWithNullOptionsAndRegistry = new Pushgateway(
+	'http://127.0.0.1:9091',
+	null,
+	registry,
+);
 
 void metricsText;
+void gatewayWithRegistry;
+void gatewayWithOptionsAndRegistry;
+void gatewayWithNullOptionsAndRegistry;


### PR DESCRIPTION
## Purpose

`Pushgateway` accepts an optional `options` argument before the `registry` argument. In TypeScript, `new Pushgateway(url, registry)` was accepted because `options` was typed as `any`, but at runtime that registry object was treated as request options and the Pushgateway fell back to the global registry.

This makes the two-argument registry form work at runtime and declares it explicitly in the TypeScript definitions.

Fixes #652.

## Changes

- Treat a `Registry` passed as the second `Pushgateway` constructor argument as the registry
- Add constructor overloads for `new Pushgateway(url, registry)` and `new Pushgateway(url, options, registry)`
- Add a small `Pushgateway.Options` type with `requireJobName` plus request option passthrough
- Add runtime coverage for pushing metrics from a second-argument registry
- Add TypeScript compile coverage for the supported constructor forms
- Update the unreleased changelog

## Testing

- `npm test -- --runInBand --forceExit`
- Manual smoke check with a local HTTP server verifying `new Pushgateway(url, registry).push()` sends metrics from the provided registry
