### PR TITLE
fix(types): make MetricType a string union matching runtime values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ This release marks our first release under the Prometheus umbrella.
 - Metric internal storage ('hashMap') changed to a separate object, LabelMap. If you have
   subclassed the built-in metric types you may need to adjust your code.
 - Counter Exemplars now report the value rather than the delta
+- TypeScript: `MetricType` is now a string union matching the runtime values
+  (`'counter' | 'gauge' | 'histogram' | 'summary'`) instead of a numeric enum that had no
+  runtime object. Value-style uses such as `MetricType.Counter` (which threw at runtime)
+  no longer compile; compare against the string literals instead. Under
+  `verbatimModuleSyntax`, import it with `import type`.
 
 ### Changed
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -270,12 +270,11 @@ export type Metric<T extends string = NoLabelNameType> =
  */
 export type Aggregator = 'omit' | 'sum' | 'first' | 'min' | 'max' | 'average';
 
-export enum MetricType {
-	Counter,
-	Gauge,
-	Histogram,
-	Summary,
-}
+/**
+ * The metric type reported in metric objects, such as those returned by
+ * `Registry#getMetricsAsJSON()`. Matches the runtime string values.
+ */
+export type MetricType = 'counter' | 'gauge' | 'histogram' | 'summary';
 
 type CollectFunction<T> = (this: T) => void | Promise<void>;
 

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -18,6 +18,7 @@ import {
 	Registry,
 	MetricObject,
 	MetricObjectWithValues,
+	MetricType,
 	MetricValue,
 	MetricValueWithName,
 } from '../index';
@@ -71,3 +72,38 @@ async function metricObjectTypesAreExported() {
 	void named;
 }
 void metricObjectTypesAreExported;
+
+// MetricType matches the runtime strings reported in metric metadata, so a
+// reported type can be compared against a literal and narrowed without casts.
+// The switch fails to compile if the union and this member list ever drift
+// apart, in either direction.
+async function metricTypeMatchesRuntimeStrings() {
+	const t: MetricType = 'counter';
+	void t;
+
+	const [first] = await registry.getMetricsAsJSON();
+	if (first !== undefined && first.type === 'counter') {
+		const narrowed: 'counter' = first.type;
+		void narrowed;
+	}
+
+	const lockMembers = (type: MetricType): string => {
+		switch (type) {
+			case 'counter':
+			case 'gauge':
+			case 'histogram':
+			case 'summary':
+				return type;
+			default: {
+				const missing: never = type;
+				return missing;
+			}
+		}
+	};
+	void lockMembers;
+
+	// @ts-expect-error MetricType is a type-only string union with no runtime
+	// object (#336), so value-style access must not compile.
+	void MetricType.Counter;
+}
+void metricTypeMatchesRuntimeStrings;


### PR DESCRIPTION
Fixes #336

`index.d.ts` declares `MetricType` as a numeric enum, but no such object is exported at runtime — `require('prom-client').MetricType` is `undefined`, so `MetricType.Counter` type-checks and then throws when evaluated. Meanwhile the property it describes, `MetricObject.type`, is a runtime string (`'counter'`, `'gauge'`, `'histogram'`, `'summary'` — set in lib/counter.js, lib/gauge.js, lib/histogram.js, lib/summary.js). Both halves were diagnosed in #336 back in 2020.

This models it the way the neighbouring `Aggregator` type already models the same situation — a string-literal union of the runtime values:

```ts
export type MetricType = 'counter' | 'gauge' | 'histogram' | 'summary';
```

Why not the alternatives: a declaration-only enum with string values would still claim a runtime object exists (the crash stays), and shipping a runtime object would add new JS API solely to rehabilitate one that never worked. The union just describes what the library returns.

**What changes for consumers** (declaration-only; `index.js` is untouched):

- Type-position uses keep compiling.
- Comparing a reported type against its actual value (`m.type === 'counter'`) now type-checks and narrows — with the numeric enum this comparison was itself a compile error (TS2367, no overlap), forcing casts.
- Value-style access (`MetricType.Counter`) stops compiling (TS2693) — it previously threw at runtime.
- Under `verbatimModuleSyntax`, importing `MetricType` now requires `import type`.

**Tests** (`test/typescript.ts`, compiled by `tsc --project .` in CI):

- type-position use, and narrowing of a reported metric type;
- an exhaustive `switch` that fails to compile if the union and the member list drift apart in either direction (verified by mutation: removing `'gauge'` → TS2678, adding a member → TS2322 on the `never` default);
- a `@ts-expect-error` guard on `MetricType.Counter` — if a value declaration for `MetricType` is ever introduced, the directive turns unused and the compile fails, flagging the test for update.

Since Unreleased already carries breaking changes for the first release under the Prometheus umbrella, this seemed like the right window for a type-level break; the CHANGELOG entry is under **Breaking**.
