### PR TITLE
Fix escaping for non-string label values

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -305,7 +305,7 @@ function flattenSharedLabels(labels) {
 }
 function escapeLabelValue(str) {
 	if (typeof str !== 'string') {
-		return str;
+		str = String(str);
 	}
 	return escapeString(str).replace(/"/g, '\\"');
 }

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -340,6 +340,29 @@ describe('Register', () => {
 			expect(escapedResult).toMatch(/\\"/);
 		});
 
+		it('should stringify and escape non-string label values', async () => {
+			register.registerMetric({
+				async get() {
+					return {
+						name: 'test_metric',
+						type: 'counter',
+						help: 'A test metric',
+						values: [
+							{
+								value: 12,
+								labels: {
+									label: ['say "hi"\nand \\back'],
+								},
+							},
+						],
+					};
+				},
+			});
+
+			const escapedResult = await register.metrics();
+			expect(escapedResult).toContain('label="say \\"hi\\"\\nand \\\\back"');
+		});
+
 		describe('should output metrics as JSON', () => {
 			it('should output metrics as JSON', async () => {
 				register.registerMetric(getMetric());


### PR DESCRIPTION
Fixes #791.

Non-string label values are now converted to strings during exposition formatting before the existing backslash, newline, and quote escaping runs. This keeps the metric-recording path unchanged and preserves the existing fast path for string values.

A regression test covers an array label whose string representation contains a quote, newline, and backslash. The test fails against the previous implementation and passes with this change.

Validation:
- `npm test`
- 29 test suites passed
- 546 tests passed
- ESLint, Prettier, and TypeScript checks passed