### PR TITLE
fix: skip cluster responses after IPC disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This release marks our first release under the Prometheus umbrella.
 
 ### Changed
 
+- Avoid sending cluster worker responses after the IPC channel disconnects (Fixes [#563](https://github.com/prometheus/client_js/issues/563))
 - Allow `Pushgateway` to accept a custom registry as the second constructor argument
 - Add `Registry#getMetricsAsString()` to the TypeScript definitions
 - Improve types for no labels

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -39,6 +39,10 @@ let requestCtr = 0; // Concurrency control
 let listenersAdded = false;
 const requests = new Map(); // Pending requests for workers' local metrics.
 
+function sendToPrimary(message) {
+	if (process.connected) process.send(message);
+}
+
 class AggregatorRegistry extends Registry {
 	constructor(regContentType = Registry.PROMETHEUS_CONTENT_TYPE) {
 		super(regContentType);
@@ -185,14 +189,14 @@ function addListeners() {
 			if (message.type === GET_METRICS_REQ) {
 				Promise.all(registries.map(r => r.getMetricsAsJSON()))
 					.then(metrics => {
-						process.send({
+						sendToPrimary({
 							type: GET_METRICS_RES,
 							requestId: message.requestId,
 							metrics,
 						});
 					})
 					.catch(error => {
-						process.send({
+						sendToPrimary({
 							type: GET_METRICS_RES,
 							requestId: message.requestId,
 							error: error.message,

--- a/test/clusterWorkerTest.js
+++ b/test/clusterWorkerTest.js
@@ -1,0 +1,73 @@
+// Copyright The Prometheus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const process = require('process');
+
+describe('cluster worker message handling', () => {
+	const originalConnected = Object.getOwnPropertyDescriptor(
+		process,
+		'connected',
+	);
+	const originalSend = Object.getOwnPropertyDescriptor(process, 'send');
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+		jest.resetModules();
+		jest.unmock('cluster');
+
+		if (originalConnected) {
+			Object.defineProperty(process, 'connected', originalConnected);
+		} else {
+			delete process.connected;
+		}
+		if (originalSend) {
+			Object.defineProperty(process, 'send', originalSend);
+		} else {
+			delete process.send;
+		}
+	});
+
+	it('does not send a metrics response after the IPC channel disconnects', async () => {
+		let messageHandler;
+		jest.doMock('cluster', () => {
+			return { isPrimary: false };
+		});
+		jest.spyOn(process, 'on').mockImplementation((event, listener) => {
+			if (event === 'message') messageHandler = listener;
+			return process;
+		});
+
+		const send = jest.fn();
+		Object.defineProperty(process, 'connected', {
+			configurable: true,
+			value: false,
+		});
+		Object.defineProperty(process, 'send', {
+			configurable: true,
+			value: send,
+		});
+
+		const AggregatorRegistry = require('../lib/cluster');
+		new AggregatorRegistry();
+		messageHandler({
+			type: '@prometheus/client:getMetricsReq',
+			requestId: 1,
+		});
+		await new Promise(resolve => setImmediate(resolve));
+
+		expect(send).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

- route worker metric responses through a small `sendToPrimary` guard
- skip both successful and error responses after the worker IPC channel disconnects
- add a regression test that emulates a disconnected worker and verifies `process.send` is not called
- document the fix in the unreleased changelog

Fixes #563.

## Validation

### Regression test

- before the fix: failed because `process.send` was called once after `process.connected` became false
- after the fix: passed

### Full suite

- `npm test`
  - ESLint passed
  - Prettier passed
  - TypeScript compilation passed
  - 29 test suites passed
  - 541 tests and 34 snapshots passed

The full suite emitted its existing Jest worker force-exit warning after completion, but exited successfully with every test passing.