### PR TITLE
fix(types): allow string[] label values

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -304,7 +304,7 @@ type MetricValueWithName<T extends string> = MetricValue<T> & {
 
 type LabelValues<T extends string> = T extends NoLabelNameType
 	? Partial<Record<string, never>>
-	: Partial<Record<T, string | number>>;
+	: Partial<Record<T, string | number | string[]>>;
 
 interface MetricConfiguration<T extends string> {
 	name: string;

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -18,8 +18,10 @@ const registry = new Registry();
 const counter = new Counter({
 	name: 'typescript_test_counter',
 	help: 'TypeScript test counter',
+	labelNames: ['handler'],
 	registers: [registry],
 });
+counter.inc({ handler: ['/a', '/b'] });
 
 const metricsText: Promise<string> = registry.getMetricsAsString(counter);
 const gatewayWithRegistry = new Pushgateway('http://127.0.0.1:9091', registry);


### PR DESCRIPTION
## Problem

prom-client accepts an array of strings as a label value at runtime — e.g. `.inc({ handler: ['/a', '/b'] })`, which renders as `handler="/a,/b"` — but its TypeScript types reject it: the label-values type only allows `string | number`, so that call fails to type-check even though it works. Reported in #582.

## Change

- `index.d.ts`: widen the label-values type to `string | number | string[]` so array-valued labels type-check.
- `test/typescript.ts`: add an array-valued-label usage so `tsc` proves the type now accepts it.

### Checks (Node 22)
- `npm run compile-typescript` (`tsc --project .`) and `npm run test-unit` — both pass.

Fixes #582

---
Disclosure: this change was prepared with AI assistance and reviewed by me before submitting.
I ran the check(s) above in a network-isolated container and published a signed, re-runnable
record of that run, verifiable via GitHub artifact attestation:
https://northset-oss.github.io/verification-pilot/. Contributor self-run, not a maintainer verification.
