### PR TITLE
fix(types): export MetricObjectWithValues, MetricValue and related types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This release marks our first release under the Prometheus umbrella.
 - perf: Stat aggregation uses similar strategy to collection. 60% faster aggregation
 - chore: Add copyright license headers and test
 - Make cluster and worker-thread metric aggregation order deterministic
+- Export `MetricObject`, `MetricObjectWithValues`, `MetricValue` and `MetricValueWithName` from the TypeScript definitions
 
 ### Added
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -279,7 +279,7 @@ export enum MetricType {
 
 type CollectFunction<T> = (this: T) => void | Promise<void>;
 
-interface MetricObject {
+export interface MetricObject {
 	name: string;
 	help: string;
 	type: MetricType;
@@ -287,18 +287,18 @@ interface MetricObject {
 	collect: CollectFunction<any>;
 }
 
-interface MetricObjectWithValues<
+export interface MetricObjectWithValues<
 	T extends MetricValue<string>,
 > extends MetricObject {
 	values: T[];
 }
 
-type MetricValue<T extends string> = {
+export type MetricValue<T extends string> = {
 	value: number;
 	labels: LabelValues<T>;
 };
 
-type MetricValueWithName<T extends string> = MetricValue<T> & {
+export type MetricValueWithName<T extends string> = MetricValue<T> & {
 	metricName?: string;
 };
 

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -12,7 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Counter, Pushgateway, Registry } from '../index';
+import {
+	Counter,
+	Pushgateway,
+	Registry,
+	MetricObject,
+	MetricObjectWithValues,
+	MetricValue,
+	MetricValueWithName,
+} from '../index';
 
 const registry = new Registry();
 const counter = new Counter({
@@ -38,3 +46,28 @@ void metricsText;
 void gatewayWithRegistry;
 void gatewayWithOptionsAndRegistry;
 void gatewayWithNullOptionsAndRegistry;
+
+// The metric-object types are exported, so consumers can name the return
+// types of Registry#getMetricsAsJSON()/getMetricsAsArray() and Metric#get()
+// instead of re-deriving them. These annotations fail to compile if the types
+// are removed, renamed, or reshaped.
+async function metricObjectTypesAreExported() {
+	const asJson: MetricObjectWithValues<MetricValue<string>>[] =
+		await registry.getMetricsAsJSON();
+	void asJson;
+
+	const asArray: MetricObject[] = registry.getMetricsAsArray();
+	void asArray;
+
+	const counterSnapshot: MetricObjectWithValues<MetricValue<string>> =
+		await counter.get();
+	void counterSnapshot;
+
+	const named: MetricValueWithName<string> = {
+		value: 1,
+		labels: {},
+		metricName: 'typescript_test_counter',
+	};
+	void named;
+}
+void metricObjectTypesAreExported;


### PR DESCRIPTION
`Registry.getMetricsAsJSON()` returns `MetricObjectWithValues<MetricValue<string>>[]`, and the per-metric `get()` methods return `MetricObjectWithValues<...>`, but those types — along with the base `MetricObject` and `MetricValueWithName` — are not exported from `index.d.ts`.

As a result, consumers cannot name the return type of these public methods and have to fall back to workarounds like `Awaited<ReturnType<Registry['getMetricsAsJSON']>>`.

This exports the four types, consistent with the ~20 other public types already exported from the same declaration file. No behavior change, declaration-only.

- `npm run compile-typescript` passes.
- `prettier --check index.d.ts` passes.
- Verified a consumer can now `import { MetricObjectWithValues, MetricValue } from 'prom-client'` and annotate the `getMetricsAsJSON()` result.