### PR TITLE
Address misreported value on exemplars for counters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Drop support for Node.js versions 16, 18, 20, 21 and 23
 - Metric internal storage ('hashMap') changed to a separate object, LabelMap. If you have
   subclassed the built-in metric types you may need to adjust your code.
+- Counter Exemplars now report the value rather than the delta
 
 ### Changed
 

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -42,7 +42,7 @@ class Counter extends Metric {
 			throw new Error('It is not possible to decrease a counter');
 		}
 
-		if (value === null || value === undefined) value = 1;
+		value = value ?? 1;
 
 		this.store.validate(labels);
 		this.store.setDelta(labels, value);
@@ -68,7 +68,7 @@ class Counter extends Metric {
 		exemplarLabels = this.defaultExemplarLabelSet,
 	} = {}) {
 		this.incWithoutExemplar(labels, value);
-		this.updateExemplar(labels, exemplarLabels, value);
+		this.updateExemplar(labels, exemplarLabels, this.store.get(labels));
 	}
 
 	updateExemplar(labels, exemplarLabels, value) {

--- a/test/exemplarsTest.js
+++ b/test/exemplarsTest.js
@@ -33,8 +33,11 @@ describe('Exemplars', () => {
 					labelNames: ['method', 'code'],
 					enableExemplars: true,
 				});
+
 				counterInstance.inc({
-					value: 2,
+					labels: { method: 'get', code: '200' },
+				}); // 1
+				counterInstance.inc({
 					labels: { method: 'get', code: '200' },
 					exemplarLabels: { traceId: 'trace_id_test', spanId: 'span_id_test' },
 				});


### PR DESCRIPTION
After one AI user filed a PR to fix this the wrong way, I finally went tracing through the code to understand what the heck is wrong as implemented. The real issue turned out to be pretty dumb: mislabeled variables resulting in mischaracterization of the data it represents. 

We're calling the increment step 'value' but we use the 'value' to call `setDelta` in `incWithoutExemplars()` and delegating to it from `incWithExemplars()` but then using the passed-in delta as a 'value' again when updating the 'value' field in the exemplar, which is not the same meaning of 'value'.

Within minutes of updating the ticket to set the labels and the problem, a completely separate user filed a PR. Maybe I should not have set helpWanted when a PR was already open. However, both PRs had an identical new unit test, and both of them were identically asserting the wrong thing, and solving the issue the wrong way.

At this point I had invested more time in both PRs than the authors had. The entire problem was front-of mind, and the existing test is wrong but written in a way where either interpretation would be correct. Clearly they are not.

Fixes #621