### PR TITLE
feat(counter): optionally use the counter value as the exemplar value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -323,6 +323,7 @@ export interface CounterConfiguration<
 	T extends string,
 > extends MetricConfiguration<T> {
 	collect?: CollectFunction<Counter<T>>;
+	useCounterValueAsExemplar?: boolean;
 }
 
 export interface IncreaseDataWithExemplar<T extends string> {

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -24,7 +24,7 @@ const Exemplar = require('./exemplar');
 
 class Counter extends Metric {
 	constructor(config) {
-		super(config);
+		super(config, { useCounterValueAsExemplar: false });
 		this.type = 'counter';
 		this.defaultLabels = {};
 		this.defaultValue = 1;
@@ -93,7 +93,11 @@ class Counter extends Metric {
 		entry.exemplar ??= new Exemplar();
 		entry.exemplar.validateExemplarLabelSet(exemplarLabels);
 		entry.exemplar.labelSet = exemplarLabels;
-		entry.exemplar.value = value ? value : 1;
+		entry.exemplar.value = this.useCounterValueAsExemplar
+			? entry.value
+			: value
+				? value
+				: 1;
 		entry.exemplar.timestamp = nowTimestamp();
 	}
 

--- a/test/exemplarsTest.js
+++ b/test/exemplarsTest.js
@@ -60,6 +60,34 @@ describe('Exemplars', () => {
 				);
 			});
 
+			it('should optionally use the counter value for exemplars', async () => {
+				const counterWithTotal = new Counter({
+					name: 'counter_total_exemplar_test',
+					help: 'help',
+					enableExemplars: true,
+					useCounterValueAsExemplar: true,
+					registers: [],
+				});
+				const counterWithIncrement = new Counter({
+					name: 'counter_increment_exemplar_test',
+					help: 'help',
+					enableExemplars: true,
+					registers: [],
+				});
+
+				counterWithTotal.inc({ exemplarLabels: { traceId: 'x' } });
+				counterWithTotal.inc({ exemplarLabels: { traceId: 'x' } });
+				counterWithIncrement.inc({ exemplarLabels: { traceId: 'x' } });
+				counterWithIncrement.inc({ exemplarLabels: { traceId: 'x' } });
+
+				const totalValues = await counterWithTotal.get();
+				const incrementValues = await counterWithIncrement.get();
+				expect(totalValues.values[0].value).toEqual(2);
+				expect(totalValues.values[0].exemplar.value).toEqual(2);
+				expect(incrementValues.values[0].value).toEqual(2);
+				expect(incrementValues.values[0].exemplar.value).toEqual(1);
+			});
+
 			it('should make histogram with exemplars on multiple buckets', async () => {
 				const histogramInstance = new Histogram({
 					name: 'histogram_exemplar_test',


### PR DESCRIPTION
## Problem

When a counter is incremented with `inc({ exemplarLabels })`, the exemplar's value is set to the amount passed to `inc` — `1` by default. As raised in #621, that makes exemplars unhelpful for the common case of calling `inc()` with no argument: every exemplar reads `1`, so in tools like Grafana the exemplar markers all sit at the bottom of the graph regardless of the counter's actual value.

## Change

- Add an opt-in Counter option `useCounterValueAsExemplar` (default `false`, so existing behavior is unchanged). When `true`, the exemplar value recorded on an increment is the counter's current total rather than the increment amount.
- `lib/counter.js` threads the option through and records `entry.value` vs. the passed value accordingly; `index.d.ts` types the new option.
- Add a unit test covering both modes (exemplar value `2` with the option after two `inc()` calls, `1` without it).

### Checks (Node 22)
- `npm run test-unit` — 543 passing, including the new exemplar-value test.

Fixes #621

---
Disclosure: this change was prepared with AI assistance and reviewed by me before submitting.
I ran the check(s) above in a network-isolated container and published a signed, re-runnable
record of that run, verifiable via GitHub artifact attestation:
https://northset-oss.github.io/verification-pilot/. Contributor self-run, not a maintainer verification.
