### PR TITLE
fix(counter): use counter total as exemplar value instead of increment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This release marks our first release under the Prometheus umbrella.
 - Drop support for Node.js versions 16, 18, 20, 21 and 23
 - Metric internal storage ('hashMap') changed to a separate object, LabelMap. If you have
   subclassed the built-in metric types you may need to adjust your code.
+- Counter exemplar values now record the counter's total value instead of the increment
+  amount, matching the behavior of other Prometheus clients (Fixes [#621](https://github.com/prometheus/client_js/issues/621))
 
 ### Changed
 

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -82,7 +82,8 @@ class Counter extends Metric {
 		exemplarLabels = this.defaultExemplarLabelSet,
 	} = {}) {
 		this.incWithoutExemplar(labels, value);
-		this.updateExemplar(labels, exemplarLabels, value);
+		const entry = this.store.entry(labels);
+		this.updateExemplar(labels, exemplarLabels, entry.value);
 	}
 
 	updateExemplar(labels, exemplarLabels, value) {

--- a/test/exemplarsTest.js
+++ b/test/exemplarsTest.js
@@ -60,6 +60,31 @@ describe('Exemplars', () => {
 				);
 			});
 
+			it('should use the counter total as the exemplar value, not the increment', async () => {
+				const localRegistry = new Registry();
+				localRegistry.setContentType(regType);
+				const counterInstance = new Counter({
+					name: 'counter_exemplar_total_test',
+					help: 'help',
+					labelNames: ['method', 'code'],
+					enableExemplars: true,
+					registers: [localRegistry],
+				});
+				counterInstance.inc({
+					labels: { method: 'get', code: '200' },
+					exemplarLabels: { traceId: 'trace_id_1' },
+				});
+				counterInstance.inc({
+					value: 3,
+					labels: { method: 'get', code: '200' },
+					exemplarLabels: { traceId: 'trace_id_2' },
+				});
+				const vals = await counterInstance.get();
+				expect(vals.values[0].value).toEqual(4);
+				expect(vals.values[0].exemplar.value).toEqual(4);
+				expect(vals.values[0].exemplar.labelSet.traceId).toEqual('trace_id_2');
+			});
+
 			it('should make histogram with exemplars on multiple buckets', async () => {
 				const histogramInstance = new Histogram({
 					name: 'histogram_exemplar_test',


### PR DESCRIPTION
## Summary

When a `Counter` with exemplars enabled is incremented via `inc({ exemplarLabels })`, the exemplar's value was set to the increment amount (default `1`) instead of the counter's current total. This caused every exemplar to read `1` in common usage, making exemplar markers in tools like Grafana sit at the bottom of the graph regardless of the counter's actual value.

## Root cause

In `Counter.incWithExemplar`, after calling `incWithoutExemplar(labels, value)`, the code passed the raw increment `value` to `updateExemplar`. The exemplar should instead record the counter's total after the increment, which is what other Prometheus clients do.

## Changes

- `lib/counter.js`: pass `this.store.entry(labels).value` (the counter total) to `updateExemplar` instead of `value` (the increment amount).
- `test/exemplarsTest.js`: add regression test verifying that after `inc()` then `inc(3)`, the second exemplar records `4` (the total), not `3`.
- `CHANGELOG.md`: document the breaking behavior change under the Unreleased section.

## Testing

- `npm test` — 543 passing (28 test suites)
- `npx jest test/exemplarsTest.js` — 9 passing, 1 snapshot passing
- Verified with a standalone reproduction script that exemplar values now match the counter total on each increment.

## Compatibility

This changes the value written to counter exemplars from the increment amount to the counter total. Anyone relying on the previous (buggy) behavior of exemplars always being `1` will see a change. The fix aligns with the behavior described in the linked issue and with other Prometheus client libraries.

Fixes #621
