### PR TITLE
Add debug logging for metrics collection failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This release marks our first release under the Prometheus umbrella.
 
 ### Added
 
+- Add debug logging for metrics collection failures.
 - Node 26 added to the test matrix
 - Expanded benchmarking code
 - new WorkerRegistry to provide equivalent support to AggregatorRegistry

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -15,7 +15,6 @@
 'use strict';
 
 const Benchmark = require('faceoff').default;
-const debug = require('debug')('benchmark');
 
 /**
  * Async suite workaround. benchmark-regression forwards no options to
@@ -41,14 +40,9 @@ benchmarks.suite('summary', require('./summary'));
 benchmarks.suite('registry', require('./registry'));
 benchmarks.suite('cluster', require('./cluster'));
 
-benchmarks
-	.run()
-	.then(() => {
-		debug('Process end');
-	})
-	.catch(err => {
-		console.error('Failure', err);
-		console.error(err.stack);
-		// eslint-disable-next-line n/no-process-exit
-		process.exit(1);
-	});
+benchmarks.run().catch(err => {
+	console.error('Failure', err);
+	console.error(err.stack);
+	// eslint-disable-next-line n/no-process-exit
+	process.exit(1);
+});

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -14,6 +14,8 @@
 
 'use strict';
 
+const { debuglog } = require('node:util');
+const debug = debuglog('prom:metrics:safe-memory-usage');
 const Benchmark = require('faceoff').default;
 
 /**
@@ -40,9 +42,14 @@ benchmarks.suite('summary', require('./summary'));
 benchmarks.suite('registry', require('./registry'));
 benchmarks.suite('cluster', require('./cluster'));
 
-benchmarks.run().catch(err => {
-	console.error('Failure', err);
-	console.error(err.stack);
-	// eslint-disable-next-line n/no-process-exit
-	process.exit(1);
-});
+benchmarks
+	.run()
+	.then(() => {
+		debug('Process end');
+	})
+	.catch(err => {
+		console.error('Failure', err);
+		console.error(err.stack);
+		// eslint-disable-next-line n/no-process-exit
+		process.exit(1);
+	});

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const { debuglog } = require('node:util');
-const debug = debuglog('prom:metrics:safe-memory-usage');
+const debug = debuglog('prom:benchmark');
 const Benchmark = require('faceoff').default;
 
 /**

--- a/lib/metrics/eventLoopLag.js
+++ b/lib/metrics/eventLoopLag.js
@@ -14,14 +14,15 @@
 
 'use strict';
 
+const debug = require('debug')('prom:metrics:event-loop-lag');
 const Gauge = require('../gauge');
 
 // Check if perf_hooks module is available
 let perf_hooks;
 try {
 	perf_hooks = require('perf_hooks');
-} catch {
-	// node version is too old
+} catch (error) {
+	debug('perf_hooks module is unavailable: %o', error);
 }
 
 // Reported always.

--- a/lib/metrics/eventLoopLag.js
+++ b/lib/metrics/eventLoopLag.js
@@ -14,8 +14,10 @@
 
 'use strict';
 
-const debug = require('debug')('prom:metrics:event-loop-lag');
+const { debuglog } = require('node:util');
 const Gauge = require('../gauge');
+
+const debug = debuglog('prom:metrics:event-loop-lag');
 
 // Check if perf_hooks module is available
 let perf_hooks;

--- a/lib/metrics/gc.js
+++ b/lib/metrics/gc.js
@@ -13,14 +13,15 @@
 // limitations under the License.
 
 'use strict';
+const debug = require('debug')('prom:metrics:gc');
 const Histogram = require('../histogram');
 
 let perf_hooks;
 
 try {
 	perf_hooks = require('perf_hooks');
-} catch {
-	// node version is too old
+} catch (error) {
+	debug('perf_hooks module is unavailable: %o', error);
 }
 
 const NODEJS_GC_DURATION_SECONDS = 'nodejs_gc_duration_seconds';

--- a/lib/metrics/gc.js
+++ b/lib/metrics/gc.js
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 'use strict';
-const debug = require('debug')('prom:metrics:gc');
+const { debuglog } = require('node:util');
 const Histogram = require('../histogram');
+
+const debug = debuglog('prom:metrics:gc');
 
 let perf_hooks;
 

--- a/lib/metrics/helpers/safeMemoryUsage.js
+++ b/lib/metrics/helpers/safeMemoryUsage.js
@@ -14,7 +14,9 @@
 
 'use strict';
 
-const debug = require('debug')('prom:metrics:safe-memory-usage');
+const { debuglog } = require('node:util');
+
+const debug = debuglog('prom:metrics:safe-memory-usage');
 
 // process.memoryUsage() can throw on some platforms, see #67
 function safeMemoryUsage() {

--- a/lib/metrics/helpers/safeMemoryUsage.js
+++ b/lib/metrics/helpers/safeMemoryUsage.js
@@ -14,11 +14,14 @@
 
 'use strict';
 
+const debug = require('debug')('prom:metrics:safe-memory-usage');
+
 // process.memoryUsage() can throw on some platforms, see #67
 function safeMemoryUsage() {
 	try {
 		return process.memoryUsage();
-	} catch {
+	} catch (error) {
+		debug('process.memoryUsage() failed: %o', error);
 		return;
 	}
 }

--- a/lib/metrics/helpers/safeRss.js
+++ b/lib/metrics/helpers/safeRss.js
@@ -14,7 +14,9 @@
 
 'use strict';
 
-const debug = require('debug')('prom:metrics:safe-rss');
+const { debuglog } = require('node:util');
+
+const debug = debuglog('prom:metrics:safe-rss');
 
 // process.memoryUsage.rss() can throw on some platforms, see #67
 function safeRss() {

--- a/lib/metrics/helpers/safeRss.js
+++ b/lib/metrics/helpers/safeRss.js
@@ -14,11 +14,14 @@
 
 'use strict';
 
+const debug = require('debug')('prom:metrics:safe-rss');
+
 // process.memoryUsage.rss() can throw on some platforms, see #67
 function safeRss() {
 	try {
 		return process.memoryUsage.rss();
-	} catch {
+	} catch (error) {
+		debug('process.memoryUsage.rss() failed: %o', error);
 		return;
 	}
 }

--- a/lib/metrics/osMemoryHeapLinux.js
+++ b/lib/metrics/osMemoryHeapLinux.js
@@ -14,9 +14,11 @@
 
 'use strict';
 
-const debug = require('debug')('prom:metrics:os-memory-heap-linux');
+const { debuglog } = require('node:util');
 const Gauge = require('../gauge');
 const fs = require('fs');
+
+const debug = debuglog('prom:metrics:os-memory-heap-linux');
 
 const values = ['VmSize', 'VmRSS', 'VmData'];
 

--- a/lib/metrics/osMemoryHeapLinux.js
+++ b/lib/metrics/osMemoryHeapLinux.js
@@ -14,6 +14,7 @@
 
 'use strict';
 
+const debug = require('debug')('prom:metrics:os-memory-heap-linux');
 const Gauge = require('../gauge');
 const fs = require('fs');
 
@@ -70,8 +71,8 @@ module.exports = (registry, config = {}) => {
 				residentMemGauge.set(labels, structuredOutput.VmRSS);
 				virtualMemGauge.set(labels, structuredOutput.VmSize);
 				heapSizeMemGauge.set(labels, structuredOutput.VmData);
-			} catch {
-				// noop
+			} catch (error) {
+				debug('failed to collect Linux memory metrics: %o', error);
 			}
 		},
 	});

--- a/lib/metrics/processMaxFileDescriptors.js
+++ b/lib/metrics/processMaxFileDescriptors.js
@@ -14,6 +14,7 @@
 
 'use strict';
 
+const debug = require('debug')('prom:metrics:process-max-fds');
 const Gauge = require('../gauge');
 const fs = require('fs');
 
@@ -34,7 +35,8 @@ module.exports = (registry, config = {}) => {
 					break;
 				}
 			}
-		} catch {
+		} catch (error) {
+			debug('failed to collect maximum file descriptors: %o', error);
 			return;
 		}
 	}

--- a/lib/metrics/processMaxFileDescriptors.js
+++ b/lib/metrics/processMaxFileDescriptors.js
@@ -14,9 +14,11 @@
 
 'use strict';
 
-const debug = require('debug')('prom:metrics:process-max-fds');
+const { debuglog } = require('node:util');
 const Gauge = require('../gauge');
 const fs = require('fs');
+
+const debug = debuglog('prom:metrics:process-max-fds');
 
 const PROCESS_MAX_FDS = 'process_max_fds';
 

--- a/lib/metrics/processOpenFileDescriptors.js
+++ b/lib/metrics/processOpenFileDescriptors.js
@@ -14,6 +14,7 @@
 
 'use strict';
 
+const debug = require('debug')('prom:metrics:process-open-fds');
 const Gauge = require('../gauge');
 const fs = require('fs');
 const process = require('process');
@@ -40,8 +41,8 @@ module.exports = (registry, config = {}) => {
 				// Minus 1 to not count the fd that was used by readdirSync(),
 				// it's now closed.
 				this.set(labels, fds.length - 1);
-			} catch {
-				// noop
+			} catch (error) {
+				debug('failed to collect open file descriptors: %o', error);
 			}
 		},
 	});

--- a/lib/metrics/processOpenFileDescriptors.js
+++ b/lib/metrics/processOpenFileDescriptors.js
@@ -14,10 +14,12 @@
 
 'use strict';
 
-const debug = require('debug')('prom:metrics:process-open-fds');
+const { debuglog } = require('node:util');
 const Gauge = require('../gauge');
 const fs = require('fs');
 const process = require('process');
+
+const debug = debuglog('prom:metrics:process-open-fds');
 
 const PROCESS_OPEN_FDS = 'process_open_fds';
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
 	},
 	"dependencies": {
 		"@opentelemetry/api": "^1.4.0",
-		"debug": "^4.4.1",
 		"tdigest": "^0.1.1"
 	},
 	"types": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
 	"homepage": "https://github.com/prometheus/client_js",
 	"devDependencies": {
 		"@eslint/js": "^9.29.0",
-		"debug": "^4.4.1",
 		"eslint": "^9.29.0",
 		"eslint-config-prettier": "^10.1.5",
 		"eslint-plugin-jsdoc": "^61.4.1",
@@ -54,6 +53,7 @@
 	},
 	"dependencies": {
 		"@opentelemetry/api": "^1.4.0",
+		"debug": "^4.4.1",
 		"tdigest": "^0.1.1"
 	},
 	"types": "./index.d.ts",


### PR DESCRIPTION
Fixes #649

#### What this PR does
Adds debug logging for metrics collection failures that were previously silently ignored.

The debug namespaces are scoped by metric area, for example:

- `prom:metrics:gc`
- `prom:metrics:event-loop-lag`
- `prom:metrics:process-open-fds`
- `prom:metrics:process-max-fds`

This keeps the default behavior quiet, while allowing users to inspect these failure paths with `DEBUG=prom:*`.

#### Notes
`debug` is moved from `devDependencies` to `dependencies` because it is now required by runtime library files.

#### Tests
- `npm run lint`
- `npm run check-prettier`
- `npm run compile-typescript`
- `npm run test-unit -- --runInBand --forceExit`
- `npm test -- --runInBand --forceExit`
